### PR TITLE
Pass variables to `afterLoad`

### DIFF
--- a/.changeset/lucky-forks-lick.md
+++ b/.changeset/lucky-forks-lick.md
@@ -1,0 +1,5 @@
+---
+'houdini': minor
+---
+
+Only generate after load types for queries

--- a/.changeset/tough-suns-begin.md
+++ b/.changeset/tough-suns-begin.md
@@ -1,0 +1,5 @@
+---
+'houdini': minor
+---
+
+Pass variables to `afterLoad` hook

--- a/src/cmd/generators/typescript/index.ts
+++ b/src/cmd/generators/typescript/index.ts
@@ -180,29 +180,55 @@ async function generateOperationTypeDefs(
 	)
 
 	// generate type for the afterload function
+	const properties: ReturnType<typeof readonlyProperty>[] = [
+		readonlyProperty(
+			AST.tsPropertySignature(
+				AST.stringLiteral('data'),
+				AST.tsTypeAnnotation(
+					AST.tsTypeLiteral([
+						readonlyProperty(
+							AST.tsPropertySignature(
+								AST.stringLiteral(definition.name!.value),
+								AST.tsTypeAnnotation(
+									AST.tsTypeReference(AST.identifier(shapeTypeName))
+								)
+							)
+						),
+					])
+				)
+			)
+		),
+	]
+
+	if (hasInputs) {
+		properties.splice(
+			0,
+			0,
+			readonlyProperty(
+				AST.tsPropertySignature(
+					AST.stringLiteral('input'),
+					AST.tsTypeAnnotation(
+						AST.tsTypeLiteral([
+							readonlyProperty(
+								AST.tsPropertySignature(
+									AST.stringLiteral(definition.name!.value),
+									AST.tsTypeAnnotation(
+										AST.tsTypeReference(AST.identifier(inputTypeName))
+									)
+								)
+							),
+						])
+					)
+				)
+			)
+		)
+	}
+
 	body.push(
 		AST.exportNamedDeclaration(
 			AST.tsTypeAliasDeclaration(
 				AST.identifier(afterLoadTypeName),
-				AST.tsTypeLiteral([
-					readonlyProperty(
-						AST.tsPropertySignature(
-							AST.stringLiteral('data'),
-							AST.tsTypeAnnotation(
-								AST.tsTypeLiteral([
-									readonlyProperty(
-										AST.tsPropertySignature(
-											AST.stringLiteral(definition.name!.value),
-											AST.tsTypeAnnotation(
-												AST.tsTypeReference(AST.identifier(shapeTypeName))
-											)
-										)
-									),
-								])
-							)
-						)
-					),
-				])
+				AST.tsTypeLiteral(properties)
 			)
 		)
 	)

--- a/src/cmd/generators/typescript/index.ts
+++ b/src/cmd/generators/typescript/index.ts
@@ -224,14 +224,16 @@ async function generateOperationTypeDefs(
 		)
 	}
 
-	body.push(
-		AST.exportNamedDeclaration(
-			AST.tsTypeAliasDeclaration(
-				AST.identifier(afterLoadTypeName),
-				AST.tsTypeLiteral(properties)
+	if (definition.operation === 'query') {
+		body.push(
+			AST.exportNamedDeclaration(
+				AST.tsTypeAliasDeclaration(
+					AST.identifier(afterLoadTypeName),
+					AST.tsTypeLiteral(properties)
+				)
 			)
 		)
-	)
+	}
 
 	// if there are variables in this query
 	if (hasInputs && definition.variableDefinitions && definition.variableDefinitions.length > 0) {

--- a/src/cmd/generators/typescript/typescript.test.ts
+++ b/src/cmd/generators/typescript/typescript.test.ts
@@ -403,15 +403,6 @@ describe('typescript', function () {
 		    } | null
 		};
 
-		export type Mutation$afterLoad = {
-		    readonly "input": {
-		        readonly "Mutation": Mutation$input
-		    },
-		    readonly "data": {
-		        readonly "Mutation": Mutation$result
-		    }
-		};
-
 		type NestedUserFilter = {
 		    id: string,
 		    firstName: string,

--- a/src/cmd/generators/typescript/typescript.test.ts
+++ b/src/cmd/generators/typescript/typescript.test.ts
@@ -336,6 +336,9 @@ describe('typescript', function () {
 		};
 
 		export type Query$afterLoad = {
+		    readonly "input": {
+		        readonly "Query": Query$input
+		    },
 		    readonly "data": {
 		        readonly "Query": Query$result
 		    }
@@ -401,6 +404,9 @@ describe('typescript', function () {
 		};
 
 		export type Mutation$afterLoad = {
+		    readonly "input": {
+		        readonly "Mutation": Mutation$input
+		    },
 		    readonly "data": {
 		        readonly "Mutation": Mutation$result
 		    }
@@ -468,6 +474,9 @@ describe('typescript', function () {
 		};
 
 		export type Query$afterLoad = {
+		    readonly "input": {
+		        readonly "Query": Query$input
+		    },
 		    readonly "data": {
 		        readonly "Query": Query$result
 		    }
@@ -896,6 +905,9 @@ describe('typescript', function () {
 		};
 
 		export type Query$afterLoad = {
+		    readonly "input": {
+		        readonly "Query": Query$input
+		    },
 		    readonly "data": {
 		        readonly "Query": Query$result
 		    }

--- a/src/preprocess/transforms/query.test.ts
+++ b/src/preprocess/transforms/query.test.ts
@@ -1003,6 +1003,10 @@ test('afterLoad hook', async function () {
 		        "framework": "sapper",
 		        "hookFn": afterLoad,
 
+		        "input": {
+		            "TestQuery": _TestQuery_Input
+		        },
+
 		        "data": {
 		            "TestQuery": _TestQuery.result.data
 		        }
@@ -1135,6 +1139,11 @@ test('afterLoad hook - multiple queries', async function () {
 		        "variant": "after",
 		        "framework": "sapper",
 		        "hookFn": afterLoad,
+
+		        "input": {
+		            "TestQuery1": _TestQuery1_Input,
+		            "TestQuery2": _TestQuery2_Input
+		        },
 
 		        "data": {
 		            "TestQuery1": _TestQuery1.result.data,
@@ -1283,6 +1292,10 @@ test('both beforeLoad and afterLoad hooks', async function () {
 		        "variant": "after",
 		        "framework": "sapper",
 		        "hookFn": afterLoad,
+
+		        "input": {
+		            "TestQuery": _TestQuery_Input
+		        },
 
 		        "data": {
 		            "TestQuery": _TestQuery.result.data

--- a/src/preprocess/transforms/query.ts
+++ b/src/preprocess/transforms/query.ts
@@ -713,6 +713,10 @@ function loadHookStatements(
 							...(name === 'afterLoad'
 								? [
 										AST.objectProperty(
+											AST.literal('input'),
+											afterLoadQueryInput(queries)
+										),
+										AST.objectProperty(
 											AST.literal('data'),
 											afterLoadQueryData(queries)
 										),
@@ -736,6 +740,19 @@ function loadHookStatements(
 			])
 		),
 	]
+}
+
+function afterLoadQueryInput(queries: EmbeddedGraphqlDocument[]) {
+	return AST.objectExpression(
+		queries.map(({ parsedDocument: { definitions } }) =>
+			AST.objectProperty(
+				AST.literal(
+					(definitions[0] as graphql.OperationDefinitionNode)?.name?.value || null
+				),
+				AST.identifier(variablesKey(definitions[0] as graphql.OperationDefinitionNode))
+			)
+		)
+	)
 }
 
 function afterLoadQueryData(queries: EmbeddedGraphqlDocument[]) {

--- a/src/runtime/network.ts
+++ b/src/runtime/network.ts
@@ -69,6 +69,7 @@ export type FetchContext = {
 
 export type BeforeLoadContext = FetchContext
 export type AfterLoadContext = FetchContext & {
+	input: Record<string, any>
 	data: Record<string, any>
 }
 
@@ -318,11 +319,13 @@ export class RequestContext {
 		variant,
 		framework,
 		hookFn,
+		input,
 		data,
 	}: {
 		variant: 'before' | 'after'
 		framework: 'kit' | 'sapper'
 		hookFn: KitBeforeLoad | KitAfterLoad | SapperBeforeLoad | SapperAfterLoad
+		input: Record<string, any>
 		data: Record<string, any>
 	}) {
 		// call the onLoad function to match the framework
@@ -333,6 +336,7 @@ export class RequestContext {
 			} else {
 				hookCall = (hookFn as KitAfterLoad).call(this, {
 					...this.context,
+					input,
 					data,
 				} as AfterLoadContext)
 			}
@@ -349,7 +353,8 @@ export class RequestContext {
 					this,
 					this.context.page,
 					this.context.session,
-					data
+					data,
+					input
 				)
 			}
 		}
@@ -406,7 +411,8 @@ type SapperBeforeLoad = (
 type SapperAfterLoad = (
 	page: FetchContext['page'],
 	session: FetchContext['session'],
-	data: Record<string, any>
+	data: Record<string, any>,
+	input: Record<string, any>
 ) => Record<string, any>
 
 type KitBeforeLoad = (ctx: BeforeLoadContext) => Record<string, any>


### PR DESCRIPTION
I want to eliminate duplicate code when I need the query variables also at other places.