### PR TITLE
Optimistic updates

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
 	"packages": ["packages/*", "example"],
-	"version": "0.13.7-alpha.0",
+	"version": "0.13.7-alpha.1",
 	"npmClient": "yarn",
 	"command": {
 		"publish": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
 	"packages": ["packages/*", "example"],
-	"version": "0.13.6",
+	"version": "0.13.7-alpha.0",
 	"npmClient": "yarn",
 	"command": {
 		"publish": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
 	"packages": ["packages/*", "example"],
-	"version": "0.13.7-alpha.1",
+	"version": "0.13.7-alpha.2",
 	"npmClient": "yarn",
 	"command": {
 		"publish": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
 	"packages": ["packages/*", "example"],
-	"version": "0.13.7-alpha.2",
+	"version": "0.13.7-alpha.3",
 	"npmClient": "yarn",
 	"command": {
 		"publish": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 	"dependencies": {
 		"@types/mock-fs": "^4.13.0",
 		"global": "^4.4.0",
+		"houdini": "^0.13.7-alpha.2",
 		"remove": "^0.1.5",
 		"rollup-plugin-typescript2": "^0.30.0"
 	}

--- a/packages/houdini/package-lock.json
+++ b/packages/houdini/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.13.7-alpha.1",
+	"version": "0.13.7-alpha.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/houdini/package-lock.json
+++ b/packages/houdini/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.13.7-alpha.2",
+	"version": "0.13.7-alpha.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/houdini/package-lock.json
+++ b/packages/houdini/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.13.7-alpha.0",
+	"version": "0.13.7-alpha.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/houdini/package-lock.json
+++ b/packages/houdini/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.13.6",
+	"version": "0.13.7-alpha.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/houdini/package.json
+++ b/packages/houdini/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.13.6",
+	"version": "0.13.7-alpha.0",
 	"description": "The disappearing graphql client for SvelteKit",
 	"scripts": {
 		"build:runtime": "npm run build:runtime:cjs && npm run build:runtime:esm",

--- a/packages/houdini/package.json
+++ b/packages/houdini/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.13.7-alpha.1",
+	"version": "0.13.7-alpha.2",
 	"description": "The disappearing graphql client for SvelteKit",
 	"scripts": {
 		"build:runtime": "npm run build:runtime:cjs && npm run build:runtime:esm",

--- a/packages/houdini/package.json
+++ b/packages/houdini/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.13.7-alpha.0",
+	"version": "0.13.7-alpha.1",
 	"description": "The disappearing graphql client for SvelteKit",
 	"scripts": {
 		"build:runtime": "npm run build:runtime:cjs && npm run build:runtime:esm",

--- a/packages/houdini/package.json
+++ b/packages/houdini/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "houdini",
-	"version": "0.13.7-alpha.2",
+	"version": "0.13.7-alpha.3",
 	"description": "The disappearing graphql client for SvelteKit",
 	"scripts": {
 		"build:runtime": "npm run build:runtime:cjs && npm run build:runtime:esm",

--- a/packages/houdini/runtime/cache/cache.ts
+++ b/packages/houdini/runtime/cache/cache.ts
@@ -357,6 +357,7 @@ class CacheInternal {
 						toNotify,
 						applyUpdates,
 						layer,
+						forceNotify,
 					})
 				}
 			}
@@ -833,6 +834,7 @@ class CacheInternal {
 		specs,
 		layer,
 		startingWith,
+		forceNotify,
 	}: {
 		value: GraphQLValue[]
 		recordID: string
@@ -845,6 +847,7 @@ class CacheInternal {
 		fields: SubscriptionSelection
 		layer: Layer
 		startingWith: number
+		forceNotify?: boolean
 	}): { nestedIDs: LinkedList; newIDs: (string | null)[] } {
 		// build up the two lists
 		const nestedIDs: LinkedList = []
@@ -931,6 +934,7 @@ class CacheInternal {
 				toNotify: specs,
 				applyUpdates,
 				layer,
+				forceNotify,
 			})
 
 			newIDs.push(linkedID)

--- a/packages/houdini/runtime/cache/cache.ts
+++ b/packages/houdini/runtime/cache/cache.ts
@@ -228,7 +228,7 @@ class CacheInternal {
 			const { value: previousValue, displayLayers } = this.storage.get(parent, key)
 
 			// if the layer we are updating is the top most layer for the field
-			// then its value is "live", it is providing the current value and
+			// then its value is "live". It is providing the current value and
 			// subscribers need to know if the value changed
 			const displayLayer = displayLayers.length === 0 || displayLayers.includes(layer.id)
 

--- a/packages/houdini/runtime/cache/cache.ts
+++ b/packages/houdini/runtime/cache/cache.ts
@@ -34,7 +34,7 @@ export class Cache {
 		selection: SubscriptionSelection
 		variables?: {}
 		parent?: string
-		layer?: LayerID
+		layer?: LayerID | null
 		applyUpdates?: boolean
 	}): LayerID {
 		// find the correct layer

--- a/packages/houdini/runtime/cache/cache.ts
+++ b/packages/houdini/runtime/cache/cache.ts
@@ -36,6 +36,7 @@ export class Cache {
 		parent?: string
 		layer?: LayerID | null
 		applyUpdates?: boolean
+		forceNotify?: boolean
 	}): LayerID {
 		// find the correct layer
 		const layer = layerID
@@ -181,6 +182,7 @@ class CacheInternal {
 		parent = rootID,
 		applyUpdates = false,
 		layer,
+		forceNotify,
 		toNotify = [],
 	}: {
 		data: { [key: string]: GraphQLValue }
@@ -191,6 +193,7 @@ class CacheInternal {
 		layer: Layer
 		toNotify?: SubscriptionSpec[]
 		applyUpdates?: boolean
+		forceNotify?: boolean
 	}): SubscriptionSpec[] {
 		// if the cache is disabled, dont do anything
 		if (this._disabled) {
@@ -230,14 +233,14 @@ class CacheInternal {
 			// if the layer we are updating is the top most layer for the field
 			// then its value is "live". It is providing the current value and
 			// subscribers need to know if the value changed
-			const displayLayer = displayLayers.length === 0 || displayLayers.includes(layer.id)
+			const displayLayer = layer.isDisplayLayer(displayLayers)
 
 			// if we are writing to the display layer we need to refresh the lifetime of the value
 			if (displayLayer) {
 				this.lifetimes.resetLifetime(parent, key)
 			}
 
-			// any non-scalar is defined as a field with no selection
+			// any scalar is defined as a field with no selection
 			if (!fields) {
 				// the value to write to the layer
 				let newValue = value
@@ -257,7 +260,7 @@ class CacheInternal {
 				// if the value changed on a layer that impacts the current latest value
 				const valueChanged = JSON.stringify(newValue) !== JSON.stringify(previousValue)
 
-				if (valueChanged && displayLayer) {
+				if ((valueChanged || forceNotify) && displayLayer) {
 					// we need to add the fields' subscribers to the set of callbacks
 					// we need to invoke
 					toNotify.push(...currentSubcribers)
@@ -319,7 +322,7 @@ class CacheInternal {
 				layer.writeLink(parent, key, linkedID)
 
 				// if the link target of this field changed and it was responsible for the current subscription
-				if (linkedID && displayLayer && linkChange) {
+				if (linkedID && displayLayer && (linkChange || forceNotify)) {
 					// we need to clear the subscriptions in the previous link
 					// and add them to the new link
 					if (previousValue && typeof previousValue === 'string') {
@@ -494,7 +497,7 @@ class CacheInternal {
 				const contentChanged = JSON.stringify(linkedIDs) !== JSON.stringify(oldIDs)
 
 				// we need to look at the last time we saw each subscriber to check if they need to be added to the spec
-				if (contentChanged) {
+				if (contentChanged || forceNotify) {
 					toNotify.push(...currentSubcribers)
 				}
 

--- a/packages/houdini/runtime/cache/storage.ts
+++ b/packages/houdini/runtime/cache/storage.ts
@@ -208,6 +208,7 @@ export class InMemoryStorage {
 
 			// if the layer is optimistic, we can't go further
 			if (layer.optimistic) {
+				layerIndex--
 				break
 			}
 

--- a/packages/houdini/runtime/cache/storage.ts
+++ b/packages/houdini/runtime/cache/storage.ts
@@ -319,7 +319,18 @@ export class Layer {
 		return this.id
 	}
 
+	isDisplayLayer(displayLayers: number[]) {
+		return (
+			displayLayers.length === 0 ||
+			displayLayers.includes(this.id) ||
+			Math.max(...displayLayers) < this.id
+		)
+	}
+
 	clear() {
+		// before we clear the data of the layer, look for any subscribers that need to be updated
+
+		// now that everything has been notified we can reset the data
 		this.links = {}
 		this.fields = {}
 		this.operations = {}

--- a/packages/houdini/runtime/cache/tests/subscriptions.test.ts
+++ b/packages/houdini/runtime/cache/tests/subscriptions.test.ts
@@ -1638,6 +1638,10 @@ test('clearing a display layer updates subscribers', function () {
 	})
 })
 
+test('subscribers get called when optimistic response updates a different object than the real payload', function () {
+	fail('dont forget me')
+})
+
 test.todo('can write to and resolve layers')
 
 test.todo("resolving a layer with the same value as the most recent doesn't notify subscribers")

--- a/packages/houdini/runtime/cache/tests/subscriptions.test.ts
+++ b/packages/houdini/runtime/cache/tests/subscriptions.test.ts
@@ -1626,7 +1626,6 @@ test('clearing a display layer updates subscribers', function () {
 			},
 		},
 		layer: layer.id,
-		forceNotify: true,
 	})
 
 	expect(set).toHaveBeenNthCalledWith(2, {
@@ -1636,10 +1635,6 @@ test('clearing a display layer updates subscribers', function () {
 			id: '1',
 		},
 	})
-})
-
-test('subscribers get called when optimistic response updates a different object than the real payload', function () {
-	fail('dont forget me')
 })
 
 test.todo('can write to and resolve layers')

--- a/packages/houdini/runtime/mutation.ts
+++ b/packages/houdini/runtime/mutation.ts
@@ -88,6 +88,10 @@ export function mutation<_Mutation extends Operation<any, any>>(
 				variables,
 				// if we had an optimistic response we need to write to the appropriate layer
 				layer: layer.id,
+				// anything that we right here should notify the parents even if the content didn't change
+				// this is to avoid a situation where the value before the layer clear is the same as
+				// the response from the mutation but the optimistic result was incorrect and changed the display value
+				forceNotify: true,
 			})
 
 			// merge the layer back into the cache

--- a/packages/houdini/runtime/mutation.ts
+++ b/packages/houdini/runtime/mutation.ts
@@ -17,7 +17,10 @@ export type MutationConfig<_Mutation extends Operation<any, any>> = {
 // invoked
 export function mutation<_Mutation extends Operation<any, any>>(
 	document: GraphQLTagResult
-): (_input: _Mutation['input'], config: MutationConfig<_Mutation>) => Promise<_Mutation['result']> {
+): (
+	_input: _Mutation['input'],
+	config?: MutationConfig<_Mutation>
+) => Promise<_Mutation['result']> {
 	// make sure we got a query document
 	if (document.kind !== 'HoudiniMutation') {
 		throw new Error('mutation() must be passed a mutation document')

--- a/packages/houdini/runtime/mutation.ts
+++ b/packages/houdini/runtime/mutation.ts
@@ -90,7 +90,7 @@ export function mutation<_Mutation extends Operation<any, any>>(
 			// merge the layer back into the cache
 			cache._internal_unstable.storage.resolveLayer(layer.id)
 
-			// unmarshal any scalars in the response
+			// turn any scalars in the response into their complex form
 			return unmarshalSelection(config, artifact.selection, result.data)
 		} catch (error) {
 			// if the mutation failed, roll the layer back and delete it

--- a/packages/houdini/runtime/mutation.ts
+++ b/packages/houdini/runtime/mutation.ts
@@ -88,7 +88,7 @@ export function mutation<_Mutation extends Operation<any, any>>(
 				variables,
 				// if we had an optimistic response we need to write to the appropriate layer
 				layer: layer.id,
-				// anything that we right here should notify the parents even if the content didn't change
+				// we should notify the parents even if the content didn't change
 				// this is to avoid a situation where the value before the layer clear is the same as
 				// the response from the mutation but the optimistic result was incorrect and changed the display value
 				forceNotify: true,


### PR DESCRIPTION
This PR closes #152 and adds the API for providing an optimistic response for a mutation. All of the actual work was done in #228 when I rewrote the cache's storage mechanism but I wanted to avoid releasing this portion while I collected feedback on the rewrite. Now that the cache has been used by a number of people, I feel more comfortable releasing this API.

In short, providing an optimistic response for a mutation looks something like this:

```svelte
<script>
    import { mutation, graphql } from '$houdini'

    export let itemID

    const toggleItem = mutation(graphql`
        mutation ToggleItem($id: ID!) {
            toggleItem {
                item {
                    id
                    checked
                }
            }
        }
    `)
</script>


<button on:click={() => {
    toggleItem({ id: itemID }, {
        optimisticResponse: {
            toggleItem: {
                item: {
                    id: '1',
                    checked: true
                }
            }
        }
    }
)}}>
    toggle item
</button>
```

Todo: 
- [x] simple testing 
- [x] docs PR: https://github.com/HoudiniGraphql/docs/pull/8
- [x] make sure multiple mutations can be in flight at the same time