### PR TITLE
Make list operations silent

### DIFF
--- a/.changeset/clean-bears-rescue.md
+++ b/.changeset/clean-bears-rescue.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+List operations no longer throw an exception if the list isn't found as well as a few improvements to the list caching strategy

--- a/src/runtime/cache/cache.ts
+++ b/src/runtime/cache/cache.ts
@@ -554,6 +554,11 @@ class CacheInternal {
 					}
 				}
 
+				// if the necessary list doesn't exist, don't do anything
+				if (operation.list && !this.lists.get(operation.list, parentID)) {
+					continue
+				}
+
 				// there could be a list of elements to perform the operation on
 				const targets = Array.isArray(value) ? value : [value]
 				for (const target of targets) {

--- a/src/runtime/cache/cache.ts
+++ b/src/runtime/cache/cache.ts
@@ -2,7 +2,7 @@
 import { ConfigFile, defaultConfigValues } from '../config'
 import { GraphQLObject, GraphQLValue, SubscriptionSelection, SubscriptionSpec } from '..'
 import { GarbageCollector } from './gc'
-import { List, ListManager } from './lists'
+import { List, ListCollection, ListManager } from './lists'
 import { InMemoryStorage, Layer, LayerID } from './storage'
 import { evaluateKey, flattenList } from './stuff'
 import { InMemorySubscriptions } from './subscription'
@@ -108,7 +108,7 @@ export class Cache {
 	}
 
 	// return the list handler to mutate a named list in the cache
-	list(name: string, parentID?: string): List {
+	list(name: string, parentID?: string): ListCollection {
 		const handler = this._internal_unstable.lists.get(name, parentID)
 		if (!handler) {
 			throw new Error(

--- a/src/runtime/cache/cache.ts
+++ b/src/runtime/cache/cache.ts
@@ -8,10 +8,6 @@ import { evaluateKey, flattenList } from './stuff'
 import { InMemorySubscriptions } from './subscription'
 import { computeID, keyFieldsForType } from '../config'
 
-// we need to generate an id when handling embedded lists in a response. rather than use the list index which isn't
-// stable in the face of list operations, or something like crypto.randomUUID which is slower than just some globally incrementing id
-let embeddedID = 0
-
 export class Cache {
 	// the internal implementation for a lot of the cache's methods are moved into
 	// a second class to avoid users from relying on unstable APIs. typescript's private
@@ -900,7 +896,7 @@ class CacheInternal {
 
 			// start off building up the embedded id
 			// @ts-ignore
-			let linkedID = `${recordID}.${key}[${embeddedID++}]`
+			let linkedID = `${recordID}.${key}[${this.storage.nextRank}]`
 
 			// figure out if this is an embedded list or a linked one by looking for all of the fields marked as
 			// required to compute the entity's id

--- a/src/runtime/cache/gc.ts
+++ b/src/runtime/cache/gc.ts
@@ -38,6 +38,8 @@ export class GarbageCollector {
 				// if the lifetime is older than the maximum value, delete the value
 				if (fieldMap.get(field)! > this.cacheBufferSize) {
 					this.cache._internal_unstable.storage.deleteField(id, field)
+					// if there is a list associated with this field, the handler needs to be deleted
+					this.cache._internal_unstable.lists.deleteField(id, field)
 
 					// delete the entry in lifetime map
 					fieldMap.delete(field)

--- a/src/runtime/cache/lists.ts
+++ b/src/runtime/cache/lists.ts
@@ -279,30 +279,6 @@ export class List {
 		// remove the target from the parent
 		this.cache._internal_unstable.storage.remove(parentID, targetKey, targetID)
 
-		// if we are removing an id from a connection then the id we were given points to an edge
-		if (this.connection) {
-			// grab the index we are removing
-			const [, field, index] = targetID.match(/(.*)\[(\d+)\]$/) || []
-			if (!field || !index) {
-				throw new Error('Could not find id of edge')
-			}
-			const newIDs = []
-
-			// every element in the linked list after the element we removed needs to have an updated id
-			for (let i = parseInt(index) + 1; i < value.length; i++) {
-				const to = `${field}[${i - 1}]`
-				newIDs.push(to)
-				this.cache._internal_unstable.storage.replaceID({
-					from: `${field}[${i}]`,
-					to,
-				})
-			}
-
-			value = value.slice(0, parseInt(index)).concat(newIDs)
-
-			this.cache._internal_unstable.storage.writeLink(parentID, targetKey, value)
-		}
-
 		// notify the subscribers about the change
 		for (const spec of subscribers) {
 			// trigger the update

--- a/src/runtime/cache/lists.ts
+++ b/src/runtime/cache/lists.ts
@@ -92,9 +92,10 @@ export class List {
 		this.manager = manager
 	}
 
-	// when applies a when condition to a new list pointing to the same spot
-	when(when?: ListWhen): List {
-		return new List({
+	// looks for the collection of all of the lists in the cache that satisfies a when
+	// condition
+	when(when?: ListWhen): ListCollection {
+		const listConfig = {
 			cache: this.cache,
 			recordID: this.recordID,
 			key: this.key,
@@ -106,7 +107,14 @@ export class List {
 			name: this.name,
 			connection: this.connection,
 			manager: this.manager,
-		})
+		}
+
+		// build up the collection of Lists that satisfy the conditions
+		const collection = new ListCollection([])
+
+		collection.lists.push(new List(listConfig))
+
+		return collection
 	}
 
 	append(selection: SubscriptionSelection, data: {}, variables: {} = {}) {
@@ -374,6 +382,46 @@ export class List {
 			this.cache._internal_unstable.storage.get(this.recordID, this.key).value as LinkedList
 		)) {
 			yield record
+		}
+	}
+}
+
+export class ListCollection {
+	lists: List[] = []
+
+	constructor(lists: List[]) {
+		this.lists = lists
+	}
+
+	append(...args: Parameters<List['append']>) {
+		this.lists.forEach((list) => list.append(...args))
+	}
+
+	prepend(...args: Parameters<List['prepend']>) {
+		this.lists.forEach((list) => list.prepend(...args))
+	}
+
+	addToList(...args: Parameters<List['addToList']>) {
+		this.lists.forEach((list) => list.addToList(...args))
+	}
+
+	removeID(...args: Parameters<List['removeID']>) {
+		this.lists.forEach((list) => list.removeID(...args))
+	}
+
+	remove(...args: Parameters<List['remove']>) {
+		this.lists.forEach((list) => list.remove(...args))
+	}
+
+	toggleElement(...args: Parameters<List['toggleElement']>) {
+		this.lists.forEach((list) => list.toggleElement(...args))
+	}
+
+	// iterating over the collection should be the same as iterating over
+	// the underlying list
+	*[Symbol.iterator]() {
+		for (let list of this.lists) {
+			yield list
 		}
 	}
 }

--- a/src/runtime/cache/lists.ts
+++ b/src/runtime/cache/lists.ts
@@ -88,6 +88,9 @@ export class ListManager {
 		// grab the list of fields associated with the parent/field combo
 		for (const list of this.listsByField.get(parentID)!.get(field)!) {
 			this.lists.get(list.name)?.get(list.parentID)?.deleteListWithKey(field)
+			if (this.lists.get(list.name)?.get(list.parentID)?.lists.length === 0) {
+				this.lists.get(list.name)?.delete(list.parentID)
+			}
 		}
 
 		// delete the lists by field lookups

--- a/src/runtime/cache/lists.ts
+++ b/src/runtime/cache/lists.ts
@@ -210,8 +210,6 @@ export class List {
 			return
 		}
 
-		console.log('removing id', id)
-
 		// if we are removing from a connection, the id we are removing from
 		// has to be computed
 		let parentID = this.recordID
@@ -256,8 +254,6 @@ export class List {
 			}
 			parentID = embeddedConnectionID
 			targetKey = 'edges'
-
-			console.log(parentID, targetID)
 		}
 
 		// if the id is not contained in the list, dont notify anyone

--- a/src/runtime/cache/storage.ts
+++ b/src/runtime/cache/storage.ts
@@ -9,6 +9,7 @@ import { flattenList } from './stuff'
 export class InMemoryStorage {
 	private data: Layer[]
 	private idCount = 0
+	private rank = 0
 
 	constructor() {
 		this.data = []
@@ -16,6 +17,10 @@ export class InMemoryStorage {
 
 	get layerCount(): number {
 		return this.data.length
+	}
+
+	get nextRank(): number {
+		return this.rank++
 	}
 
 	// create a layer and return its id

--- a/src/runtime/cache/storage.ts
+++ b/src/runtime/cache/storage.ts
@@ -290,7 +290,7 @@ export class Layer {
 		}
 
 		// there could be a mutation for the specific field
-		if (this.operations[id]?.fields[field]) {
+		if (this.operations[id]?.fields?.[field]) {
 			return this.operations[id].fields[field]
 		}
 	}
@@ -434,6 +434,11 @@ export class Layer {
 	}
 
 	writeLayer(layer: Layer): void {
+		// if we are merging into ourselves, we're done
+		if (layer.id === this.id) {
+			return
+		}
+
 		// we have to apply operations before we move fields so we can clean up existing
 		// data if we have a delete before we copy over the values
 		for (const [id, ops] of Object.entries(layer.operations)) {

--- a/src/runtime/cache/subscription.ts
+++ b/src/runtime/cache/subscription.ts
@@ -49,7 +49,7 @@ export class InMemorySubscriptions {
 				// if this field is marked as a list, register it. this will overwrite existing list handlers
 				// so that they can get up to date filters
 				if (list && fields) {
-					this.cache._internal_unstable.lists.set({
+					this.cache._internal_unstable.lists.add({
 						name: list.name,
 						connection: list.connection,
 						parentID: spec.parentID,
@@ -62,7 +62,7 @@ export class InMemorySubscriptions {
 							(acc, [key, { kind, value }]) => {
 								return {
 									...acc,
-									[key]: kind !== 'Variable' ? value : variables[value],
+									[key]: kind !== 'Variable' ? value : variables[value as string],
 								}
 							},
 							{}
@@ -199,11 +199,6 @@ export class InMemorySubscriptions {
 
 			// remove the subscribers for the field
 			this.removeSubscribers(id, key, targets)
-
-			// if this field is marked as a list remove it from the cache
-			if (selection.list) {
-				this.cache._internal_unstable.lists.remove(selection.list.name, id)
-			}
 
 			// if there is no subselection it doesn't point to a link, move on
 			if (!selection.fields) {

--- a/src/runtime/cache/tests/gc.test.ts
+++ b/src/runtime/cache/tests/gc.test.ts
@@ -227,39 +227,92 @@ test('resubscribing to fields marked for garbage collection resets counter', fun
 })
 
 test('ticks of gc delete list handlers', function () {
+	// instantiate a cache
 	const cache = new Cache(config)
-	const userFields = {
-		id: {
-			type: 'ID',
-			keyRaw: 'id',
-		},
-		firstName: {
-			type: 'String',
-			keyRaw: 'firstName',
+
+	const selection = {
+		viewer: {
+			type: 'User',
+			keyRaw: 'viewer',
+			fields: {
+				id: {
+					type: 'ID',
+					keyRaw: 'id',
+				},
+				friends: {
+					type: 'User',
+					// the key takes an argument so that we can have multiple
+					// lists tracked in the cache
+					keyRaw: 'friends',
+					list: {
+						name: 'All_Users',
+						connection: false,
+						type: 'User',
+					},
+					fields: {
+						id: {
+							type: 'ID',
+							keyRaw: 'id',
+						},
+						firstName: {
+							type: 'String',
+							keyRaw: 'firstName',
+						},
+					},
+				},
+			},
 		},
 	}
 
+	// start off associated with one object
 	cache.write({
-		selection: {
-			viewer: {
-				type: 'User',
-				keyRaw: 'viewer',
-				fields: userFields,
-			},
+		selection,
+		variables: {
+			var: 'hello',
 		},
 		data: {
 			viewer: {
 				id: '1',
-				firstName: 'bob',
+				friends: [
+					{
+						id: '2',
+						firstName: 'yves',
+					},
+				],
 			},
 		},
 	})
 
-	// tick the garbage collector enough times to fill up the buffer size
-	for (const _ of Array.from({ length: config.cacheBufferSize! })) {
+	// a function to spy on that will play the role of set
+	const set = jest.fn()
+
+	cache.subscribe(
+		{
+			rootType: 'Query',
+			set,
+			selection,
+		},
+		{
+			var: 'hello',
+		}
+	)
+
+	cache.unsubscribe(
+		{
+			rootType: 'Query',
+			set,
+			selection,
+		},
+		{
+			var: 'hello',
+		}
+	)
+
+	// tick the garbage collector enough times to trigger garbage collection
+	for (const _ of Array.from({ length: config.cacheBufferSize! + 1 })) {
 		cache._internal_unstable.collectGarbage()
-		expect(cache.read({ selection: userFields, parent: 'User:1' })).toMatchObject({
-			data: { id: '1' },
-		})
 	}
+
+	// make sure we dont have a handler for the list
+	expect(cache._internal_unstable.lists.get('All_Users')).toBeUndefined()
 })

--- a/src/runtime/cache/tests/list.test.ts
+++ b/src/runtime/cache/tests/list.test.ts
@@ -3065,3 +3065,42 @@ test('writing a scalar marked with an append', function () {
 		},
 	})
 })
+
+test('list operations fail silently', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	// write some data to a different location with a new user
+	// that should be added to the list
+	expect(() =>
+		cache.write({
+			selection: {
+				newUser: {
+					type: 'User',
+					keyRaw: 'newUser',
+					operations: [
+						{
+							action: 'insert',
+							list: 'All_Users',
+							parentID: {
+								kind: 'String',
+								value: cache._internal_unstable.id('User', '1')!,
+							},
+						},
+					],
+					fields: {
+						id: {
+							type: 'ID',
+							keyRaw: 'id',
+						},
+					},
+				},
+			},
+			data: {
+				newUser: {
+					id: '3',
+				},
+			},
+		})
+	).not.toThrow()
+})

--- a/src/runtime/cache/tests/subscriptions.test.ts
+++ b/src/runtime/cache/tests/subscriptions.test.ts
@@ -957,7 +957,7 @@ test('variables in query and subscription', function () {
 	)
 
 	// make sure we have a cached value for friends(filter: "foo")
-	expect(cache.list('All_Users').key).toEqual('friends(filter: "foo")')
+	expect(cache.list('All_Users').lists[0].key).toEqual('friends(filter: "foo")')
 
 	// somehow write a user to the cache with a new friends list
 	cache.write({

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -183,7 +183,7 @@ export type SubscriptionSelection = {
 		filters?: {
 			[key: string]: {
 				kind: 'Boolean' | 'String' | 'Float' | 'Int' | 'Variable'
-				value: string
+				value: string | number | boolean
 			}
 		}
 		fields?: SubscriptionSelection

--- a/yarn.lock
+++ b/yarn.lock
@@ -5163,7 +5163,7 @@ __metadata:
     concurrently: ^6.2.1
     graphql: 15.5.0
     graphql-relay: ^0.8.0
-    houdini: ^0.13.9
+    houdini: ^0.14.0
     subscriptions-transport-ws: ^0.9.18
     svelte: ^3.38.2
     svelte-preprocess: ^4.0.0
@@ -6081,7 +6081,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"houdini@^0.13.9, houdini@workspace:.":
+"houdini@^0.14.0, houdini@workspace:.":
   version: 0.0.0-use.local
   resolution: "houdini@workspace:."
   dependencies:


### PR DESCRIPTION
This PR does a few things:

- List operations are now silent. If the list hasn't been created when a mutation triggers, nothing happens. Previously, an exception was thrown which couples a mutation to the view
- If an element is appended to a list, it is added to all lists that satisfy the name and when conditions, not just the latest one to register

To Do:
- [x] add tests for multiple lists
- [x] garbage collection of list handlers