### PR TITLE
add pinst to disable postinstall on packaging

### DIFF
--- a/.changeset/violet-shoes-hide.md
+++ b/.changeset/violet-shoes-hide.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+add pinst to disable postinstall for publishing

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
 		"changeset": "changeset",
 		"version": "changeset version",
 		"release": "yarn build && changeset publish",
-		"postinstall": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\""
+		"posinstall": "node -e \"try { require('husky').install(); console.log('ran prepack') } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",
+		"prepack": "pinst --disable",
+		"postpack": "pinst --enable"
 	},
 	"resolutions": {
 		"typescript": "3.9.5"
@@ -59,6 +61,7 @@
 		"jest": "^26.6.3",
 		"mock-fs": "^4.13.0",
 		"npm": "^8.6.0",
+		"pinst": "^3.0.0",
 		"prettier": "^2.0.5",
 		"pretty-quick": "^3.1.1",
 		"rollup": "2.68.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5163,7 +5163,7 @@ __metadata:
     concurrently: ^6.2.1
     graphql: 15.5.0
     graphql-relay: ^0.8.0
-    houdini: ^0.13.9
+    houdini: ^0.14.0
     subscriptions-transport-ws: ^0.9.18
     svelte: ^3.38.2
     svelte-preprocess: ^4.0.0
@@ -6081,7 +6081,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"houdini@^0.13.9, houdini@workspace:.":
+"houdini@^0.14.0, houdini@workspace:.":
   version: 0.0.0-use.local
   resolution: "houdini@workspace:."
   dependencies:
@@ -6119,6 +6119,7 @@ __metadata:
     mock-fs: ^4.13.0
     node-fetch: ^2.6.1
     npm: ^8.6.0
+    pinst: ^3.0.0
     prettier: ^2.0.5
     pretty-quick: ^3.1.1
     recast: ^0.20.4
@@ -9223,6 +9224,15 @@ __metadata:
   version: 4.0.1
   resolution: "pify@npm:4.0.1"
   checksum: 9c4e34278cb09987685fa5ef81499c82546c033713518f6441778fbec623fc708777fe8ac633097c72d88470d5963094076c7305cafc7ad340aae27cfacd856b
+  languageName: node
+  linkType: hard
+
+"pinst@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "pinst@npm:3.0.0"
+  bin:
+    pinst: bin.js
+  checksum: 4ae48a6a60f79c37071233af51b4d91bfc85cfa3c12b66ccda60cdb642b4d14a4ab0cb3587afc55b1f6192cea1772a5e4822026a0d0d3528296edef00cc2d61f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
resolves #278 by implementing the method [husky docs suggest](https://typicode.github.io/husky/#/?id=yarn-2) to disable postinstall for publishing with [pinst](https://github.com/typicode/pinst).