### PR TITLE
handle resolving base optimistic layer

### DIFF
--- a/.changeset/eleven-cherries-breathe.md
+++ b/.changeset/eleven-cherries-breathe.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+fixes an issue when resolving the first layer in the cache

--- a/packages/houdini/runtime/cache/storage.ts
+++ b/packages/houdini/runtime/cache/storage.ts
@@ -194,6 +194,11 @@ export class InMemoryStorage {
 			throw new Error('could not find layer with id: ' + id)
 		}
 
+		// if we are resolving the base layer make sure we start at zero
+		if (startingIndex === -1) {
+			startingIndex = 0
+		}
+
 		// if the starting layer is optimistic then we can't write to it
 		if (this.data[startingIndex].optimistic) {
 			startingIndex++

--- a/packages/houdini/runtime/cache/tests/storage.test.ts
+++ b/packages/houdini/runtime/cache/tests/storage.test.ts
@@ -236,6 +236,23 @@ describe('in memory layers', function () {
 		expect(storage.topLayer.fields['User:1']).toBeUndefined()
 	})
 
+	test('create and resolve on base layer', function () {
+		// note: this situation happens if a mutation fires before any queries
+		// are sent to the server to create a non-optimistic layer
+
+		const storage = new InMemoryStorage()
+
+		// create an optimistic layer
+		const layer = storage.createLayer(true)
+
+		layer.writeField('User:1', 'firstName', 'bob')
+
+		// resolve the layer
+		storage.resolveLayer(layer.id)
+
+		expect(storage.get('User:1', 'firstName').value).toEqual('bob')
+	})
+
 	test.todo('links are reset when layer is cleared')
 
 	describe('operations', function () {


### PR DESCRIPTION
This PR closes #258 (i hope) and fixes an issue when resolving the first layer in the cache which can happen if a mutation triggers before any queries.

cc @ClaytonFarr