### PR TITLE
Allow users to specify path to config file for preprocessor

### DIFF
--- a/.changeset/lazy-kings-watch.md
+++ b/.changeset/lazy-kings-watch.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Add a `configFile` parameter to the preprocessor so users can specify where to find their `houdini.config.js` file

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -546,13 +546,16 @@ async function loadSchemaFile(schemaPath: string): Promise<graphql.GraphQLSchema
 }
 
 // get the project's current configuration
-export async function getConfig(extraConfig?: Partial<ConfigFile>): Promise<Config> {
+export async function getConfig({
+	configFile,
+	...extraConfig
+}: { configFile?: string } & Partial<ConfigFile>): Promise<Config> {
 	if (_config) {
 		return _config
 	}
 
 	// add the filepath and save the result
-	const configPath = DEFAULT_CONFIG_PATH
+	const configPath = configFile || DEFAULT_CONFIG_PATH
 	const config = await readConfigFile(configPath)
 
 	// look up the schema

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -549,7 +549,7 @@ async function loadSchemaFile(schemaPath: string): Promise<graphql.GraphQLSchema
 export async function getConfig({
 	configFile,
 	...extraConfig
-}: { configFile?: string } & Partial<ConfigFile>): Promise<Config> {
+}: { configFile?: string } & Partial<ConfigFile> = {}): Promise<Config> {
 	if (_config) {
 		return _config
 	}

--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -3,8 +3,16 @@ import { getConfig } from '../common'
 import { ConfigFile } from '../runtime'
 import applyTransforms from './transforms'
 
-// the main entry point for the preprocessor
-export default function houdiniPreprocessor(extraConfig?: Partial<ConfigFile>) {
+/**
+ * The houdini processor automates a lot of boilerplate to make inline documents
+ * work.
+ *
+ * It takes the same configuration values as the houdini config file as well as an
+ * optional `configFile` parameter to specify the path to use to find houdini.config.js
+ */
+export default function houdiniPreprocessor(
+	extraConfig: { configFile?: string } & Partial<ConfigFile>
+) {
 	return {
 		async markup({ content, filename }: { content: string; filename: string }) {
 			// grab the config


### PR DESCRIPTION
This PR adds a `configFile` parameter to the preprocessor so users can specify the location of their `houdini.config.js` file in order to accommodate monorepos and other unique situations. 

closes #302