### PR TITLE
Fix/paginate store

### DIFF
--- a/.graphqlrc.yaml
+++ b/.graphqlrc.yaml
@@ -3,7 +3,7 @@ projects:
         # 👇 For vscode-graphql and intellisense
         schema:
             - integration/api/*.graphql
-            - integration/$houdini/graphql/schema.gql
+            - integration/$houdini/graphql/schema.graphql
         documents:
             - integration/src/**/*.gql
             - integration/$houdini/graphql/documents.gql

--- a/integration/src/lib/utils/routes.ts
+++ b/integration/src/lib/utils/routes.ts
@@ -17,6 +17,8 @@ export const routes = {
   Stores_Fragment_Null: '/stores/fragment-null',
   Stores_Metadata: '/stores/metadata',
 
+  Stores_Pagination_query_forward_cursor: '/stores/pagination/query/forward-cursor',
+
   Preprocess_query_simple: '/preprocess/query/simple',
   Preprocess_query_variable_1: '/preprocess/query/variable-1',
   Preprocess_query_variable_2: '/preprocess/query/variable-2',

--- a/integration/src/routes/stores/pagination/query/StoreForwardCursorPaginationQuery.gql
+++ b/integration/src/routes/stores/pagination/query/StoreForwardCursorPaginationQuery.gql
@@ -1,0 +1,9 @@
+query StoreForwardCursorPaginationQuery {
+  usersConnection(first: 2, snapshot: "store-pagination-query-forwards-cursor") @paginate {
+    edges {
+      node {
+        name
+      }
+    }
+  }
+}

--- a/integration/src/routes/stores/pagination/query/forward-cursor.spec.ts
+++ b/integration/src/routes/stores/pagination/query/forward-cursor.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from '@playwright/test';
-import { routes } from '../../../lib/utils/routes.js';
+import { routes } from '../../../../lib/utils/routes.js';
 import {
   expectGraphQLResponse,
   expectNoGraphQLRequest,
   expectToBe,
   expectToContain
-} from '../../../lib/utils/testsHelper.js';
+} from '../../../../lib/utils/testsHelper.js';
 
 test.describe('forwards cursor paginatedQuery', () => {
   test('loadNextPage', async ({ page }) => {

--- a/integration/src/routes/stores/pagination/query/forward-cursor.svelte
+++ b/integration/src/routes/stores/pagination/query/forward-cursor.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { browser } from '$app/env';
+  import { CachePolicy, getHoudiniContext, GQL_StoreForwardCursorPaginationQuery } from '$houdini';
+
+  const context = getHoudiniContext();
+
+  $: browser && GQL_StoreForwardCursorPaginationQuery.fetch();
+
+  function loadNextPage() {
+    GQL_StoreForwardCursorPaginationQuery.loadNextPage(context);
+  }
+
+  function refetch() {
+    GQL_StoreForwardCursorPaginationQuery.fetch({ policy: CachePolicy.NetworkOnly });
+  }
+</script>
+
+<div id="result">
+  {$GQL_StoreForwardCursorPaginationQuery?.data?.usersConnection.edges
+    .map(({ node }) => node?.name)
+    .join(', ')}
+</div>
+
+<div id="pageInfo">
+  {JSON.stringify($GQL_StoreForwardCursorPaginationQuery?.data?.usersConnection.pageInfo)}
+</div>
+
+<button id="next" on:click={() => loadNextPage()}>next</button>
+
+<button id="refetch" on:click={() => refetch()}>refetch</button>

--- a/src/cmd/generators/definitions/schema.test.ts
+++ b/src/cmd/generators/definitions/schema.test.ts
@@ -35,6 +35,12 @@ test('adds internal documents to schema', async function () {
 		"""
 		directive @list(name: String!, connection: Boolean) on FIELD
 
+		"""
+		@paginate is used to enable infinite scrolling pagination.
+		More info in the [doc](https://www.houdinigraphql.com/guides/pagination).
+		"""
+		directive @paginate(name: String) on FIELD
+
 		"""@prepend is used to tell the runtime to add the result to the end of the list"""
 		directive @prepend(parentID: ID) on FRAGMENT_SPREAD
 
@@ -88,6 +94,12 @@ test('list operations are included', async function () {
 		entities in mutations
 		"""
 		directive @list(name: String!, connection: Boolean) on FIELD
+
+		"""
+		@paginate is used to enable infinite scrolling pagination.
+		More info in the [doc](https://www.houdinigraphql.com/guides/pagination).
+		"""
+		directive @paginate(name: String) on FIELD
 
 		"""@prepend is used to tell the runtime to add the result to the end of the list"""
 		directive @prepend(parentID: ID) on FRAGMENT_SPREAD
@@ -161,6 +173,12 @@ test("writing twice doesn't duplicate definitions", async function () {
 		entities in mutations
 		"""
 		directive @list(name: String!, connection: Boolean) on FIELD
+
+		"""
+		@paginate is used to enable infinite scrolling pagination.
+		More info in the [doc](https://www.houdinigraphql.com/guides/pagination).
+		"""
+		directive @paginate(name: String) on FIELD
 
 		"""@prepend is used to tell the runtime to add the result to the end of the list"""
 		directive @prepend(parentID: ID) on FRAGMENT_SPREAD

--- a/src/cmd/generators/stores/pagination.ts
+++ b/src/cmd/generators/stores/pagination.ts
@@ -24,13 +24,13 @@ export default function pagination(config: Config, doc: CollectedGraphQLDocument
 	}
 	// cursor pagination
 	else if (paginationMethod === 'cursor') {
-		typeImports = `import type { PageInfo } from '../runtime/lib/utils'
-import type { Readable } from 'svelte/store'
-`
+		typeImports = `import type { Readable } from 'svelte/store'
+import { type HoudiniFetchContext } from '../runtime/lib/types'
+import type { PageInfo } from '../runtime/lib/utils'`
 		// forwards cursor pagination
 		if (doc.refetch?.direction === 'forward') {
 			types = `{
-    loadNextPage: (pageCount?: number, after?: string | number) => Promise<void>
+    loadNextPage: (context: HoudiniFetchContext, pageCount?: number, after?: string | number) => Promise<void>
     pageInfo: Readable<PageInfo>
 }`
 			methods = {
@@ -43,7 +43,7 @@ import type { Readable } from 'svelte/store'
 			// backwards cursor pagination
 		} else {
 			types = `{
-    loadPreviousPage: (pageCount?: number, before?: string) => Promise<void>
+    loadPreviousPage: (context: HoudiniFetchContext, pageCount?: number, before?: string) => Promise<void>
     pageInfo: Readable<PageInfo>
 }`
 			methods = {

--- a/src/cmd/generators/stores/query.ts
+++ b/src/cmd/generators/stores/query.ts
@@ -47,7 +47,7 @@ export default ${storeName}
 
 	// type definitions
 	const typeDefs = `import type { ${artifactName}$input, ${artifactName}$result, CachePolicy } from '$houdini'
-import { QueryStore } from '../runtime/lib/types'
+import { type QueryStore } from '../runtime/lib/types'
 ${paginationExtras.typeImports}
 
 export declare const ${storeName}: QueryStore<${artifactName}$result | undefined, ${VariableInputsType}> ${

--- a/src/cmd/transforms/schema.ts
+++ b/src/cmd/transforms/schema.ts
@@ -27,6 +27,12 @@ enum CachePolicy {
 directive @${config.listDirective}(${config.listNameArg}: String!, connection: Boolean) on FIELD
 
 """
+	@${config.paginateDirective} is used to enable infinite scrolling pagination.
+	More info in the [doc](https://www.houdinigraphql.com/guides/pagination).
+"""
+directive @${config.paginateDirective}(${config.paginateNameArg}: String) on FIELD
+
+"""
 	@${config.listPrependDirective} is used to tell the runtime to add the result to the end of the list
 """
 directive @${config.listPrependDirective}(

--- a/src/cmd/validators/uniqueNames.ts
+++ b/src/cmd/validators/uniqueNames.ts
@@ -20,13 +20,13 @@ export default async function uniqueDocumentNames(
 	const errors: HoudiniInfoError[] = Object.entries(nameMap)
 		.filter(([_, filenames]) => filenames.length > 1)
 		.map(([docName, fileNames]) => ({
-			message: 'Encountered conflict in document names',
+			message: `Operation "${docName}" conflict. It should not be defined in multiple places!`,
 			description: fileNames,
 		}))
 
 	// if we got errors
 	if (errors.length > 0) {
-		throw errors
+		throw { filepath: errors[0].description?.join(' | '), message: errors[0].message }
 	}
 
 	// we're done here

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -361,6 +361,10 @@ For more information, visit this link: https://www.houdinigraphql.com/guides/mig
 		return 'paginate'
 	}
 
+	get paginateNameArg() {
+		return 'name'
+	}
+
 	get cacheDirective() {
 		return 'cache'
 	}

--- a/src/runtime/lib/pagination.ts
+++ b/src/runtime/lib/pagination.ts
@@ -1,7 +1,7 @@
 // externals
 import { derived, get, readable, Readable, Writable, writable } from 'svelte/store'
 // locals
-import { FragmentStore, QueryResult, QueryStore, QueryStoreFetchParams, deepEquals } from '..'
+import { deepEquals, FragmentStore, QueryResult, QueryStore, QueryStoreFetchParams } from '..'
 import cache from '../cache'
 import { ConfigFile, keyFieldsForType } from './config'
 import { getHoudiniContext } from './context'


### PR DESCRIPTION
Link to https://github.com/HoudiniGraphql/houdini/issues/373

- [x] Adding `@paginate` directive to `src/$houdini/graphql/schema.graphql`
So that you will get intellisense if you have 👇
```yaml
# file .graphqlrc.yaml

projects:
  # You can add multiple projects and generate with -p args
  default:
    # 👇 For vscode-graphql and intellisense
    schema:
      - ./src/lib/graphql/schema.json
      # - ./src/**/*.graphql
      - ./$houdini/graphql/schema.graphql
    documents:
      - ./src/**/*.gql
      - ./$houdini/graphql/documents.gql
```

- [x] add type to enforce to set the `context` in `loadNextPage` function
```svelte
<script>
    import { getHoudiniContext, GQL_MyStore } from '$houdini'

    const context = getHoudiniContext()
 </script>
 
 <button on:click={() => GQL_MyStore.loadNextPage(context)}>
     load next
 </button>
```

- [x] add tests for store pagination
- [ ] adding `pageInfo` in the `STORE$data` type