### PR TITLE
only set inline query navigation block when using afterLoad

### DIFF
--- a/.changeset/forty-experts-occur.md
+++ b/.changeset/forty-experts-occur.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Only generate load with navigation block when user defines afterLoad

--- a/src/preprocess/transforms/query.test.ts
+++ b/src/preprocess/transforms/query.test.ts
@@ -33,7 +33,7 @@ describe('query preprocessor', function () {
 		    const _TestQuery = await _TestQueryStore.prefetch({
 		        "variables": _TestQuery_Input,
 		        "event": context,
-		        "blocking": true
+		        "blocking": false
 		    });
 
 		    return {
@@ -193,7 +193,7 @@ describe('query preprocessor', function () {
 		    const _TestQuery2Promise = _TestQuery2Store.prefetch({
 		        "variables": _TestQuery2_Input,
 		        "event": context,
-		        "blocking": true
+		        "blocking": false
 		    });
 
 		    const _TestQuery1_Input = {};
@@ -201,7 +201,7 @@ describe('query preprocessor', function () {
 		    const _TestQuery1Promise = _TestQuery1Store.prefetch({
 		        "variables": _TestQuery1_Input,
 		        "event": context,
-		        "blocking": true
+		        "blocking": false
 		    });
 
 		    const _TestQuery2 = await _TestQuery2Promise;
@@ -319,7 +319,7 @@ describe('query preprocessor', function () {
 		    const _TestQuery = await _TestQueryStore.prefetch({
 		        "variables": _TestQuery_Input,
 		        "event": context,
-		        "blocking": true
+		        "blocking": false
 		    });
 
 		    return {
@@ -394,7 +394,7 @@ describe('query preprocessor', function () {
 		    const _TestQuery = await _TestQueryStore.prefetch({
 		        "variables": _TestQuery_Input,
 		        "event": context,
-		        "blocking": true
+		        "blocking": false
 		    });
 
 		    return {
@@ -751,7 +751,7 @@ test('beforeLoad hook', async function () {
 		    const _TestQuery = await _TestQueryStore.prefetch({
 		        "variables": _TestQuery_Input,
 		        "event": context,
-		        "blocking": true
+		        "blocking": false
 		    });
 
 		    return {
@@ -836,7 +836,7 @@ test('beforeLoad hook - multiple queries', async function () {
 		    const _TestQuery2Promise = _TestQuery2Store.prefetch({
 		        "variables": _TestQuery2_Input,
 		        "event": context,
-		        "blocking": true
+		        "blocking": false
 		    });
 
 		    const _TestQuery1_Input = {};
@@ -844,7 +844,7 @@ test('beforeLoad hook - multiple queries', async function () {
 		    const _TestQuery1Promise = _TestQuery1Store.prefetch({
 		        "variables": _TestQuery1_Input,
 		        "event": context,
-		        "blocking": true
+		        "blocking": false
 		    });
 
 		    const _TestQuery2 = await _TestQuery2Promise;
@@ -1239,7 +1239,7 @@ test('deprecated onLoad hook', async function () {
 		    const _TestQuery = await _TestQueryStore.prefetch({
 		        "variables": _TestQuery_Input,
 		        "event": context,
-		        "blocking": true
+		        "blocking": false
 		    });
 
 		    return {

--- a/src/preprocess/transforms/query.ts
+++ b/src/preprocess/transforms/query.ts
@@ -382,7 +382,10 @@ function addKitLoad({
 						AST.identifier(variableIdentifier)
 					),
 					AST.objectProperty(AST.literal('event'), AST.identifier('context')),
-					AST.objectProperty(AST.literal('blocking'), AST.booleanLiteral(true)),
+					AST.objectProperty(
+						AST.literal('blocking'),
+						AST.booleanLiteral(!!afterLoadDefinition)
+					),
 				]),
 			]
 		)


### PR DESCRIPTION
This PR changes the load function generated by the preprocessor to only set `blocking: true` when the user defines the `afterLoad` hook 