### PR TITLE
Let `error` and `redirect` return `any`

### DIFF
--- a/packages/houdini/runtime/network.ts
+++ b/packages/houdini/runtime/network.ts
@@ -262,7 +262,7 @@ export class RequestContext {
 		this.context = ctx
 	}
 
-	error(status: number, message: string | Error) {
+	error(status: number, message: string | Error): any {
 		this.continue = false
 		this.returnValue = {
 			error: message,
@@ -270,7 +270,7 @@ export class RequestContext {
 		}
 	}
 
-	redirect(status: number, location: string) {
+	redirect(status: number, location: string): any {
 		this.continue = false
 		this.returnValue = {
 			redirect: location,


### PR DESCRIPTION
This changes the return type of `RequestContext.error` and `RequestContext.redirect` from `void` to `any`. Now I can do
```ts
  export function afterLoad(
    this: RequestContext,
    {
      data,
      params,
    }: Parameters<Load>[0] & {
      data: { GetProductPublic: GetProductPublic$result };
    },
  ): ReturnType<Load> {
    if (!data.GetProductPublic.productByArticleNumber) {
      return this.error(404, 'Not found');
    }

    if (params.slug !== data.GetProductPublic.productByArticleNumber.slug) {
      return this.redirect(301, productUrlPublic(data.GetProductPublic.productByArticleNumber));
    }

    return {};
  }
```
without typescript jumping into my face because of the early returns.

The early returns are possible because after calls to `error`/`redirect` the return value of `beforeLoad`/`afterLoad` will be ignored.