### PR TITLE
Preprocess direct imports

### DIFF
--- a/.changeset/rich-seahorses-change.md
+++ b/.changeset/rich-seahorses-change.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+improved preprocessor performance

--- a/src/preprocess/index.ts
+++ b/src/preprocess/index.ts
@@ -19,9 +19,7 @@ export default function houdiniPreprocessor(
 			const config = await getConfig(extraConfig)
 
 			// apply the transform pipeline
-			const result = await applyTransforms(config, { content, filename })
-
-			return result
+			return await applyTransforms(config, { content, filename })
 		},
 	}
 }

--- a/src/preprocess/transforms/fragment.test.ts
+++ b/src/preprocess/transforms/fragment.test.ts
@@ -20,7 +20,7 @@ describe('fragment preprocessor', function () {
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import _TestFragmentArtifact from "$houdini/artifacts/TestFragment";
 		import _TestFragmentStore from "$houdini/stores/TestFragment";
-		import { HoudiniDocumentProxy } from "$houdini/runtime";
+		import { HoudiniDocumentProxy } from "$houdini/runtime/lib/proxy";
 		let TestFragmentProxy = new HoudiniDocumentProxy();
 		let reference;
 
@@ -58,7 +58,7 @@ describe('fragment preprocessor', function () {
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import _TestFragmentArtifact from "$houdini/artifacts/TestFragment";
 		import _TestFragmentStore from "$houdini/stores/TestFragment";
-		import { HoudiniDocumentProxy } from "$houdini/runtime";
+		import { HoudiniDocumentProxy } from "$houdini/runtime/lib/proxy";
 		let TestFragmentProxy = new HoudiniDocumentProxy();
 		let reference;
 

--- a/src/preprocess/transforms/fragment.ts
+++ b/src/preprocess/transforms/fragment.ts
@@ -42,7 +42,7 @@ export default async function fragmentProcessor(
 				config,
 				body: doc.instance!.content.body,
 				import: ['HoudiniDocumentProxy'],
-				sourceModule: '$houdini/runtime',
+				sourceModule: '$houdini/runtime/lib/proxy',
 			})
 
 			// instantiate a proxy we can use to update this fragment

--- a/src/preprocess/transforms/query.test.ts
+++ b/src/preprocess/transforms/query.test.ts
@@ -20,8 +20,8 @@ describe('query preprocessor', function () {
 
 		// make sure we added the right stuff
 		expect(doc.module?.content).toMatchInlineSnapshot(`
-		import { convertKitPayload } from "$houdini/runtime";
-		import { RequestContext } from "$houdini/runtime";
+		import { convertKitPayload } from "$houdini/runtime/lib/network";
+		import { RequestContext } from "$houdini/runtime/lib/network";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
 		import { TestQueryStore } from "$houdini/stores/TestQuery";
 		const store_TestQueryStore = TestQueryStore();
@@ -52,7 +52,8 @@ describe('query preprocessor', function () {
 		}
 	`)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
-		import { getHoudiniContext, isBrowser } from "$houdini/runtime";
+		import { isBrowser } from "$houdini/runtime/adapter";
+		import { getHoudiniContext } from "$houdini/runtime/lib/context";
 		const _houdini_context_generated_DONT_USE = getHoudiniContext();
 
 		const {
@@ -103,7 +104,7 @@ describe('query preprocessor', function () {
 
 		// make sure we added the right stuff
 		expect(doc.module?.content).toMatchInlineSnapshot(`
-		import { RequestContext } from "$houdini/runtime";
+		import { RequestContext } from "$houdini/runtime/lib/network";
 		import _TestQuery2Artifact from "$houdini/artifacts/TestQuery2";
 		import { TestQuery2Store } from "$houdini/stores/TestQuery2";
 		import _TestQuery1Artifact from "$houdini/artifacts/TestQuery1";
@@ -112,7 +113,8 @@ describe('query preprocessor', function () {
 		export async function load() {}
 	`)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
-		import { getHoudiniContext, isBrowser } from "$houdini/runtime";
+		import { isBrowser } from "$houdini/runtime/adapter";
+		import { getHoudiniContext } from "$houdini/runtime/lib/context";
 		const _houdini_context_generated_DONT_USE = getHoudiniContext();
 
 		const {
@@ -175,8 +177,8 @@ describe('query preprocessor', function () {
 
 		// make sure we added the right stuff
 		expect(doc.module?.content).toMatchInlineSnapshot(`
-		import { convertKitPayload } from "$houdini/runtime";
-		import { RequestContext } from "$houdini/runtime";
+		import { convertKitPayload } from "$houdini/runtime/lib/network";
+		import { RequestContext } from "$houdini/runtime/lib/network";
 		import _TestQuery2Artifact from "$houdini/artifacts/TestQuery2";
 		import { TestQuery2Store } from "$houdini/stores/TestQuery2";
 		import _TestQuery1Artifact from "$houdini/artifacts/TestQuery1";
@@ -222,7 +224,8 @@ describe('query preprocessor', function () {
 		}
 	`)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
-		import { getHoudiniContext, isBrowser } from "$houdini/runtime";
+		import { isBrowser } from "$houdini/runtime/adapter";
+		import { getHoudiniContext } from "$houdini/runtime/lib/context";
 		const _houdini_context_generated_DONT_USE = getHoudiniContext();
 
 		const {
@@ -286,8 +289,8 @@ describe('query preprocessor', function () {
 
 		// make sure we added the right stuff
 		expect(doc.module?.content).toMatchInlineSnapshot(`
-		import { convertKitPayload } from "$houdini/runtime";
-		import { RequestContext } from "$houdini/runtime";
+		import { convertKitPayload } from "$houdini/runtime/lib/network";
+		import { RequestContext } from "$houdini/runtime/lib/network";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
 		import { TestQueryStore } from "$houdini/stores/TestQuery";
 		import { houdiniConfig } from "$houdini";
@@ -334,7 +337,8 @@ describe('query preprocessor', function () {
 		}
 	`)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
-		import { getHoudiniContext, isBrowser } from "$houdini/runtime";
+		import { isBrowser } from "$houdini/runtime/adapter";
+		import { getHoudiniContext } from "$houdini/runtime/lib/context";
 		const _houdini_context_generated_DONT_USE = getHoudiniContext();
 
 		const {
@@ -378,7 +382,7 @@ describe('query preprocessor', function () {
 
 		// make sure we added the right stuff
 		expect(doc.module?.content).toMatchInlineSnapshot(`
-		import { RequestContext } from "$houdini/runtime";
+		import { RequestContext } from "$houdini/runtime/lib/network";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
 		import { TestQueryStore } from "$houdini/stores/TestQuery";
 		const store_TestQueryStore = TestQueryStore();
@@ -405,7 +409,8 @@ describe('query preprocessor', function () {
 		}
 	`)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
-		import { getHoudiniContext, isBrowser } from "$houdini/runtime";
+		import { isBrowser } from "$houdini/runtime/adapter";
+		import { getHoudiniContext } from "$houdini/runtime/lib/context";
 		const _houdini_context_generated_DONT_USE = getHoudiniContext();
 
 		const {
@@ -454,7 +459,8 @@ describe('query preprocessor', function () {
 			`import { houdiniConfig } from "$houdini";`
 		)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
-		import { getHoudiniContext, isBrowser } from "$houdini/runtime";
+		import { isBrowser } from "$houdini/runtime/adapter";
+		import { getHoudiniContext } from "$houdini/runtime/lib/context";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
 		import { TestQueryStore } from "$houdini/stores/TestQuery";
 		const store_TestQueryStore = TestQueryStore();
@@ -503,7 +509,8 @@ describe('query preprocessor', function () {
 			`import { houdiniConfig } from "$houdini";`
 		)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
-		import { getHoudiniContext, isBrowser } from "$houdini/runtime";
+		import { isBrowser } from "$houdini/runtime/adapter";
+		import { getHoudiniContext } from "$houdini/runtime/lib/context";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
 		import { TestQueryStore } from "$houdini/stores/TestQuery";
 		const store_TestQueryStore = TestQueryStore();
@@ -571,7 +578,8 @@ describe('query preprocessor', function () {
 	`)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
 		import { marshalInputs } from "$houdini/runtime/lib/scalars";
-		import { getHoudiniContext, isBrowser } from "$houdini/runtime";
+		import { isBrowser } from "$houdini/runtime/adapter";
+		import { getHoudiniContext } from "$houdini/runtime/lib/context";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
 		import { TestQueryStore } from "$houdini/stores/TestQuery";
 		const store_TestQueryStore = TestQueryStore();
@@ -638,7 +646,8 @@ describe('query preprocessor', function () {
 		`
 		)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
-		import { getHoudiniContext, isBrowser } from "$houdini/runtime";
+		import { isBrowser } from "$houdini/runtime/adapter";
+		import { getHoudiniContext } from "$houdini/runtime/lib/context";
 		const _houdini_context_generated_DONT_USE = getHoudiniContext();
 
 		const {
@@ -684,7 +693,8 @@ describe('query preprocessor', function () {
 			`import { houdiniConfig } from "$houdini";`
 		)
 		expect(doc.instance?.content).toMatchInlineSnapshot(`
-		import { getHoudiniContext, isBrowser } from "$houdini/runtime";
+		import { isBrowser } from "$houdini/runtime/adapter";
+		import { getHoudiniContext } from "$houdini/runtime/lib/context";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
 		import { TestQueryStore } from "$houdini/stores/TestQuery";
 		const store_TestQueryStore = TestQueryStore();
@@ -741,8 +751,8 @@ test('beforeLoad hook', async function () {
 	)
 
 	expect(doc.module?.content).toMatchInlineSnapshot(`
-		import { convertKitPayload } from "$houdini/runtime";
-		import { RequestContext } from "$houdini/runtime";
+		import { convertKitPayload } from "$houdini/runtime/lib/network";
+		import { RequestContext } from "$houdini/runtime/lib/network";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
 		import { TestQueryStore } from "$houdini/stores/TestQuery";
 		import { houdiniConfig } from "$houdini";
@@ -834,8 +844,8 @@ test('beforeLoad hook - multiple queries', async function () {
 	)
 
 	expect(doc.module?.content).toMatchInlineSnapshot(`
-		import { convertKitPayload } from "$houdini/runtime";
-		import { RequestContext } from "$houdini/runtime";
+		import { convertKitPayload } from "$houdini/runtime/lib/network";
+		import { RequestContext } from "$houdini/runtime/lib/network";
 		import _TestQuery2Artifact from "$houdini/artifacts/TestQuery2";
 		import { TestQuery2Store } from "$houdini/stores/TestQuery2";
 		import _TestQuery1Artifact from "$houdini/artifacts/TestQuery1";
@@ -926,8 +936,8 @@ test('afterLoad hook', async function () {
 	)
 
 	expect(doc.module?.content).toMatchInlineSnapshot(`
-		import { convertKitPayload } from "$houdini/runtime";
-		import { RequestContext } from "$houdini/runtime";
+		import { convertKitPayload } from "$houdini/runtime/lib/network";
+		import { RequestContext } from "$houdini/runtime/lib/network";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
 		import { TestQueryStore } from "$houdini/stores/TestQuery";
 		import { houdiniConfig } from "$houdini";
@@ -1027,8 +1037,8 @@ test('afterLoad hook - multiple queries', async function () {
 	)
 
 	expect(doc.module?.content).toMatchInlineSnapshot(`
-		import { convertKitPayload } from "$houdini/runtime";
-		import { RequestContext } from "$houdini/runtime";
+		import { convertKitPayload } from "$houdini/runtime/lib/network";
+		import { RequestContext } from "$houdini/runtime/lib/network";
 		import _TestQuery2Artifact from "$houdini/artifacts/TestQuery2";
 		import { TestQuery2Store } from "$houdini/stores/TestQuery2";
 		import _TestQuery1Artifact from "$houdini/artifacts/TestQuery1";
@@ -1132,8 +1142,8 @@ test('both beforeLoad and afterLoad hooks', async function () {
 	)
 
 	expect(doc.module?.content).toMatchInlineSnapshot(`
-		import { convertKitPayload } from "$houdini/runtime";
-		import { RequestContext } from "$houdini/runtime";
+		import { convertKitPayload } from "$houdini/runtime/lib/network";
+		import { RequestContext } from "$houdini/runtime/lib/network";
 		import _TestQueryArtifact from "$houdini/artifacts/TestQuery";
 		import { TestQueryStore } from "$houdini/stores/TestQuery";
 		import { houdiniConfig } from "$houdini";
@@ -1236,7 +1246,8 @@ test('2 queries, one paginated one not', async function () {
 	)
 
 	expect(doc.instance?.content).toMatchInlineSnapshot(`
-		import { getHoudiniContext, isBrowser } from "$houdini/runtime";
+		import { isBrowser } from "$houdini/runtime/adapter";
+		import { getHoudiniContext } from "$houdini/runtime/lib/context";
 		import _TestQuery2Artifact from "$houdini/artifacts/TestQuery2";
 		import { TestQuery2Store } from "$houdini/stores/TestQuery2";
 		import _TestQuery1Artifact from "$houdini/artifacts/TestQuery1";

--- a/src/preprocess/transforms/query.ts
+++ b/src/preprocess/transforms/query.ts
@@ -199,7 +199,7 @@ function processModule({
 		config,
 		body: script.content.body,
 		import: ['RequestContext'],
-		sourceModule: '$houdini/runtime',
+		sourceModule: '$houdini/runtime/lib/network',
 	})
 
 	// if there is already a load function, don't do anything
@@ -491,7 +491,7 @@ function addSapperPreload(config: Config, body: Statement[]) {
 		config,
 		body,
 		import: ['convertKitPayload'],
-		sourceModule: '$houdini/runtime',
+		sourceModule: '$houdini/runtime/lib/network',
 	})
 
 	// look for a preload definition
@@ -626,8 +626,14 @@ function processInstance({
 	ensureImports({
 		config,
 		body: script.content.body,
-		import: ['getHoudiniContext', 'isBrowser'],
-		sourceModule: '$houdini/runtime',
+		import: ['getHoudiniContext'],
+		sourceModule: '$houdini/runtime/lib/context',
+	})
+	ensureImports({
+		config,
+		body: script.content.body,
+		import: ['isBrowser'],
+		sourceModule: '$houdini/runtime/adapter',
 	})
 
 	// any prop declarations and statements need to come after the first import

--- a/src/runtime/stores/query.ts
+++ b/src/runtime/stores/query.ts
@@ -227,8 +227,6 @@ export function queryStore<_Data extends GraphQLObject, _Input>({
 			},
 		})
 
-		console.log({ fakeAwait })
-
 		// if the await isn't fake, await it
 		if (!fakeAwait) {
 			await request

--- a/src/runtime/stores/query.ts
+++ b/src/runtime/stores/query.ts
@@ -227,13 +227,12 @@ export function queryStore<_Data extends GraphQLObject, _Input>({
 			},
 		})
 
-		// if we weren't told to block we're done (only valid for a client-side request)
-		if (fakeAwait) {
-			return get(store)
-		}
+		console.log({ fakeAwait })
 
-		// if we got this far, we need to wait for the response from the request
-		await request
+		// if the await isn't fake, await it
+		if (!fakeAwait) {
+			await request
+		}
 
 		// the store will have been updated already since we waited for the response
 		return get(store)


### PR DESCRIPTION
This PR improves the preprocessor's reliability by updating the imports to point directly to the path avoiding any circular import issues