### PR TITLE
Given component queries better default prop values

### DIFF
--- a/.changeset/polite-pans-hammer.md
+++ b/.changeset/polite-pans-hammer.md
@@ -2,4 +2,4 @@
 'houdini': patch
 ---
 
-Fixed bug in component queries
+Fixed bug in component queries associated with the unloaded response from `load`.

--- a/.changeset/polite-pans-hammer.md
+++ b/.changeset/polite-pans-hammer.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fixed bug in component queries

--- a/src/preprocess/transforms/query.test.ts
+++ b/src/preprocess/transforms/query.test.ts
@@ -57,7 +57,7 @@ describe('query preprocessor', function () {
 	`)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
-		export let _TestQuery = undefined;
+		export let _TestQuery = {};
 
 		let _TestQuery_handler = query({
 		    "config": houdiniConfig,
@@ -171,7 +171,7 @@ describe('query preprocessor', function () {
 	`)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
-		export let _TestQuery2 = undefined;
+		export let _TestQuery2 = {};
 
 		let _TestQuery2_handler = query({
 		    "config": houdiniConfig,
@@ -183,7 +183,7 @@ describe('query preprocessor', function () {
 		    "source": _TestQuery2.source
 		});
 
-		export let _TestQuery1 = undefined;
+		export let _TestQuery1 = {};
 
 		let _TestQuery1_handler = query({
 		    "config": houdiniConfig,
@@ -305,7 +305,7 @@ describe('query preprocessor', function () {
 	`)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
-		export let _TestQuery = undefined;
+		export let _TestQuery = {};
 
 		let _TestQuery_handler = query({
 		    "config": houdiniConfig,
@@ -388,7 +388,7 @@ describe('query preprocessor', function () {
 	`)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
-		export let _TestQuery = undefined;
+		export let _TestQuery = {};
 
 		let _TestQuery_handler = query({
 		    "config": houdiniConfig,
@@ -446,7 +446,7 @@ describe('query preprocessor', function () {
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
-		export let _TestQuery = undefined;
+		export let _TestQuery = {};
 
 		let _TestQuery_handler = query({
 		    "config": houdiniConfig,
@@ -496,7 +496,7 @@ describe('query preprocessor', function () {
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
-		export let _TestQuery = undefined;
+		export let _TestQuery = {};
 
 		let _TestQuery_handler = query({
 		    "config": houdiniConfig,
@@ -546,7 +546,7 @@ describe('query preprocessor', function () {
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
-		export let _TestQuery = undefined;
+		export let _TestQuery = {};
 
 		let _TestQuery_handler = query({
 		    "config": houdiniConfig,
@@ -594,7 +594,7 @@ describe('query preprocessor', function () {
 		)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
-		export let _TestQuery = undefined;
+		export let _TestQuery = {};
 
 		let _TestQuery_handler = paginatedQuery({
 		    "config": houdiniConfig,
@@ -649,7 +649,7 @@ describe('query preprocessor', function () {
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
-		export let _TestQuery = undefined;
+		export let _TestQuery = {};
 
 		let _TestQuery_handler = query({
 		    "config": houdiniConfig,
@@ -1485,7 +1485,7 @@ test('2 queries, one paginated one not', async function () {
 
 	expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { routeQuery, componentQuery, query } from "$houdini";
-		export let _TestQuery2 = undefined;
+		export let _TestQuery2 = {};
 
 		let _TestQuery2_handler = paginatedQuery({
 		    "config": houdiniConfig,
@@ -1497,7 +1497,7 @@ test('2 queries, one paginated one not', async function () {
 		    "source": _TestQuery2.source
 		});
 
-		export let _TestQuery1 = undefined;
+		export let _TestQuery1 = {};
 
 		let _TestQuery1_handler = query({
 		    "config": houdiniConfig,

--- a/src/preprocess/transforms/query.ts
+++ b/src/preprocess/transforms/query.ts
@@ -205,7 +205,7 @@ function processInstance(
 			// @ts-ignore: babel's ast does something weird with comments, we won't use em
 			AST.exportNamedDeclaration(
 				AST.variableDeclaration('let', [
-					AST.variableDeclarator(AST.identifier(preloadKey), AST.identifier('undefined')),
+					AST.variableDeclarator(AST.identifier(preloadKey), AST.objectExpression([])),
 				])
 			),
 			AST.variableDeclaration('let', [


### PR DESCRIPTION
This PR closes #282 by providing a default value of `{}` to the props driven by the query response