### PR TITLE
Parallel queries

### DIFF
--- a/.changeset/rotten-frogs-deny.md
+++ b/.changeset/rotten-frogs-deny.md
@@ -1,0 +1,5 @@
+---
+'houdini-preprocess': minor
+---
+
+Execute multiple queries in parallel

--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -29,10 +29,6 @@ describe('query preprocessor', function () {
 		    const _houdini_context = new RequestContext(context);
 		    const _TestQuery_Input = {};
 
-		    if (!_houdini_context.continue) {
-		        return _houdini_context.returnValue;
-		    }
-
 		    const _TestQuery = await fetchQuery({
 		        "context": context,
 		        "artifact": _TestQueryArtifact,
@@ -124,10 +120,6 @@ describe('query preprocessor', function () {
 		    const _houdini_context = new RequestContext(context);
 		    const _TestQuery2_Input = {};
 
-		    if (!_houdini_context.continue) {
-		        return _houdini_context.returnValue;
-		    }
-
 		    const _TestQuery2 = await fetchQuery({
 		        "context": context,
 		        "artifact": _TestQuery2Artifact,
@@ -141,10 +133,6 @@ describe('query preprocessor', function () {
 		    }
 
 		    const _TestQuery1_Input = {};
-
-		    if (!_houdini_context.continue) {
-		        return _houdini_context.returnValue;
-		    }
 
 		    const _TestQuery1 = await fetchQuery({
 		        "context": context,
@@ -371,10 +359,6 @@ describe('query preprocessor', function () {
 		export async function load(context) {
 		    const _houdini_context = new RequestContext(context);
 		    const _TestQuery_Input = {};
-
-		    if (!_houdini_context.continue) {
-		        return _houdini_context.returnValue;
-		    }
 
 		    const _TestQuery = await fetchQuery({
 		        "context": context,
@@ -869,10 +853,6 @@ test('beforeLoad hook - multiple queries', async function () {
 		    const beforeHookReturn = _houdini_context.returnValue;
 		    const _TestQuery2_Input = {};
 
-		    if (!_houdini_context.continue) {
-		        return _houdini_context.returnValue;
-		    }
-
 		    const _TestQuery2 = await fetchQuery({
 		        "context": context,
 		        "artifact": _TestQuery2Artifact,
@@ -886,10 +866,6 @@ test('beforeLoad hook - multiple queries', async function () {
 		    }
 
 		    const _TestQuery1_Input = {};
-
-		    if (!_houdini_context.continue) {
-		        return _houdini_context.returnValue;
-		    }
 
 		    const _TestQuery1 = await fetchQuery({
 		        "context": context,
@@ -1117,10 +1093,6 @@ test('afterLoad hook - multiple queries', async function () {
 		    const _houdini_context = new RequestContext(context);
 		    const _TestQuery2_Input = {};
 
-		    if (!_houdini_context.continue) {
-		        return _houdini_context.returnValue;
-		    }
-
 		    const _TestQuery2 = await fetchQuery({
 		        "context": context,
 		        "artifact": _TestQuery2Artifact,
@@ -1134,10 +1106,6 @@ test('afterLoad hook - multiple queries', async function () {
 		    }
 
 		    const _TestQuery1_Input = {};
-
-		    if (!_houdini_context.continue) {
-		        return _houdini_context.returnValue;
-		    }
 
 		    const _TestQuery1 = await fetchQuery({
 		        "context": context,

--- a/packages/houdini-preprocess/src/transforms/query.test.ts
+++ b/packages/houdini-preprocess/src/transforms/query.test.ts
@@ -120,26 +120,30 @@ describe('query preprocessor', function () {
 		    const _houdini_context = new RequestContext(context);
 		    const _TestQuery2_Input = {};
 
-		    const _TestQuery2 = await fetchQuery({
+		    const _TestQuery2Promise = fetchQuery({
 		        "context": context,
 		        "artifact": _TestQuery2Artifact,
 		        "variables": _TestQuery2_Input,
 		        "session": context.session
 		    });
 
-		    if (!_TestQuery2.result.data) {
-		        _houdini_context.graphqlErrors(_TestQuery2);
-		        return _houdini_context.returnValue;
-		    }
-
 		    const _TestQuery1_Input = {};
 
-		    const _TestQuery1 = await fetchQuery({
+		    const _TestQuery1Promise = fetchQuery({
 		        "context": context,
 		        "artifact": _TestQuery1Artifact,
 		        "variables": _TestQuery1_Input,
 		        "session": context.session
 		    });
+
+		    const _TestQuery2 = await _TestQuery2Promise;
+
+		    if (!_TestQuery2.result.data) {
+		        _houdini_context.graphqlErrors(_TestQuery2);
+		        return _houdini_context.returnValue;
+		    }
+
+		    const _TestQuery1 = await _TestQuery1Promise;
 
 		    if (!_TestQuery1.result.data) {
 		        _houdini_context.graphqlErrors(_TestQuery1);
@@ -853,26 +857,30 @@ test('beforeLoad hook - multiple queries', async function () {
 		    const beforeHookReturn = _houdini_context.returnValue;
 		    const _TestQuery2_Input = {};
 
-		    const _TestQuery2 = await fetchQuery({
+		    const _TestQuery2Promise = fetchQuery({
 		        "context": context,
 		        "artifact": _TestQuery2Artifact,
 		        "variables": _TestQuery2_Input,
 		        "session": context.session
 		    });
 
-		    if (!_TestQuery2.result.data) {
-		        _houdini_context.graphqlErrors(_TestQuery2);
-		        return _houdini_context.returnValue;
-		    }
-
 		    const _TestQuery1_Input = {};
 
-		    const _TestQuery1 = await fetchQuery({
+		    const _TestQuery1Promise = fetchQuery({
 		        "context": context,
 		        "artifact": _TestQuery1Artifact,
 		        "variables": _TestQuery1_Input,
 		        "session": context.session
 		    });
+
+		    const _TestQuery2 = await _TestQuery2Promise;
+
+		    if (!_TestQuery2.result.data) {
+		        _houdini_context.graphqlErrors(_TestQuery2);
+		        return _houdini_context.returnValue;
+		    }
+
+		    const _TestQuery1 = await _TestQuery1Promise;
 
 		    if (!_TestQuery1.result.data) {
 		        _houdini_context.graphqlErrors(_TestQuery1);
@@ -1093,26 +1101,30 @@ test('afterLoad hook - multiple queries', async function () {
 		    const _houdini_context = new RequestContext(context);
 		    const _TestQuery2_Input = {};
 
-		    const _TestQuery2 = await fetchQuery({
+		    const _TestQuery2Promise = fetchQuery({
 		        "context": context,
 		        "artifact": _TestQuery2Artifact,
 		        "variables": _TestQuery2_Input,
 		        "session": context.session
 		    });
 
-		    if (!_TestQuery2.result.data) {
-		        _houdini_context.graphqlErrors(_TestQuery2);
-		        return _houdini_context.returnValue;
-		    }
-
 		    const _TestQuery1_Input = {};
 
-		    const _TestQuery1 = await fetchQuery({
+		    const _TestQuery1Promise = fetchQuery({
 		        "context": context,
 		        "artifact": _TestQuery1Artifact,
 		        "variables": _TestQuery1_Input,
 		        "session": context.session
 		    });
+
+		    const _TestQuery2 = await _TestQuery2Promise;
+
+		    if (!_TestQuery2.result.data) {
+		        _houdini_context.graphqlErrors(_TestQuery2);
+		        return _houdini_context.returnValue;
+		    }
+
+		    const _TestQuery1 = await _TestQuery1Promise;
 
 		    if (!_TestQuery1.result.data) {
 		        _houdini_context.graphqlErrors(_TestQuery1);


### PR DESCRIPTION
See #268 

I changed the approach to only split into storing promises and awaiting them if one `load` function has to execute more than one query.

I could not yet test it but from looking at the generated code there shouldn't be any problems.