### PR TITLE
✨ Improve onborading

### DIFF
--- a/src/cmd/init.ts
+++ b/src/cmd/init.ts
@@ -148,6 +148,17 @@ export default async (_path: string | undefined, args: { pullHeader?: string[] }
 	// generate an empty runtime
 	console.log('✨ Creating necessary files...')
 
+	// make sure we don't log anything else
+	const config = await getConfig({
+		logLevel: LogLevel.Quiet,
+	})
+	await generate(config)
+
+	// we're done!
+	console.log('🎩 Welcome to Houdini!')
+
+	console.log('')
+
 	if (!answers.allowWritingEverywhere) {
 		console.log('🪄  To compelte the setup, you need to:')
 		console.log('  - update "svelte.config.js"')
@@ -158,17 +169,10 @@ export default async (_path: string | undefined, args: { pullHeader?: string[] }
 		console.log(
 			'  More infos on https://www.houdinigraphql.com/guides/setting-up-your-project"'
 		)
+	} else {
+		console.log('👉  Write your GraphQL operations...')
+		console.log('👉  Run: "houdini generate" to start using them.')
 	}
-
-	// make sure we don't log anything else
-	const config = await getConfig({
-		logLevel: LogLevel.Quiet,
-	})
-	await generate(config)
-
-	// we're done!
-	console.log('🎩 Welcome to Houdini!')
-	console.log('👉  run: "houdini generate"')
 }
 
 const houdiniClientFile = (url: string, isTypeScript: boolean) => {

--- a/src/cmd/init.ts
+++ b/src/cmd/init.ts
@@ -1,35 +1,55 @@
-import path from 'path'
-import inquirer from 'inquirer'
 import fs from 'fs/promises'
+import inquirer from 'inquirer'
+import path from 'path'
 import { Config, getConfig, LogLevel } from '../common'
-import { writeSchema } from './utils/writeSchema'
 import generate from './generate'
+import { writeSchema } from './utils/writeSchema'
 
 // the init command is responsible for scaffolding a few files
 // as well as pulling down the initial schema representation
 export default async (_path: string | undefined, args: { pullHeader?: string[] }) => {
 	// we need to collect some information from the user before we
 	// can continue
-	let answers = await inquirer.prompt([
+	let answers = (await inquirer.prompt([
 		{
-			name: 'url',
-			type: 'input',
-			message: 'Please enter the URL for your api, including its protocol.',
+			message:
+				'Did you git commit everything before running init? (so that you can see all changes easily)',
+			name: 'isTypeScript',
+			type: 'confirm',
 		},
 		{
+			message: 'What framework are you using?',
 			name: 'framework',
 			type: 'list',
-			message: 'Are you using Sapper or SvelteKit?',
 			choices: [
-				{ value: 'svelte', name: 'No' },
-				{ value: 'sapper', name: 'Sapper' },
 				{ value: 'kit', name: 'SvelteKit' },
+				{ value: 'svelte', name: 'Svelte' },
+				{ value: 'sapper', name: 'Sapper (deprecated)' },
 			],
 		},
 		{
+			message: 'Will SvelteKit be your GraphQL endpoint as well?',
+			name: 'isGraphQLEndpoint',
+			type: 'confirm',
+			when: ({ framework }) => framework === 'kit',
+		},
+		{
+			message: 'Please enter the GraphQL endpoint URL (including its protocol):',
+			name: 'url',
+			type: 'input',
+			when: ({ framework }) => framework !== 'kit',
+		},
+		{
+			message: 'Please enter the GraphQL endpoint URL (including its protocol):',
+			name: 'urlKit',
+			type: 'input',
+			default: 'http://localhost/api/graphql',
+			when: ({ framework, isGraphQLEndpoint }) => framework === 'kit' && isGraphQLEndpoint,
+		},
+		{
+			message: 'What kind of modules do you want to be generated?',
 			name: 'module',
 			type: 'list',
-			message: 'What kind of modules do you want to be generated?',
 			when: ({ framework }) => framework === 'svelte',
 			choices: [
 				{ value: 'commonjs', name: 'CommonJS' },
@@ -37,26 +57,38 @@ export default async (_path: string | undefined, args: { pullHeader?: string[] }
 			],
 		},
 		{
-			name: 'schemaPath',
-			type: 'input',
-			default: './schema.graphql',
-			validate: (input: string) => {
-				const validExtensions = ['json', 'gql', 'graphql']
-
-				const extension = input.split('.').pop()
-				if (!extension) {
-					return 'Please provide a valid schema path.'
-				}
-				if (!validExtensions.includes(extension)) {
-					return 'The provided schema path should be of type ' + validExtensions.join('|')
-				}
-
-				return true
-			},
-			message:
-				'Where should the schema be written to? Valid file extensions are .json, .gql, or .graphql',
+			message: 'Just to be sure, you want the magic in TypeScript?',
+			name: 'isTypeScript',
+			type: 'confirm',
 		},
-	])
+		// {
+		// 	message:
+		// 		'Where should the schema be written to? Valid file extensions are .json, .gql, or .graphql',
+		// 	name: 'schemaPath',
+		// 	type: 'input',
+		// 	default: './schema.graphql',
+		// 	validate: (input: string) => {
+		// 		const validExtensions = ['json', 'gql', 'graphql']
+
+		// 		const extension = input.split('.').pop()
+		// 		if (!extension) {
+		// 			return 'Please provide a valid schema path.'
+		// 		}
+		// 		if (!validExtensions.includes(extension)) {
+		// 			return 'The provided schema path should be of type ' + validExtensions.join('|')
+		// 		}
+
+		// 		return true
+		// 	},
+		// },
+	])) as {
+		framework: 'kit' | 'svelte' | 'sapper'
+		isGraphQLEndpoint: boolean
+		url: string
+		module: 'commonjs' | 'esm'
+		isTypeScript: boolean
+		// schemaPath: string
+	}
 
 	// if the user didn't choose a module type, figure it out from the framework choice
 	let module: Config['module'] = answers.module
@@ -65,8 +97,6 @@ export default async (_path: string | undefined, args: { pullHeader?: string[] }
 	} else if (answers.framework === 'sapper') {
 		module = 'commonjs'
 	}
-	// dry up the framework choice
-	const { framework } = answers
 
 	// if no path was given, we'll use cwd
 	const targetPath = _path ? path.resolve(_path) : process.cwd()
@@ -76,29 +106,37 @@ export default async (_path: string | undefined, args: { pullHeader?: string[] }
 	// the config file path
 	const configPath = path.join(targetPath, 'houdini.config.js')
 	// where we put the houdiniClient
-	const houdiniClientPath = path.join(sourceDir, 'houdiniClient.js')
+	const houdiniClientPath = path.join(
+		sourceDir,
+		answers.isTypeScript ? 'houdiniClient.ts' : 'houdiniClient.js'
+	)
+
+	const kitGraphQLEndpoint = answers.framework === 'kit' && answers.isGraphQLEndpoint
+	const schemaPath = kitGraphQLEndpoint ? 'src/**/*.graphql' : './schema.graphql'
 
 	await Promise.all([
 		// Get the schema from the url and write it to file
-		writeSchema(answers.url, path.join(targetPath, answers.schemaPath), args?.pullHeader),
+		!kitGraphQLEndpoint &&
+			writeSchema(answers.url, path.join(targetPath, schemaPath), args?.pullHeader),
 
 		// write the config file
 		fs.writeFile(
 			configPath,
 			configFile({
-				schemaPath: answers.schemaPath,
-				framework,
+				schemaPath,
+				framework: answers.framework,
 				module,
 				url: answers.url,
+				kitGraphQLEndpoint,
 			})
 		),
 
 		// write the houdiniClient file
-		fs.writeFile(houdiniClientPath, networkFile(answers.url)),
+		fs.writeFile(houdiniClientPath, houdiniClientFile(answers.url, answers.isTypeScript)),
 	])
 
 	// generate an empty runtime
-	console.log('Creating necessary files...')
+	console.log('✨ Creating necessary files...')
 
 	// make sure we don't log anything else
 	const config = await getConfig({
@@ -107,12 +145,43 @@ export default async (_path: string | undefined, args: { pullHeader?: string[] }
 	await generate(config)
 
 	// we're done!
-	console.log('Welcome to Houdini!')
+	console.log('🎩 Welcome to Houdini!')
 }
 
-const networkFile = (url: string) => `import { HoudiniClient } from '$houdini/runtime'
+const houdiniClientFile = (url: string, isTypeScript: boolean) => {
+	if (isTypeScript) {
+		return `import type { RequestHandlerArgs } from '$houdini';
+import { HoudiniClient } from '$houdini';
 
-async function fetchQuery({ fetch, session, text = '', variables = {} }) {
+async function fetchQuery({
+	fetch,
+	text = '',
+	variables = {},
+	session,
+	metadata
+}: RequestHandlerArgs) {
+	const url = import.meta.env.VITE_GRAPHQL_ENDPOINT || '${url}';
+
+	const result = await fetch(url, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify({
+			query: text,
+			variables
+		})
+	});
+
+	return await result.json();
+}
+
+export const houdiniClient = new HoudiniClient(fetchQuery);
+`
+	}
+	return `import { HoudiniClient } from '$houdini'
+
+async function fetchQuery({ fetch, session, text = '', variables = {}, session, metadata }) {
 	const result = await fetch('${url}', {
 		method: 'POST',
 		headers: {
@@ -126,40 +195,50 @@ async function fetchQuery({ fetch, session, text = '', variables = {} }) {
 	return await result.json()
 }
 
-export default new HoudiniClient(fetchQuery)
+export default new HoudiniClient(fetchQuery)}
 `
+}
 
 const configFile = ({
 	schemaPath,
 	framework,
 	module,
 	url,
+	kitGraphQLEndpoint,
 }: {
 	schemaPath: string
 	framework: string
 	module: string
 	url: string
+	kitGraphQLEndpoint: boolean
 }) => {
 	// the actual config contents
-	const configObj = `{
-	schemaPath: '${schemaPath}',
-	sourceGlob: 'src/**/*.{svelte,gql,graphql}',
-	module: '${module}',
-	framework: '${framework}',
-	apiUrl: '${url}'
-}`
+	const configObj: string[] = []
 
-	return module === 'esm'
-		? // SvelteKit default config
-		  `/** @type {import('houdini').ConfigFile} */
-const config = ${configObj}
+	configObj.push(`/** @type {import('houdini').ConfigFile} */`)
+	configObj.push(`const config = {`)
+	configObj.push(`		schemaPath: '${schemaPath}',`)
+	configObj.push(`		sourceGlob: 'src/**/*.{svelte,gql}',`)
 
-export default config
-`
-		: // sapper default config
-		  `/** @type {import('houdini').ConfigFile} */
-const config = ${configObj}
+	if (module !== 'esm') {
+		configObj.push(`		module: '${module}',`)
+	}
+	if (framework !== 'kit') {
+		configObj.push(`		framework: '${framework}',`)
+	}
+	if (!kitGraphQLEndpoint) {
+		configObj.push(`		apiUrl: '${url}',`)
+	}
 
-module.exports = config
-`
+	configObj.push(`}`)
+	configObj.push(``)
+
+	// SvelteKit default config
+	if (module === 'esm') {
+		configObj.push(`export default config`)
+	} else {
+		configObj.push(`module.exports = config`)
+	}
+
+	return configObj.join('\n')
 }

--- a/src/cmd/utils/writeFile.ts
+++ b/src/cmd/utils/writeFile.ts
@@ -13,3 +13,9 @@ export async function writeFile(path: string, data: string) {
 
 	await fs.writeFile(path, data, 'utf8')
 }
+
+export async function createFolderIfNotExists(folder: string) {
+	if (!(await fs.readdir(folder))) {
+		await fs.mkdir(folder)
+	}
+}

--- a/src/cmd/utils/writeFile.ts
+++ b/src/cmd/utils/writeFile.ts
@@ -1,4 +1,5 @@
 import fs from 'fs/promises'
+import { existsSync } from 'fs'
 
 export async function writeFile(path: string, data: string) {
 	try {
@@ -15,7 +16,7 @@ export async function writeFile(path: string, data: string) {
 }
 
 export async function createFolderIfNotExists(folder: string) {
-	if (!(await fs.readdir(folder))) {
+	if (!existsSync(folder)) {
 		await fs.mkdir(folder)
 	}
 }


### PR DESCRIPTION
The goal is to improve the onboarding experience.

1/ Adding a TypeScript option
2/ Adding the option to write everything or to log what is needed to finish (Aggressive / Less aggressive)
3/ Option for KitQL user to have graphql endpoint in kit
4/ default esm => do not write
5/ default kit => do not write
6/ info about Sapper (deprecated)
7/ remove the schemaPath option. (If they want to change, they will do after?)

What do you think? :)