### PR TITLE
Generate type for usage in `afterLoad`

### DIFF
--- a/packages/houdini/cmd/generators/typescript/index.ts
+++ b/packages/houdini/cmd/generators/typescript/index.ts
@@ -114,6 +114,7 @@ async function generateOperationTypeDefs(
 	// the name of the types we will define
 	const inputTypeName = `${definition.name!.value}$input`
 	const shapeTypeName = `${definition.name!.value}$result`
+	const afterLoadTypeName = `${definition.name!.value}$afterLoad`
 
 	// look up the root type of the document
 	let type: graphql.GraphQLNamedType | null | undefined
@@ -175,6 +176,34 @@ async function generateOperationTypeDefs(
 					visitedTypes,
 					body,
 				})
+			)
+		)
+	)
+
+	// generate type for the afterload function
+	body.push(
+		AST.exportNamedDeclaration(
+			AST.tsTypeAliasDeclaration(
+				AST.identifier(afterLoadTypeName),
+				AST.tsTypeLiteral([
+					readonlyProperty(
+						AST.tsPropertySignature(
+							AST.stringLiteral('data'),
+							AST.tsTypeAnnotation(
+								AST.tsTypeLiteral([
+									readonlyProperty(
+										AST.tsPropertySignature(
+											AST.stringLiteral(definition.name!.value),
+											AST.tsTypeAnnotation(
+												AST.tsTypeReference(AST.identifier(shapeTypeName))
+											)
+										)
+									),
+								])
+							)
+						)
+					),
+				])
 			)
 		)
 	)

--- a/packages/houdini/cmd/generators/typescript/typescript.test.ts
+++ b/packages/houdini/cmd/generators/typescript/typescript.test.ts
@@ -259,6 +259,12 @@ describe('typescript', function () {
 		        readonly firstName: string
 		    } | null
 		};
+
+		export type Query$afterLoad = {
+		    readonly "data": {
+		        readonly "Query": Query$result
+		    }
+		};
 	`)
 	})
 
@@ -293,6 +299,12 @@ describe('typescript', function () {
 		        readonly firstName: string
 		    } | null)[] | null
 		};
+
+		export type Query$afterLoad = {
+		    readonly "data": {
+		        readonly "Query": Query$result
+		    }
+		};
 	`)
 	})
 
@@ -323,6 +335,12 @@ describe('typescript', function () {
 		    readonly user: {
 		        readonly firstName: string
 		    } | null
+		};
+
+		export type Query$afterLoad = {
+		    readonly "data": {
+		        readonly "Query": Query$result
+		    }
 		};
 
 		enum MyEnum {
@@ -384,6 +402,12 @@ describe('typescript', function () {
 		    } | null
 		};
 
+		export type Mutation$afterLoad = {
+		    readonly "data": {
+		        readonly "Mutation": Mutation$result
+		    }
+		};
+
 		type NestedUserFilter = {
 		    id: string,
 		    firstName: string,
@@ -443,6 +467,12 @@ describe('typescript', function () {
 		    readonly user: {
 		        readonly firstName: string
 		    } | null
+		};
+
+		export type Query$afterLoad = {
+		    readonly "data": {
+		        readonly "Query": Query$result
+		    }
 		};
 
 		type NestedUserFilter = {
@@ -524,6 +554,12 @@ describe('typescript', function () {
 		        }
 		    } | null
 		};
+
+		export type Query$afterLoad = {
+		    readonly "data": {
+		        readonly "Query": Query$result
+		    }
+		};
 	`)
 	})
 
@@ -570,6 +606,12 @@ describe('typescript', function () {
 		        readonly __typename: "Cat"
 		    })))[]
 		};
+
+		export type Query$afterLoad = {
+		    readonly "data": {
+		        readonly "Query": Query$result
+		    }
+		};
 	`)
 	})
 
@@ -615,6 +657,12 @@ describe('typescript', function () {
 		        readonly id: string,
 		        readonly __typename: "Cat"
 		    })) | null)[] | null
+		};
+
+		export type Query$afterLoad = {
+		    readonly "data": {
+		        readonly "Query": Query$result
+		    }
 		};
 	`)
 	})
@@ -664,6 +712,12 @@ describe('typescript', function () {
 		        readonly kitty: boolean,
 		        readonly __typename: "Cat"
 		    })))[]
+		};
+
+		export type Query$afterLoad = {
+		    readonly "data": {
+		        readonly "Query": Query$result
+		    }
 		};
 	`)
 	})
@@ -715,6 +769,12 @@ describe('typescript', function () {
 		    } & {
 		        readonly isAnimal: boolean
 		    })) | null)[] | null
+		};
+
+		export type Query$afterLoad = {
+		    readonly "data": {
+		        readonly "Query": Query$result
+		    }
 		};
 	`)
 	})
@@ -771,6 +831,12 @@ describe('typescript', function () {
 		    readonly allItems: ({
 		        readonly createdAt: Date
 		    })[]
+		};
+
+		export type Query$afterLoad = {
+		    readonly "data": {
+		        readonly "Query": Query$result
+		    }
 		};
 	`)
 	})
@@ -831,6 +897,12 @@ describe('typescript', function () {
 		    })[]
 		};
 
+		export type Query$afterLoad = {
+		    readonly "data": {
+		        readonly "Query": Query$result
+		    }
+		};
+
 		export type Query$input = {
 		    date: Date
 		};
@@ -873,6 +945,12 @@ describe('typescript', function () {
 		        readonly nickname: string | null
 		    } | null)[] | null)[]
 		};
+
+		export type Query$afterLoad = {
+		    readonly "data": {
+		        readonly "Query": Query$result
+		    }
+		};
 	`)
 	})
 
@@ -914,6 +992,12 @@ describe('typescript', function () {
 		            readonly nickname: string | null
 		        } | null
 		    } | null
+		};
+
+		export type Query$afterLoad = {
+		    readonly "data": {
+		        readonly "Query": Query$result
+		    }
 		};
 	`)
 	})


### PR DESCRIPTION
To simplify my typing I want to replace
```ts
  export function afterLoad({
    data,
    params,
  }: Parameters<Load>[0] & {
    data: {
      GetCatalogPublic: GetCatalogPublic$result;
      SearchProductsPublicByCatalog: SearchProductsPublicByCatalog$result;
    };
  }): ReturnType<Load> {
```
with
```ts
  export function afterLoad({
    data,
    params,
  }: Parameters<Load>[0] &
    GetCatalogPublic$afterLoad &
    SearchProductsPublicByCatalog$afterLoad): ReturnType<Load> {
```

---

The generated types are super simple and have the form of
```ts
type <Name>$afterLoad = {
  data: {
    <Name>: <Name>$result
  }
}
```

I tried to do a global type that is generic over `Operation<any, any>`but I failed to add the name of the type as a property to the data object. Probably I didn't understand template literal types correctly :sweat_smile: 