### PR TITLE
Enhance hook function returns

### DIFF
--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -1236,12 +1236,31 @@ test('both beforeLoad and afterLoad hooks', async function () {
 
 		    const afterHookReturn = _houdini_context.returnValue;
 
+		    const hookReturn = {
+		        ...beforeHookReturn,
+		        ...afterHookReturn
+		    };
+
+		    if (hookReturn.props) {
+		        hookReturn.props = {
+		            ...beforeHookReturn.props,
+		            ...afterHookReturn.props
+		        };
+		    }
+
+		    if (hookReturn.stuff) {
+		        hookReturn.stuff = {
+		            ...beforeHookReturn.stuff,
+		            ...afterHookReturn.stuff
+		        };
+		    }
+
 		    return {
 		        props: {
 		            _TestQuery: _TestQuery,
 		            _TestQuery_Input: _TestQuery_Input,
 		            _TestQuery_Source: _TestQuery_Source,
-		            ...afterHookReturn
+		            ...hookReturn
 		        }
 		    };
 		}

--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -773,6 +773,19 @@ test('beforeLoad hook', async function () {
 		        return _houdini_context.returnValue;
 		    }
 
+		    if (beforeHookReturn.props || beforeHookReturn.stuff) {
+		        return {
+		            ...beforeHookReturn,
+
+		            props: {
+		                _TestQuery: _TestQuery,
+		                _TestQuery_Input: _TestQuery_Input,
+		                _TestQuery_Source: _TestQuery_Source,
+		                ...beforeHookReturn.props
+		            }
+		        };
+		    }
+
 		    return {
 		        props: {
 		            _TestQuery: _TestQuery,
@@ -889,6 +902,22 @@ test('beforeLoad hook - multiple queries', async function () {
 		        return _houdini_context.returnValue;
 		    }
 
+		    if (beforeHookReturn.props || beforeHookReturn.stuff) {
+		        return {
+		            ...beforeHookReturn,
+
+		            props: {
+		                _TestQuery1: _TestQuery1,
+		                _TestQuery1_Input: _TestQuery1_Input,
+		                _TestQuery1_Source: _TestQuery1_Source,
+		                _TestQuery2: _TestQuery2,
+		                _TestQuery2_Input: _TestQuery2_Input,
+		                _TestQuery2_Source: _TestQuery2_Source,
+		                ...beforeHookReturn.props
+		            }
+		        };
+		    }
+
 		    return {
 		        props: {
 		            _TestQuery1: _TestQuery1,
@@ -991,6 +1020,19 @@ test('afterLoad hook', async function () {
 		    }
 
 		    const afterHookReturn = _houdini_context.returnValue;
+
+		    if (afterHookReturn.props || afterHookReturn.stuff) {
+		        return {
+		            ...afterHookReturn,
+
+		            props: {
+		                _TestQuery: _TestQuery,
+		                _TestQuery_Input: _TestQuery_Input,
+		                _TestQuery_Source: _TestQuery_Source,
+		                ...afterHookReturn.props
+		            }
+		        };
+		    }
 
 		    return {
 		        props: {
@@ -1112,6 +1154,22 @@ test('afterLoad hook - multiple queries', async function () {
 		    }
 
 		    const afterHookReturn = _houdini_context.returnValue;
+
+		    if (afterHookReturn.props || afterHookReturn.stuff) {
+		        return {
+		            ...afterHookReturn,
+
+		            props: {
+		                _TestQuery1: _TestQuery1,
+		                _TestQuery1_Input: _TestQuery1_Input,
+		                _TestQuery1_Source: _TestQuery1_Source,
+		                _TestQuery2: _TestQuery2,
+		                _TestQuery2_Input: _TestQuery2_Input,
+		                _TestQuery2_Source: _TestQuery2_Source,
+		                ...afterHookReturn.props
+		            }
+		        };
+		    }
 
 		    return {
 		        props: {
@@ -1255,6 +1313,19 @@ test('both beforeLoad and afterLoad hooks', async function () {
 		        };
 		    }
 
+		    if (hookReturn.props || hookReturn.stuff) {
+		        return {
+		            ...hookReturn,
+
+		            props: {
+		                _TestQuery: _TestQuery,
+		                _TestQuery_Input: _TestQuery_Input,
+		                _TestQuery_Source: _TestQuery_Source,
+		                ...hookReturn.props
+		            }
+		        };
+		    }
+
 		    return {
 		        props: {
 		            _TestQuery: _TestQuery,
@@ -1349,6 +1420,19 @@ test('deprecated onLoad hook', async function () {
 		    if (!_TestQuery.data) {
 		        _houdini_context.graphqlErrors(_TestQuery);
 		        return _houdini_context.returnValue;
+		    }
+
+		    if (beforeHookReturn.props || beforeHookReturn.stuff) {
+		        return {
+		            ...beforeHookReturn,
+
+		            props: {
+		                _TestQuery: _TestQuery,
+		                _TestQuery_Input: _TestQuery_Input,
+		                _TestQuery_Source: _TestQuery_Source,
+		                ...beforeHookReturn.props
+		            }
+		        };
 		    }
 
 		    return {

--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -748,6 +748,8 @@ test('beforeLoad hook', async function () {
 		        return _houdini_context.returnValue;
 		    }
 
+		    const beforeHookReturn = _houdini_context.returnValue;
+
 		    const _TestQuery_Input = _houdini_context.computeInput({
 		        "config": houdiniConfig,
 		        "mode": "sapper",
@@ -776,7 +778,7 @@ test('beforeLoad hook', async function () {
 		            _TestQuery: _TestQuery,
 		            _TestQuery_Input: _TestQuery_Input,
 		            _TestQuery_Source: _TestQuery_Source,
-		            ..._houdini_context.returnValue
+		            ...beforeHookReturn
 		        }
 		    };
 		}
@@ -850,6 +852,7 @@ test('beforeLoad hook - multiple queries', async function () {
 		        return _houdini_context.returnValue;
 		    }
 
+		    const beforeHookReturn = _houdini_context.returnValue;
 		    const _TestQuery2_Input = {};
 
 		    if (!_houdini_context.continue) {
@@ -894,7 +897,7 @@ test('beforeLoad hook - multiple queries', async function () {
 		            _TestQuery2: _TestQuery2,
 		            _TestQuery2_Input: _TestQuery2_Input,
 		            _TestQuery2_Source: _TestQuery2_Source,
-		            ..._houdini_context.returnValue
+		            ...beforeHookReturn
 		        }
 		    };
 		}
@@ -987,12 +990,14 @@ test('afterLoad hook', async function () {
 		        return _houdini_context.returnValue;
 		    }
 
+		    const afterHookReturn = _houdini_context.returnValue;
+
 		    return {
 		        props: {
 		            _TestQuery: _TestQuery,
 		            _TestQuery_Input: _TestQuery_Input,
 		            _TestQuery_Source: _TestQuery_Source,
-		            ..._houdini_context.returnValue
+		            ...afterHookReturn
 		        }
 		    };
 		}
@@ -1106,6 +1111,8 @@ test('afterLoad hook - multiple queries', async function () {
 		        return _houdini_context.returnValue;
 		    }
 
+		    const afterHookReturn = _houdini_context.returnValue;
+
 		    return {
 		        props: {
 		            _TestQuery1: _TestQuery1,
@@ -1114,7 +1121,7 @@ test('afterLoad hook - multiple queries', async function () {
 		            _TestQuery2: _TestQuery2,
 		            _TestQuery2_Input: _TestQuery2_Input,
 		            _TestQuery2_Source: _TestQuery2_Source,
-		            ..._houdini_context.returnValue
+		            ...afterHookReturn
 		        }
 		    };
 		}
@@ -1188,6 +1195,8 @@ test('both beforeLoad and afterLoad hooks', async function () {
 		        return _houdini_context.returnValue;
 		    }
 
+		    const beforeHookReturn = _houdini_context.returnValue;
+
 		    const _TestQuery_Input = _houdini_context.computeInput({
 		        "config": houdiniConfig,
 		        "mode": "sapper",
@@ -1225,12 +1234,14 @@ test('both beforeLoad and afterLoad hooks', async function () {
 		        return _houdini_context.returnValue;
 		    }
 
+		    const afterHookReturn = _houdini_context.returnValue;
+
 		    return {
 		        props: {
 		            _TestQuery: _TestQuery,
 		            _TestQuery_Input: _TestQuery_Input,
 		            _TestQuery_Source: _TestQuery_Source,
-		            ..._houdini_context.returnValue
+		            ...afterHookReturn
 		        }
 		    };
 		}
@@ -1296,6 +1307,8 @@ test('deprecated onLoad hook', async function () {
 		        return _houdini_context.returnValue;
 		    }
 
+		    const beforeHookReturn = _houdini_context.returnValue;
+
 		    const _TestQuery_Input = _houdini_context.computeInput({
 		        "config": houdiniConfig,
 		        "mode": "sapper",
@@ -1324,7 +1337,7 @@ test('deprecated onLoad hook', async function () {
 		            _TestQuery: _TestQuery,
 		            _TestQuery_Input: _TestQuery_Input,
 		            _TestQuery_Source: _TestQuery_Source,
-		            ..._houdini_context.returnValue
+		            ...beforeHookReturn
 		        }
 		    };
 		}


### PR DESCRIPTION
See #232

Maybe I went a bit overboard but I restructured the code generation a little bit to make it easier to work for me. I think it is best to review the commits in isolation as otherwise the changes to the generated code in the tests are rather confusing.

1. In commit 35f2be2c04053f344f926f2f670268ed08c41136 I removed some unneeded checks and changed the order of handling query documents, so it will match the order as defined in the svelte code.
2. In commit 867751f7df30e80081488772e6b73db38b7d5592 I took the liberty of (hopefully) improving the performance by not fetching sequentially but in parallel.
3. Commit 9ab933651d44eeab663e280c12c1e23ced60d003 is finally the meat of the PR and assigns hook results to variables, merges them if necessary and also merges `props` and `stuff`. I thought the other keys from `LoadOutput` can already be set by calling `this.redirect()` and `this.error()`.

I use this currently in a sveltekit project and it works as expected, but I cannot say anything about sapper. The generated code is affected but I guess since `convertKitPayload` simply extracts `props` in the happy path everything should be alright.