### PR TITLE
Remove Resolution to TypeScript 3.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 		"ts-ast-serializer": "^1.0.1",
 		"ts-jest": "^26.0.0",
 		"ts-node": "^9.1.1",
+		"tslib": "^2.4.0",
 		"typescript": "^4.6.3"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
 		"prepack": "pinst --disable",
 		"postpack": "pinst --enable"
 	},
-	"resolutions": {
-		"typescript": "3.9.5"
-	},
 	"devDependencies": {
 		"@babel/core": "^7.12.10",
 		"@babel/preset-env": "^7.12.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6130,6 +6130,7 @@ __metadata:
     ts-ast-serializer: ^1.0.1
     ts-jest: ^26.0.0
     ts-node: ^9.1.1
+    tslib: ^2.4.0
     typescript: ^4.6.3
   bin:
     houdini: ./build/cmd.js
@@ -11276,6 +11277,13 @@ resolve@^1.19.0:
   version: 2.3.1
   resolution: "tslib@npm:2.3.1"
   checksum: de17a98d4614481f7fcb5cd53ffc1aaf8654313be0291e1bfaee4b4bb31a20494b7d218ff2e15017883e8ea9626599b3b0e0229c18383ba9dce89da2adf15cb9
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "tslib@npm:2.4.0"
+  checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11374,23 +11374,23 @@ resolve@^1.19.0:
   languageName: node
   linkType: hard
 
-"typescript@npm:3.9.5":
-  version: 3.9.5
-  resolution: "typescript@npm:3.9.5"
+"typescript@npm:^4.0.0, typescript@npm:^4.6.3":
+  version: 4.7.3
+  resolution: "typescript@npm:4.7.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6ebba8deed366a5a47602a7ab6b8489526e615e20dfb3305a49d7c9bed510757f63518225fe03afbadaf3577e08d2aea406fdda23eef3669101d6f7c39e928a1
+  checksum: fd13a1ce53790a36bb8350e1f5e5e384b5f6cb9b0635114a6d01d49cb99916abdcfbc13c7521cdae2f2d3f6d8bc4a8ae7625edf645a04ee940588cd5e7597b2f
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A3.9.5#~builtin<compat/typescript>":
-  version: 3.9.5
-  resolution: "typescript@patch:typescript@npm%3A3.9.5#~builtin<compat/typescript>::version=3.9.5&hash=bda367"
+"typescript@patch:typescript@^4.0.0#~builtin<compat/typescript>, typescript@patch:typescript@^4.6.3#~builtin<compat/typescript>":
+  version: 4.7.3
+  resolution: "typescript@patch:typescript@npm%3A4.7.3#~builtin<compat/typescript>::version=4.7.3&hash=bda367"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: bfea14f536401538736250a512d6c779026e9af89a61be59aaefc35fcef9ed926aac1f90509eaa215023b1823d383090cfcc965bb91cbef47f74e151d723fd78
+  checksum: 8257ce7ecbbf9416da60045a76a99d473698ca9e973fa0ddab7137cacb1587255431176cbbcc801a650938c4dc8109ab88355774829a714fabe56a53a2fe4524
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I came across this old version of TypeScript while writing #310 and finding a case where something wouldn't type-check that should have.

Removing the resolution seems safe; the tests still pass, so I figure it's worth removing to use the latest version of TypeScript instead!