### PR TITLE
`@parentID` fix

### DIFF
--- a/.changeset/empty-socks-design.md
+++ b/.changeset/empty-socks-design.md
@@ -1,0 +1,5 @@
+---
+'houdini': minor
+---
+
+parentID directive and arguments are now relative to object containing the decorated field

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,9 @@
+{
+	"mode": "pre",
+	"tag": "next",
+	"initialVersions": {
+		"houdini": "0.14.7",
+		"example-kit": "0.13.0"
+	},
+	"changesets": []
+}

--- a/src/runtime/cache/cache.ts
+++ b/src/runtime/cache/cache.ts
@@ -790,6 +790,10 @@ class CacheInternal {
 			return null
 		}
 
+		if (!type) {
+			return id
+		}
+
 		return type + ':' + id
 	}
 

--- a/src/runtime/cache/cache.ts
+++ b/src/runtime/cache/cache.ts
@@ -20,7 +20,7 @@ export class Cache {
 			config: defaultConfigValues(config),
 			storage: new InMemoryStorage(),
 			subscriptions: new InMemorySubscriptions(this),
-			lists: new ListManager(rootID),
+			lists: new ListManager(this, rootID),
 			lifetimes: new GarbageCollector(this, config.cacheBufferSize),
 		})
 	}
@@ -108,12 +108,12 @@ export class Cache {
 	}
 
 	// return the list handler to mutate a named list in the cache
-	list(name: string, parentID?: string): ListCollection {
+	list(name: string, parentID?: string | {}): ListCollection {
 		const handler = this._internal_unstable.lists.get(name, parentID)
 		if (!handler) {
 			throw new Error(
 				`Cannot find list with name: ${name}${
-					parentID ? 'under parent ' + parentID : ''
+					parentID ? ' under parent ' + parentID : ''
 				}. ` + 'Is it possible that the query is not mounted?'
 			)
 		}
@@ -779,7 +779,7 @@ class CacheInternal {
 	}
 
 	// returns the global id of the specified field (used to access the record in the cache)
-	id(type: string, data: { id?: string } | null): string | null
+	id(type: string, data: {} | null): string | null
 	// this is like id but it trusts the value used for the id and just joins it with the
 	// type to form the global id
 	id(type: string, id: string): string | null

--- a/src/runtime/cache/lists.ts
+++ b/src/runtime/cache/lists.ts
@@ -45,8 +45,8 @@ export class ListManager {
 
 		// the provided id won't match the cache's ID so we have to compute the internal ID, using
 		// one of the matches to figure out the type of the list element
-		const { listType } = head.lists[0]
-		const parentID = id ? this.cache._internal_unstable.id(listType, id)! : this.rootID
+		const { recordType } = head.lists[0]
+		const parentID = id ? this.cache._internal_unstable.id(recordType || '', id)! : this.rootID
 
 		// return the list pointing to the correct parent
 		return this.lists.get(listName)?.get(parentID)
@@ -60,6 +60,7 @@ export class ListManager {
 		name: string
 		connection: boolean
 		recordID: SubscriptionSpec['parentID']
+		recordType?: string
 		key: string
 		listType: string
 		selection: SubscriptionSelection
@@ -131,6 +132,7 @@ export class ListManager {
 
 export class List {
 	readonly recordID: string
+	readonly recordType?: string
 	readonly key: string
 	readonly listType: string
 	private cache: Cache
@@ -144,6 +146,7 @@ export class List {
 	constructor({
 		name,
 		recordID,
+		recordType,
 		key,
 		listType,
 		selection,
@@ -153,6 +156,7 @@ export class List {
 		manager,
 	}: Parameters<ListManager['add']>[0] & { manager: ListManager }) {
 		this.recordID = recordID || rootID
+		this.recordType = recordType
 		this.key = key
 		this.listType = listType
 		this.cache = manager.cache

--- a/src/runtime/cache/lists.ts
+++ b/src/runtime/cache/lists.ts
@@ -5,9 +5,11 @@ import { flattenList } from './stuff'
 
 export class ListManager {
 	rootID: string
+	cache: Cache
 
-	constructor(rootID: string) {
+	constructor(cache: Cache, rootID: string) {
 		this.rootID = rootID
+		this.cache = cache
 	}
 
 	// associate list names with the handler that wraps the list
@@ -15,8 +17,39 @@ export class ListManager {
 
 	private listsByField: Map<string, Map<string, List[]>> = new Map()
 
-	get(listName: string, id?: string) {
-		return this.lists.get(listName)?.get(id || this.rootID)
+	get(listName: string, id?: string | {}) {
+		const matches = this.lists.get(listName)
+
+		// if we don't have a list by that name, we're done
+		if (!matches || matches.size === 0) {
+			return null
+		}
+
+		const head = [...matches.values()][0]
+
+		// if there is only one list with that name, return it
+		if (matches?.size === 1) {
+			return head
+		}
+
+		// there are multiple versions of the list so the user must
+		// have provided an id. If they meant to refer to the root object
+		// it would have been caught in the size === 1 check above since
+		// root's ID is fixed
+		if (!id) {
+			throw new Error(
+				`Found multiple instances of "${listName}". Please provide a ` +
+					`parentID that corresponds to the object containing the field marked with @list or @paginate.`
+			)
+		}
+
+		// the provided id won't match the cache's ID so we have to compute the internal ID, using
+		// one of the matches to figure out the type of the list element
+		const { listType } = head.lists[0]
+		const parentID = id ? this.cache._internal_unstable.id(listType, id)! : this.rootID
+
+		// return the list pointing to the correct parent
+		return this.lists.get(listName)?.get(parentID)
 	}
 
 	remove(listName: string, id: string) {
@@ -26,14 +59,12 @@ export class ListManager {
 	add(list: {
 		name: string
 		connection: boolean
-		cache: Cache
-		recordID: string
+		recordID: SubscriptionSpec['parentID']
 		key: string
 		listType: string
 		selection: SubscriptionSelection
 		when?: ListWhen
 		filters?: List['filters']
-		parentID: SubscriptionSpec['parentID']
 	}) {
 		// if we haven't seen this list before
 		if (!this.lists.has(list.name)) {
@@ -42,7 +73,7 @@ export class ListManager {
 
 		// if we haven't seen the list before, add a new colleciton
 		const name = list.name
-		const parentID = list.parentID || this.rootID
+		const parentID = list.recordID || this.rootID
 
 		// if we already have a handler for the key, don't do anything
 		if (this.lists.get(name)?.get(parentID)?.includes(list.key)) {
@@ -56,11 +87,11 @@ export class ListManager {
 			this.lists.get(name)!.set(parentID, new ListCollection([]))
 		}
 
-		if (!this.listsByField.has(list.recordID)) {
-			this.listsByField.set(list.recordID, new Map())
+		if (!this.listsByField.has(parentID)) {
+			this.listsByField.set(parentID, new Map())
 		}
-		if (!this.listsByField.get(list.recordID)!.has(list.key)) {
-			this.listsByField.get(list.recordID)?.set(list.key, [])
+		if (!this.listsByField.get(parentID)!.has(list.key)) {
+			this.listsByField.get(parentID)?.set(list.key, [])
 		}
 
 		// create the list handler
@@ -68,7 +99,7 @@ export class ListManager {
 
 		// add the list to the collection
 		this.lists.get(list.name)!.get(parentID)!.lists.push(handler)
-		this.listsByField.get(list.recordID)!.get(list.key)!.push(handler)
+		this.listsByField.get(parentID)!.get(list.key)!.push(handler)
 	}
 
 	removeIDFromAllLists(id: string) {
@@ -87,9 +118,9 @@ export class ListManager {
 
 		// grab the list of fields associated with the parent/field combo
 		for (const list of this.listsByField.get(parentID)!.get(field)!) {
-			this.lists.get(list.name)?.get(list.parentID)?.deleteListWithKey(field)
-			if (this.lists.get(list.name)?.get(list.parentID)?.lists.length === 0) {
-				this.lists.get(list.name)?.delete(list.parentID)
+			this.lists.get(list.name)?.get(list.recordID)?.deleteListWithKey(field)
+			if (this.lists.get(list.name)?.get(list.recordID)?.lists.length === 0) {
+				this.lists.get(list.name)?.delete(list.recordID)
 			}
 		}
 
@@ -107,32 +138,28 @@ export class List {
 	private _when?: ListWhen
 	private filters?: { [key: string]: number | boolean | string }
 	readonly name: string
-	readonly parentID: string
 	private connection: boolean
 	private manager: ListManager
 
 	constructor({
 		name,
-		cache,
 		recordID,
 		key,
 		listType,
 		selection,
 		when,
 		filters,
-		parentID,
 		connection,
 		manager,
 	}: Parameters<ListManager['add']>[0] & { manager: ListManager }) {
-		this.recordID = recordID
+		this.recordID = recordID || rootID
 		this.key = key
 		this.listType = listType
-		this.cache = cache
+		this.cache = manager.cache
 		this.selection = selection
 		this._when = when
 		this.filters = filters
 		this.name = name
-		this.parentID = parentID || rootID
 		this.connection = connection
 		this.manager = manager
 	}
@@ -140,7 +167,7 @@ export class List {
 	// looks for the collection of all of the lists in the cache that satisfies a when
 	// condition
 	when(when?: ListWhen): ListCollection {
-		return this.manager.lists.get(this.name)!.get(this.parentID)!.when(when)
+		return this.manager.lists.get(this.name)!.get(this.recordID)!.when(when)
 	}
 
 	append(selection: SubscriptionSelection, data: {}, variables: {} = {}) {

--- a/src/runtime/cache/subscription.ts
+++ b/src/runtime/cache/subscription.ts
@@ -22,13 +22,15 @@ export class InMemorySubscriptions {
 		spec,
 		selection,
 		variables,
+		parentType,
 	}: {
 		parent: string
 		spec: SubscriptionSpec
 		selection: SubscriptionSelection
 		variables: { [key: string]: GraphQLValue }
+		parentType?: string
 	}) {
-		for (const { keyRaw, fields, list, filters } of Object.values(selection)) {
+		for (const { keyRaw, fields, list, filters, type } of Object.values(selection)) {
 			const key = evaluateKey(keyRaw, variables)
 
 			// add the subscriber to the field
@@ -58,6 +60,7 @@ export class InMemorySubscriptions {
 						name: list.name,
 						connection: list.connection,
 						recordID: parent,
+						recordType: parentType,
 						listType: list.type,
 						key,
 						selection: fields,
@@ -86,6 +89,7 @@ export class InMemorySubscriptions {
 						spec,
 						selection: fields,
 						variables,
+						parentType: type,
 					})
 				}
 			}

--- a/src/runtime/cache/tests/gc.test.ts
+++ b/src/runtime/cache/tests/gc.test.ts
@@ -314,5 +314,5 @@ test('ticks of gc delete list handlers', function () {
 	}
 
 	// make sure we dont have a handler for the list
-	expect(cache._internal_unstable.lists.get('All_Users')).toBeUndefined()
+	expect(cache._internal_unstable.lists.get('All_Users')).toBeNull()
 })

--- a/src/runtime/cache/tests/list.test.ts
+++ b/src/runtime/cache/tests/list.test.ts
@@ -3396,3 +3396,86 @@ test('when conditions look for all matching lists', function () {
 		},
 	})
 })
+
+test('parentID must be passed if there are multiple instances of a list handler', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	const friendsSelection = {
+		friends: {
+			type: 'User',
+			keyRaw: 'friends',
+			list: {
+				name: 'All_Users',
+				connection: false,
+				type: 'User',
+			},
+			fields: {
+				id: {
+					type: 'ID',
+					keyRaw: 'id',
+				},
+				firstName: {
+					type: 'String',
+					keyRaw: 'firstName',
+				},
+			},
+		},
+	}
+
+	// create a list we will add to
+	cache.write({
+		selection: {
+			viewer: {
+				type: 'User',
+				keyRaw: 'viewer',
+				fields: {
+					id: {
+						type: 'ID',
+						keyRaw: 'id',
+					},
+					...friendsSelection,
+				},
+			},
+		},
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						id: '2',
+						firstName: 'Jean',
+					},
+				],
+			},
+		},
+	})
+
+	// subscribe to the data to register the list
+	cache.subscribe(
+		{
+			rootType: 'User',
+			selection: friendsSelection,
+			parentID: cache._internal_unstable.id('User', '1')!,
+			set: jest.fn(),
+		},
+		{}
+	)
+
+	// subscribe to the connection with a different parentID
+	cache.subscribe(
+		{
+			rootType: 'User',
+			selection: friendsSelection,
+			parentID: cache._internal_unstable.id('User', '2')!,
+			set: jest.fn(),
+		},
+		{}
+	)
+
+	// looking up the list without a parent id should fail
+	expect(() => cache.list('All_Users')).toThrow()
+	expect(cache.list('All_Users', '1')!.lists[0].recordID).toEqual(
+		cache._internal_unstable.id('User', '1')
+	)
+})


### PR DESCRIPTION
This PR fixes #314 by changing the `@parentID` directive behavior to take the ID pointing to the parent of the field marked with `@paginate` or `@list` instead of the target of the fragment/query. Since this is technically a breaking change, I also put the repo in prerelease mode so we can include this fix along with #291 