### PR TITLE
Mutation results shouldn't be nullable by default

### DIFF
--- a/.changeset/wicked-lamps-smoke.md
+++ b/.changeset/wicked-lamps-smoke.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fixed type generated for mutation results

--- a/src/cmd/generators/typescript/index.ts
+++ b/src/cmd/generators/typescript/index.ts
@@ -155,10 +155,12 @@ async function generateOperationTypeDefs(
 						AST.tsPropertySignature(
 							AST.stringLiteral('result'),
 							AST.tsTypeAnnotation(
-								AST.tsUnionType([
-									AST.tsTypeReference(AST.identifier(shapeTypeName)),
-									AST.tsUndefinedKeyword(),
-								])
+								definition.operation === 'mutation'
+									? AST.tsTypeReference(AST.identifier(shapeTypeName))
+									: AST.tsUnionType([
+											AST.tsTypeReference(AST.identifier(shapeTypeName)),
+											AST.tsUndefinedKeyword(),
+									  ])
 							)
 						)
 					),

--- a/src/cmd/generators/typescript/typescript.test.ts
+++ b/src/cmd/generators/typescript/typescript.test.ts
@@ -394,7 +394,7 @@ describe('typescript', function () {
 		).toMatchInlineSnapshot(`
 		export type Mutation = {
 		    readonly "input": Mutation$input,
-		    readonly "result": Mutation$result | undefined
+		    readonly "result": Mutation$result
 		};
 
 		export type Mutation$result = {


### PR DESCRIPTION
@alexlafroscia brought up a good point in #304 about the nullability of mutation results. This PR fixes the generated type for mutation artifacts to not be able to be `undefined`