### PR TITLE
Improve isRoute logic

### DIFF
--- a/.changeset/large-islands-exercise.md
+++ b/.changeset/large-islands-exercise.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+improved logic for distinguishing routes from components in a SvelteKit project

--- a/integration/houdini.config.js
+++ b/integration/houdini.config.js
@@ -6,6 +6,7 @@ const config = {
   module: 'esm',
   apiUrl: 'http://localhost:4000/graphql',
   defaultCachePolicy: 'CacheOrNetwork',
+  routes: (filepath) => filepath && !filepath.includes('_') && !filepath.includes('+'),
   scalars: {
     DateTime: {
       type: 'Date',

--- a/integration/src/lib/utils/routes.ts
+++ b/integration/src/lib/utils/routes.ts
@@ -25,6 +25,7 @@ export const routes = {
   Preprocess_query_component: '/preprocess/query/component',
   Preprocess_query_beforeLoad: '/preprocess/query/beforeLoad',
   Preprocess_query_afterLoad: '/preprocess/query/afterLoad',
+  Preprocess_query_isRoute: '/preprocess/query/isRoute',
 
   Preprocess_mutation_mutation: '/preprocess/mutation/mutation',
   Preprocess_fragment_update: '/preprocess/fragment/update',

--- a/integration/src/routes/preprocess/query/+QueryComponent.svelte
+++ b/integration/src/routes/preprocess/query/+QueryComponent.svelte
@@ -1,0 +1,24 @@
+<script context="module" lang="ts">
+  export function PlusComponentRouteQueryVariables({ props }: { props: { id?: string } }) {
+    return {
+      id: props.id || '3'
+    };
+  }
+</script>
+
+<script lang="ts">
+  import { query, graphql, type PlusComponentRouteQuery } from '$houdini';
+
+  // eslint-disable-next-line @typescript-eslint/no-inferrable-types
+  export let id: string = '';
+
+  const { data } = query<PlusComponentRouteQuery>(graphql`
+    query PlusComponentRouteQuery($id: ID!) {
+      user(id: $id, snapshot: "component-route") {
+        name
+      }
+    }
+  `);
+</script>
+
+{$data?.user.name}

--- a/integration/src/routes/preprocess/query/_QueryComponent.svelte
+++ b/integration/src/routes/preprocess/query/_QueryComponent.svelte
@@ -1,0 +1,24 @@
+<script context="module" lang="ts">
+  export function ComponentRouteQueryVariables({ props }: { props: { id?: string } }) {
+    return {
+      id: props.id || '3'
+    };
+  }
+</script>
+
+<script lang="ts">
+  import { query, graphql, type ComponentRouteQuery } from '$houdini';
+
+  // eslint-disable-next-line @typescript-eslint/no-inferrable-types
+  export let id: string = '';
+
+  const { data } = query<ComponentRouteQuery>(graphql`
+    query ComponentRouteQuery($id: ID!) {
+      user(id: $id, snapshot: "component-route") {
+        name
+      }
+    }
+  `);
+</script>
+
+{$data?.user.name}

--- a/integration/src/routes/preprocess/query/isRoute.spec.ts
+++ b/integration/src/routes/preprocess/query/isRoute.spec.ts
@@ -1,0 +1,15 @@
+import { test } from '@playwright/test';
+import { routes } from '../../../lib/utils/routes.js';
+import { expectNGraphQLResponse, expectToBe } from '../../../lib/utils/testsHelper.js';
+
+test.describe('query preprocessor', () => {
+  test('component queries', async ({ page }) => {
+    await page.goto(routes.Preprocess_query_isRoute);
+
+    // two different queries should have fired
+    await expectNGraphQLResponse(page, null, 2);
+
+    await expectToBe(page, 'Morgan Freeman', 'div[id=result-default]');
+    await expectToBe(page, 'Samuel Jackson', 'div[id=result-prop]');
+  });
+});

--- a/integration/src/routes/preprocess/query/isRoute.svelte
+++ b/integration/src/routes/preprocess/query/isRoute.svelte
@@ -1,5 +1,6 @@
 <script>
   import QueryComponent from './_QueryComponent.svelte';
+  import PlusQueryComponent from './+QueryComponent.svelte';
 </script>
 
 <div id="result-default">
@@ -7,5 +8,5 @@
 </div>
 
 <div id="result-prop">
-  <QueryComponent id="2" />
+  <PlusQueryComponent id="2" />
 </div>

--- a/integration/src/routes/preprocess/query/isRoute.svelte
+++ b/integration/src/routes/preprocess/query/isRoute.svelte
@@ -1,0 +1,11 @@
+<script>
+  import QueryComponent from './_QueryComponent.svelte';
+</script>
+
+<div id="result-default">
+  <QueryComponent />
+</div>
+
+<div id="result-prop">
+  <QueryComponent id="2" />
+</div>

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -157,8 +157,8 @@ For more information, visit this link: https://www.houdinigraphql.com/guides/mig
 				: path.join(this.projectRoot, '$houdini')
 
 		// if the config file specified an isRoute, use that
-		if (configFile.isRoute) {
-			this.configIsRoute = configFile.isRoute
+		if (configFile.routes) {
+			this.configIsRoute = configFile.routes
 		}
 	}
 
@@ -644,7 +644,7 @@ export async function getConfig(extraConfig?: Partial<ConfigFile>): Promise<Conf
 	if (config.framework === 'kit') {
 		// only load the route config if the user didn't specify one explicitly
 		await _config.loadKitConfig({
-			isRoute: !config.isRoute,
+			isRoute: !config.routes,
 			configFilePath: config.frameworkConfigFile,
 		})
 	}

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -171,13 +171,20 @@ For more information, visit this link: https://www.houdinigraphql.com/guides/mig
 			return false
 		}
 
+		// only consider filepaths in src/routes
+		if (
+			!posixify(filepath).startsWith(posixify(path.join(this.projectRoot, 'src', 'routes')))
+		) {
+			return false
+		}
+
 		// if there is a route function from the config
 		if (this.configIsRoute) {
 			return this.configIsRoute(filepath)
 		}
 
-		// no config value, use the old one (just check if there is something in src/routes)
-		return posixify(filepath).startsWith(posixify(path.join(this.projectRoot, 'src', 'routes')))
+		// there is no special filter to apply. anything this far is a route
+		return true
 	}
 
 	async loadKitConfig({
@@ -205,6 +212,7 @@ For more information, visit this link: https://www.houdinigraphql.com/guides/mig
 			}
 		} catch {}
 
+		// if its not in the route directory, its not a
 		// if we didn't assign an isRoute function, use the default kit one
 		if (!this.configIsRoute) {
 			// copied from here: https://github.com/sveltejs/kit/blob/28139749c4bf056d1e04f55e7f955da33770750d/packages/kit/src/core/config/options.js#L250

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -38,7 +38,11 @@ export class Config {
 	disableMasking: boolean
 	configIsRoute: ((filepath: string) => boolean) | null = null
 
-	constructor({ filepath, ...configFile }: ConfigFile & { filepath: string }) {
+	constructor({
+		filepath,
+		loadFrameworkConfig,
+		...configFile
+	}: ConfigFile & { filepath: string; loadFrameworkConfig?: boolean }) {
 		this.configFile = defaultConfigValues(configFile)
 
 		// apply defaults and pull out the values
@@ -151,16 +155,7 @@ For more information, visit this link: https://www.houdinigraphql.com/guides/mig
 
 		// if the config file specified an isRoute, use that
 		if (configFile.isRoute) {
-			this.isRoute = configFile.isRoute
-		}
-		// if we are loading a sveltekit project, we might be able to grab the isRoute
-		// from the config (if it exists)
-		if (this.framework === 'kit') {
-			// only load the route config if we didn't assign on
-			this.loadKitConfig({
-				isRoute: !configFile.isRoute,
-				configFilePath: configFile.frameworkConfigFile,
-			})
+			this.configIsRoute = configFile.isRoute
 		}
 	}
 
@@ -641,6 +636,17 @@ export async function getConfig(extraConfig?: Partial<ConfigFile>): Promise<Conf
 		...extraConfig,
 		filepath: configPath,
 	})
+
+	// if we are loading a sveltekit project, we might be able to grab the isRoute
+	// from the config (if it exists)
+	if (config.framework === 'kit') {
+		// only load the route config if we didn't assign on
+		await _config.loadKitConfig({
+			isRoute: !config.isRoute,
+			configFilePath: config.frameworkConfigFile,
+		})
+	}
+
 	return _config
 }
 

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -37,6 +37,7 @@ export class Config {
 	logLevel: LogLevel
 	disableMasking: boolean
 	configIsRoute: ((filepath: string) => boolean) | null = null
+	routesDir: string | null
 
 	constructor({
 		filepath,
@@ -64,6 +65,7 @@ export class Config {
 			types = {},
 			logLevel,
 			disableMasking = false,
+			routesDir = null,
 		} = this.configFile
 
 		// make sure we got some kind of schema
@@ -115,6 +117,7 @@ If that's going to be a problem, please open a discussion on GitHub.`
 		this.definitionsFolder = definitionsPath
 		this.logLevel = ((logLevel as LogLevel) || LogLevel.Summary).toLowerCase() as LogLevel
 		this.disableMasking = disableMasking
+		this.routesDir = routesDir
 
 		// if the user asked for `quiet` logging notify them its been deprecated
 		if (quiet) {
@@ -167,9 +170,8 @@ For more information, visit this link: https://www.houdinigraphql.com/guides/mig
 		}
 
 		// only consider filepaths in src/routes
-		if (
-			!posixify(filepath).startsWith(posixify(path.join(this.projectRoot, 'src', 'routes')))
-		) {
+		const routesDir = this.routesDir || 'src/routes'
+		if (!posixify(filepath).startsWith(posixify(path.join(this.projectRoot, routesDir)))) {
 			return false
 		}
 
@@ -640,7 +642,7 @@ export async function getConfig(extraConfig?: Partial<ConfigFile>): Promise<Conf
 	// if we are loading a sveltekit project, we might be able to grab the isRoute
 	// from the config (if it exists)
 	if (config.framework === 'kit') {
-		// only load the route config if we didn't assign on
+		// only load the route config if the user didn't specify one explicitly
 		await _config.loadKitConfig({
 			isRoute: !config.isRoute,
 			configFilePath: config.frameworkConfigFile,

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -157,7 +157,10 @@ For more information, visit this link: https://www.houdinigraphql.com/guides/mig
 		// from the config (if it exists)
 		if (this.framework === 'kit') {
 			// only load the route config if we didn't assign on
-			this.loadKitConfig({ isRoute: !configFile.isRoute })
+			this.loadKitConfig({
+				isRoute: !configFile.isRoute,
+				configFilePath: configFile.frameworkConfigFile,
+			})
 		}
 	}
 
@@ -177,7 +180,13 @@ For more information, visit this link: https://www.houdinigraphql.com/guides/mig
 		return posixify(filepath).startsWith(posixify(path.join(this.projectRoot, 'src', 'routes')))
 	}
 
-	async loadKitConfig({ isRoute }: { isRoute: boolean }) {
+	async loadKitConfig({
+		isRoute,
+		configFilePath,
+	}: {
+		isRoute: boolean
+		configFilePath?: string
+	}) {
 		// so far, all this does is load the route function so if we don't
 		// have to do that, we're done
 		if (!isRoute) {
@@ -185,7 +194,7 @@ For more information, visit this link: https://www.houdinigraphql.com/guides/mig
 		}
 
 		// import the user's kit config file, and look for a custom isRoute function
-		const configFile = path.join(process.cwd(), 'svelte.config.js')
+		const configFile = path.join(process.cwd(), configFilePath || 'svelte.config.js')
 		const config: KitConfig = await import(url.pathToFileURL(configFile).href)
 
 		// if there is a custom route function, use it

--- a/src/preprocess/transforms/query.ts
+++ b/src/preprocess/transforms/query.ts
@@ -28,8 +28,6 @@ type Identifier = ReturnType<typeof recast.types.builders.identifier>
 // what this means in practice is that if we see a getQuery(graphql``) in the instance script of a component, we need to hoist
 // it into the module's preload, grab the result and set it as the initial value in the store.
 
-const posixify = (str: string) => str.replace(/\\/g, '/')
-
 export default async function queryProcessor(
 	config: Config,
 	doc: TransformDocument
@@ -40,10 +38,7 @@ export default async function queryProcessor(
 	}
 
 	// how we preprocess a query depends on wether its a route/layout component
-	const isRoute =
-		config.framework !== 'svelte' &&
-		!config.static &&
-		posixify(doc.filename).startsWith(posixify(path.join(config.projectRoot, 'src', 'routes')))
+	const isRoute = config.isRoute(doc.filename)
 
 	// figure out the root type
 	const rootType = doc.config.schema.getQueryType()

--- a/src/runtime/lib/config.ts
+++ b/src/runtime/lib/config.ts
@@ -47,21 +47,26 @@ export type ConfigFile = {
 	types?: TypeConfig
 	logLevel?: string
 	disableMasking?: boolean
+
 	/**
-	 * A function to customize the logic houdini uses to identify a route vs a component
+	 * A function to customize the logic houdini uses to identify a route or component when the file
+	 * is _inside_ of the routesDir. You do not need to define this if you have a custom value in
+	 * your SvelteKit config file - Houdini will use what's there.
 	 */
-	isRoute?: (filepath: string) => boolean
+	routes?: (filepath: string) => boolean
+
+	/**
+	 * The directory containing your project routes. For default Kit and Sapper projects, this
+	 * value is ./src/routes
+	 */
+	routesDir?: string
+
 	/**
 	 * The path to your framework config file relative to the houdini config file. By
 	 * default, Houdini will look for your framework config file in process.cwd()
 	 * however that's not always valid. Use this option to customize where houdini looks.
 	 */
 	frameworkConfigFile?: string
-	/**
-	 * The directory containing your project routes. For default Kit and Sapper projects, this
-	 * value is ./src/routes
-	 */
-	routesDir?: string
 }
 
 export type TypeConfig = {

--- a/src/runtime/lib/config.ts
+++ b/src/runtime/lib/config.ts
@@ -47,6 +47,16 @@ export type ConfigFile = {
 	types?: TypeConfig
 	logLevel?: string
 	disableMasking?: boolean
+	/**
+	 * A function to customize the logic houdini uses to identify a route vs a component
+	 */
+	isRoute?: (filepath: string) => boolean
+	/**
+	 * The path to your framework config file relative to the houdini config file. By
+	 * default, Houdini will look for your framework config file in process.cwd()
+	 * however that's not always valid. Use this option to customize where houdini looks.
+	 */
+	frameworkConfigFile?: string
 }
 
 export type TypeConfig = {

--- a/src/runtime/lib/config.ts
+++ b/src/runtime/lib/config.ts
@@ -57,6 +57,11 @@ export type ConfigFile = {
 	 * however that's not always valid. Use this option to customize where houdini looks.
 	 */
 	frameworkConfigFile?: string
+	/**
+	 * The directory containing your project routes. For default Kit and Sapper projects, this
+	 * value is ./src/routes
+	 */
+	routesDir?: string
 }
 
 export type TypeConfig = {


### PR DESCRIPTION
This PR improves the logic for distinguishing a route from a component. Queries can now be inside of `_NonRouteComponent.svelte` and it will be treated as a component query instead of a route. 

fixes #281 