### PR TITLE
Fix incorrect pageInfo type

### DIFF
--- a/.changeset/cool-games-refuse.md
+++ b/.changeset/cool-games-refuse.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+fix bug with incorrect page info type

--- a/integration/src/routes/stores/pagination/query/forward-cursor.spec.ts
+++ b/integration/src/routes/stores/pagination/query/forward-cursor.spec.ts
@@ -62,6 +62,10 @@ test.describe('forwards cursor paginatedQuery', () => {
       // check the page info to know if we will click on next?
       await expectToContain(page, `"hasNextPage":true`);
 
+      // make sure that page info is an object
+      const pageInfo = (await page.textContent('div[id=pageInfo]')) || 'null';
+      expect(Array.isArray(JSON.parse(pageInfo))).toBeFalsy();
+
       // wait for the request to resolve
       await expectGraphQLResponse(page, 'button[id=next]');
 

--- a/src/runtime/stores/query.ts
+++ b/src/runtime/stores/query.ts
@@ -260,7 +260,7 @@ export function queryStore<_Data extends GraphQLObject, _Input>({
 		})
 
 		// we only want to add page info if we have to
-		relevantStores.push(derived([handlers.pageInfo], (pageInfo) => ({ pageInfo })))
+		relevantStores.push(derived([handlers.pageInfo], ([pageInfo]) => ({ pageInfo })))
 
 		extraMethods = Object.fromEntries(
 			Object.entries(paginationMethods).map(([key, value]) => [key, handlers[value]])


### PR DESCRIPTION
This PR fixes a bug that caused the pageInfo field to be an array instead of an object