### PR TITLE
Add config value to disable masking globally

### DIFF
--- a/.changeset/friendly-cameras-sort.md
+++ b/.changeset/friendly-cameras-sort.md
@@ -2,4 +2,4 @@
 'houdini': patch
 ---
 
-Add `disableMasking` config value to disable fragment masking when generating types
+Add `disableMasking` config value to disable fragment masking

--- a/.changeset/friendly-cameras-sort.md
+++ b/.changeset/friendly-cameras-sort.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Add `disableMasking` config value to disable fragment masking when generating types

--- a/src/cmd/generators/typescript/typescript.test.ts
+++ b/src/cmd/generators/typescript/typescript.test.ts
@@ -562,7 +562,7 @@ describe('typescript', function () {
 	`)
 	})
 
-	test('fragment spreads without masking', async function () {
+	test('fragment spreads no masking', async function () {
 		const withoutMasking = testConfig({ disableMasking: true })
 
 		// the document with the fragment
@@ -590,6 +590,7 @@ describe('typescript', function () {
 
 		export type Query$result = {
 		    readonly user: {
+		        readonly firstName: string,
 		        readonly $fragments: {
 		            Foo: true
 		        }

--- a/src/cmd/transforms/list.ts
+++ b/src/cmd/transforms/list.ts
@@ -379,7 +379,6 @@ export function connectionSelection(
 	const backwardsPagination =
 		fieldArgs['last'] === 'Int' && ['Cursor', 'String'].includes(fieldArgs['before'])
 	if (!forwardPagination && !backwardsPagination) {
-		console.log({ forwardPagination, backwardsPagination, fieldArgs })
 		return { selection, type, connection: false, error: missingPaginationArgMessage(config) }
 	}
 

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -33,6 +33,7 @@ export class Config {
 	typeConfig: ConfigFile['types']
 	configFile: ConfigFile
 	logLevel: LogLevel
+	disableMasking: boolean
 
 	constructor({ filepath, ...configFile }: ConfigFile & { filepath: string }) {
 		this.configFile = defaultConfigValues(configFile)
@@ -55,6 +56,7 @@ export class Config {
 			defaultKeys,
 			types = {},
 			logLevel,
+			disableMasking = false,
 		} = this.configFile
 
 		// make sure we got some kind of schema
@@ -94,6 +96,7 @@ export class Config {
 		this.defaultPartial = defaultPartial
 		this.definitionsFile = definitionsPath
 		this.logLevel = ((logLevel as LogLevel) || LogLevel.Summary).toLowerCase() as LogLevel
+		this.disableMasking = disableMasking
 
 		// if the user asked for `quiet` logging notify them its been deprecated
 		if (quiet) {

--- a/src/runtime/lib/config.ts
+++ b/src/runtime/lib/config.ts
@@ -30,6 +30,7 @@ export type ConfigFile = {
 	defaultKeys?: string[]
 	types?: TypeConfig
 	logLevel?: string
+	disableMasking?: boolean
 }
 
 export type TypeConfig = {


### PR DESCRIPTION
This PR sets the ground work for #349 and adds a `disableMasking` config value to configure the type generator to include fields from referenced fragments. This is especially important for users migrating to houdini from projects that did not enforce masking