### PR TITLE
Null fragment parents

### DIFF
--- a/.changeset/shiny-melons-rest.md
+++ b/.changeset/shiny-melons-rest.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+allow null values passed to fragment

--- a/integration/src/lib/utils/routes.ts
+++ b/integration/src/lib/utils/routes.ts
@@ -13,6 +13,7 @@ export const routes = {
   Stores_Mutation_Scalars: '/stores/mutation-scalars',
   Stores_Network_One_Store_Multivariables: '/stores/network-one-store-multivariables',
   Stores_SSR_One_Store_Multivariables: '/stores/ssr-one-store-multivariables',
+  Stores_Fragment_Null: '/stores/fragment-null',
 
   Preprocess_query_simple: '/preprocess/query/simple',
   Preprocess_query_variable_1: '/preprocess/query/variable/1',

--- a/integration/src/routes/stores/fragment-null.spec.ts
+++ b/integration/src/routes/stores/fragment-null.spec.ts
@@ -1,0 +1,18 @@
+import { test } from '@playwright/test';
+import { routes } from '../../lib/utils/routes.js';
+import {
+  expectGraphQLResponse,
+  expectNoGraphQLRequest,
+  expectToBe
+} from '../../lib/utils/testsHelper.js';
+
+test.describe('fragment store', function () {
+  test('accepts and returns null values', async function ({ page }) {
+    page.goto(routes.Stores_Mutation_Scalars);
+
+    await expectNoGraphQLRequest(page);
+
+    // make sure that the result updated with unmarshaled data
+    await expectToBe(page, 'null');
+  });
+});

--- a/integration/src/routes/stores/fragment-null.svelte
+++ b/integration/src/routes/stores/fragment-null.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import UserInfoStore from '$houdini/stores/UserInfo';
+
+  const data = UserInfoStore.get(null);
+</script>
+
+<div id="result">
+  {$data}
+</div>

--- a/src/runtime/lib/pagination.ts
+++ b/src/runtime/lib/pagination.ts
@@ -46,8 +46,8 @@ export function fragmentHandlers<_Data extends GraphQLObject, _Input>({
 }: {
 	config: ConfigFile
 	paginationArtifact: QueryArtifact
-	initialValue: _Data
-	store: Readable<GraphQLObject>
+	initialValue: _Data | null
+	store: Readable<GraphQLObject | null>
 }) {
 	const { targetType } = paginationArtifact.refetch || {}
 	const typeConfig = config.types?.[targetType || '']
@@ -71,10 +71,29 @@ export function fragmentHandlers<_Data extends GraphQLObject, _Input>({
 		}
 	}
 
+	// if there is a null value, the pagination handlers don't do anything
+	if (initialValue === null) {
+		return {
+			async loadNextPage(
+				houdiniContext: LoadContext,
+				pageCount?: number,
+				after?: string | number
+			): Promise<void> {},
+			async loadPreviousPage(
+				houdiniContext: LoadContext,
+				pageCount?: number,
+				before?: string
+			): Promise<void> {},
+			loading: readable(false),
+			pageInfo: readable(null),
+			refetch: () => {},
+		}
+	}
+
 	return paginationHandlers<_Data, _Input>({
 		config,
-		initialValue,
-		store,
+		initialValue: initialValue,
+		store: store as Readable<GraphQLObject>,
 		artifact: paginationArtifact,
 		queryVariables,
 		refetch: async () => {

--- a/src/runtime/lib/pagination.ts
+++ b/src/runtime/lib/pagination.ts
@@ -92,7 +92,7 @@ export function fragmentHandlers<_Data extends GraphQLObject, _Input>({
 
 	return paginationHandlers<_Data, _Input>({
 		config,
-		initialValue: initialValue,
+		initialValue,
 		store: store as Readable<GraphQLObject>,
 		artifact: paginationArtifact,
 		queryVariables,

--- a/src/runtime/lib/types.ts
+++ b/src/runtime/lib/types.ts
@@ -176,7 +176,7 @@ export type SubscriptionStore<_Shape, _Input> = Readable<_Shape> & {
 
 export type FragmentStore<_Shape> = {
 	get: (
-		value: any
+		value: any | null
 	) => Readable<_Shape> & {
 		update: (parent: _Shape) => void
 	}

--- a/src/runtime/stores/fragment.ts
+++ b/src/runtime/stores/fragment.ts
@@ -18,11 +18,11 @@ export function fragmentStore<_Data extends GraphQLObject, _Input = {}>({
 	paginationMethods: { [key: string]: keyof PaginatedHandlers<_Data, _Input> }
 }) {
 	return {
-		get(initialValue: _Data) {
+		get(initialValue: _Data | null) {
 			// at the moment a fragment store doesn't really do anything
 			// but we're going to keep it wrapped in a store so we can eventually
 			// optimize the updates
-			const fragmentStore = writable<_Data>(initialValue)
+			const fragmentStore = writable<_Data | null>(initialValue)
 
 			// build up the methods we want to use
 			let extraMethods: {} = {}


### PR DESCRIPTION
When mixing a fragment into a null value, it's annoying to have to check for null before passing to an inline fragment. This PR updates the inline fragment function to accept and return null values so you can just do `data?...` in the component 