### PR TITLE
Feat - Generate perf improvements

### DIFF
--- a/.changeset/green-chairs-reflect.md
+++ b/.changeset/green-chairs-reflect.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+feat: in summary a new log is displayed about what item was deleted

--- a/.changeset/yellow-suns-scream.md
+++ b/.changeset/yellow-suns-scream.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+improve: generate will write files only if it has changed

--- a/integration/.npmrc
+++ b/integration/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true

--- a/src/cmd/generate.ts
+++ b/src/cmd/generate.ts
@@ -60,9 +60,12 @@ export async function runPipeline(config: Config, docs: CollectedGraphQLDocument
 	await run(
 		config,
 		[
+			// validators
 			validators.typeCheck,
 			validators.uniqueNames,
 			validators.noIDAlias,
+
+			// transforms
 			transforms.internalSchema,
 			transforms.addID,
 			transforms.typename,
@@ -74,8 +77,10 @@ export async function runPipeline(config: Config, docs: CollectedGraphQLDocument
 			transforms.paginate,
 			transforms.fragmentVariables,
 			transforms.composeQueries,
-			generators.artifacts(artifactStats),
+
+			// generators
 			generators.runtime,
+			generators.artifacts(artifactStats),
 			generators.typescript,
 			generators.persistOutput,
 			generators.definitions,

--- a/src/cmd/generate.ts
+++ b/src/cmd/generate.ts
@@ -40,6 +40,7 @@ export async function runPipeline(config: Config, docs: CollectedGraphQLDocument
 		total: [],
 		changed: [],
 		new: [],
+		deleted: [],
 	}
 
 	// notify the user we are starting the generation process
@@ -103,7 +104,10 @@ export async function runPipeline(config: Config, docs: CollectedGraphQLDocument
 	} else if ([LogLevel.Summary, LogLevel.ShortSummary].includes(config.logLevel)) {
 		// count the number of unchanged
 		const unchanged =
-			artifactStats.total.length - artifactStats.changed.length - artifactStats.new.length
+			artifactStats.total.length -
+			artifactStats.changed.length -
+			artifactStats.new.length -
+			artifactStats.deleted.length
 
 		// if we have any unchanged artifacts
 		if (unchanged > 0) {
@@ -123,6 +127,13 @@ export async function runPipeline(config: Config, docs: CollectedGraphQLDocument
 				logFirst5(artifactStats.new)
 			}
 		}
+
+		if (artifactStats.deleted.length > 0) {
+			console.log(`🧹 Deleted: ${artifactStats.deleted.length}`)
+			if (config.logLevel === LogLevel.Summary) {
+				logFirst5(artifactStats.deleted)
+			}
+		}
 	} else if (config.logLevel === LogLevel.Full) {
 		for (const artifact of artifactStats.total) {
 			// figure out the emoji to use
@@ -131,6 +142,8 @@ export async function runPipeline(config: Config, docs: CollectedGraphQLDocument
 				emoji = '✏️ '
 			} else if (artifactStats.new.includes(artifact)) {
 				emoji = '✨'
+			} else if (artifactStats.deleted.includes(artifact)) {
+				emoji = '🧹'
 			}
 
 			// log the name

--- a/src/cmd/generators/artifacts/indexFile.test.ts
+++ b/src/cmd/generators/artifacts/indexFile.test.ts
@@ -38,8 +38,8 @@ test('index file - esm', async function () {
 	}).program
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		export { default as TestQuery} from './TestQuery'
 		export { default as TestFragment} from './TestFragment'
+		export { default as TestQuery} from './TestQuery'
 	`)
 })
 
@@ -74,9 +74,9 @@ test('index file - sapper', async function () {
 		    return (mod && mod.__esModule) ? mod : { "default": mod };
 		};
 		Object.defineProperty(exports, "__esModule", { value: true });
-		var TestQuery = require("./TestQuery");
-		Object.defineProperty(exports, "TestQuery", { enumerable: true, get: function () { return __importDefault(TestQuery).default; } });
 		var TestFragment = require("./TestFragment");
 		Object.defineProperty(exports, "TestFragment", { enumerable: true, get: function () { return __importDefault(TestFragment).default; } });
+		var TestQuery = require("./TestQuery");
+		Object.defineProperty(exports, "TestQuery", { enumerable: true, get: function () { return __importDefault(TestQuery).default; } });
 	`)
 })

--- a/src/cmd/generators/artifacts/indexFile.ts
+++ b/src/cmd/generators/artifacts/indexFile.ts
@@ -7,7 +7,9 @@ import { CollectedGraphQLDocument } from '../../types'
 import { cjsIndexFilePreamble, exportDefaultFrom, writeFile } from '../../utils'
 
 export default async function writeIndexFile(config: Config, docs: CollectedGraphQLDocument[]) {
-	const docsToGenerate = docs.filter((doc) => doc.generateArtifact)
+	const docsToGenerate = docs
+		.filter((doc) => doc.generateArtifact)
+		.sort((a, b) => a.name.localeCompare(b.name))
 
 	// we want to export every artifact from the index file.
 	let body =

--- a/src/cmd/generators/definitions/enums.ts
+++ b/src/cmd/generators/definitions/enums.ts
@@ -43,6 +43,7 @@ export default async function definitionsGenerator(config: Config) {
 
 	// generate the type definitions
 	const typeDefinitions = enums
+		.sort((a, b) => a.name.value.localeCompare(b.name.value))
 		.map(
 			(definition) => `
 export declare enum ${definition.name.value} {

--- a/src/cmd/generators/runtime/adapter.ts
+++ b/src/cmd/generators/runtime/adapter.ts
@@ -9,12 +9,6 @@ export default async function generateAdapter(config: Config) {
 	// the location of the adapter
 	const adapterLocation = path.join(config.runtimeDirectory, 'adapter.js')
 
-	// delete the existing adapter
-	try {
-		await fs.stat(adapterLocation)
-		await fs.rm(adapterLocation)
-	} catch {}
-
 	// figure out which adapter we need to lay down
 	const adapter = {
 		sapper: sapperAdapter,

--- a/src/cmd/generators/runtime/copyRuntime.ts
+++ b/src/cmd/generators/runtime/copyRuntime.ts
@@ -91,7 +91,10 @@ async function recursiveCopy(config: Config, source: string, target: string, not
 							contents.replace('"use strict";', '')
 					}
 
-					await writeFile(targetPath, contents)
+					// Do not write `/runtime/adapter.js` file. It will be generated later depending on the framework.
+					if (!targetPath.endsWith('/runtime/adapter.js')) {
+						await writeFile(targetPath, contents)
+					}
 				}
 			})
 		)

--- a/src/cmd/generators/stores/index.ts
+++ b/src/cmd/generators/stores/index.ts
@@ -31,6 +31,7 @@ export default async function storesGenerator(config: Config, docs: CollectedGra
 
 	const dataIndex = listOfStores
 		.filter((c) => c !== null)
+		.sort((a, b) => (a + '').localeCompare(b + ''))
 		.map((c) => `export * from './${c}'`)
 		.join(`\n`)
 	await writeFile(path.join(config.rootDir, 'stores', `index.js`), dataIndex)

--- a/src/cmd/generators/typescript/index.ts
+++ b/src/cmd/generators/typescript/index.ts
@@ -107,6 +107,7 @@ export default async function typescriptGenerator(
 	// now that we have every type generated, create an index file in the runtime root that exports the types
 	const typeIndex = AST.program(
 		typePaths
+			.sort((a, b) => a.localeCompare(b))
 			.map((typePath) => {
 				return AST.exportAllDeclaration(
 					AST.literal(

--- a/src/cmd/utils/cleanupFiles.ts
+++ b/src/cmd/utils/cleanupFiles.ts
@@ -1,0 +1,21 @@
+import { readdir, remove } from 'fs-extra'
+import path from 'path'
+
+export async function cleanupFiles(pathFolder: string, listOfObj: string[]): Promise<string[]> {
+	const listFile = await readdir(pathFolder, { withFileTypes: true })
+	const storeListFile = listFile
+		.map((c) => c.name)
+		.filter((c) => c.endsWith('.js') && c !== 'index.js')
+		.map((c) => c.slice(0, -3))
+		.sort()
+
+	let allFilesNotInList = storeListFile.filter((x) => !listOfObj.includes(x))
+	await Promise.all(
+		allFilesNotInList.map(async (storeName) => {
+			await remove(path.join(pathFolder, `${storeName}.js`))
+			await remove(path.join(pathFolder, `${storeName}.d.ts`))
+		})
+	)
+
+	return allFilesNotInList
+}


### PR DESCRIPTION
Add Predictability of file content by sorting imports. 
Like this, we don't need to generate the same index file over and over. (as `writeFile` will not write the file if it's the same content)

Also not copying `/runtime/adapter.js` as it will be replaced by the framework choice. (today the file was written twice at each generate)

I believe that we will have less issues while in dev mode generating in the background. (To follow after this PR merged)

Adding also `deleted` items
![image](https://user-images.githubusercontent.com/5312607/179375183-f84d91b5-ed59-4e7a-a5c3-d4424d580827.png)
