### PR TITLE
remove the query hook deprecation notice

### DIFF
--- a/.changeset/angry-ladybugs-decide.md
+++ b/.changeset/angry-ladybugs-decide.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Remove deprecation warning (its no longer deprecated)

--- a/src/preprocess/transforms/query.ts
+++ b/src/preprocess/transforms/query.ts
@@ -227,13 +227,6 @@ function addKitLoad({
 	let afterLoadDefinition = findExportedFunction(body, 'afterLoad')
 	let onLoadDefinition = findExportedFunction(body, 'onLoad')
 
-	// if there are any hooks, warn the user they will be gone soon
-	if (beforeLoadDefinition || afterLoadDefinition || onLoadDefinition) {
-		console.warn(
-			'Query hooks are deprecated and will be removed soon. For more information please see the 0.15.0 migration doc: <link>.'
-		)
-	}
-
 	// the name of the variable
 	const requestContext = AST.identifier('_houdini_context')
 


### PR DESCRIPTION
query hooks are no longer deprecated since we don't want to encourage users to define their own loads (it'll break the variable call to `fetch`)