### PR TITLE
Fix `stuff` bug in component query variables

### DIFF
--- a/.changeset/great-rocks-wait.md
+++ b/.changeset/great-rocks-wait.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+fix bug when computing variables in component queries

--- a/src/preprocess/transforms/query.test.ts
+++ b/src/preprocess/transforms/query.test.ts
@@ -598,7 +598,9 @@ describe('query preprocessor', function () {
 		            prop4: prop4
 		        },
 
-		        session: _houdini_context_generated_DONT_USE.session
+		        session: _houdini_context_generated_DONT_USE.session(),
+		        stuff: _houdini_context_generated_DONT_USE.stuff(),
+		        url: _houdini_context_generated_DONT_USE.url()
 		    })
 		});
 

--- a/src/preprocess/transforms/query.ts
+++ b/src/preprocess/transforms/query.ts
@@ -752,11 +752,17 @@ function processInstance({
 														)
 													)
 												),
-												AST.objectProperty(
-													AST.identifier('session'),
-													AST.memberExpression(
-														contextIdentifier,
-														AST.identifier('session')
+												// pull session, stuff, and url from the context
+												...['session', 'stuff', 'url'].map((name) =>
+													AST.objectProperty(
+														AST.identifier(name),
+														AST.callExpression(
+															AST.memberExpression(
+																contextIdentifier,
+																AST.identifier(name)
+															),
+															[]
+														)
 													)
 												),
 											]),

--- a/src/runtime/lib/context.ts
+++ b/src/runtime/lib/context.ts
@@ -13,7 +13,7 @@ export function nullHoudiniContext(): HoudiniFetchContext {
 		url: () => null,
 		session: () => null,
 		variables: async () => {},
-		stuff: {},
+		stuff: () => ({}),
 	}
 }
 
@@ -35,7 +35,7 @@ export function getHoudiniContext(): HoudiniFetchContext {
 			url: () => url,
 			session: () => session,
 			variables: svelteContext('variables') || (() => ({})),
-			stuff,
+			stuff: () => stuff,
 		}
 	} catch (e) {
 		log.info(

--- a/src/runtime/lib/context.ts
+++ b/src/runtime/lib/context.ts
@@ -25,14 +25,17 @@ export function getHoudiniContext(): HoudiniFetchContext {
 		sessionStore.subscribe((val) => (session = val))
 
 		const pageStore = getPage()
-		let url = get(pageStore).url
-		pageStore.subscribe((val) => (url = val.url))
+		let { url, stuff } = get(pageStore)
+		pageStore.subscribe((val) => {
+			url = val.url
+			stuff = val.stuff
+		})
 
 		return {
 			url: () => url,
 			session: () => session,
 			variables: svelteContext('variables') || (() => ({})),
-			stuff: {},
+			stuff,
 		}
 	} catch (e) {
 		log.info(

--- a/src/runtime/lib/types.ts
+++ b/src/runtime/lib/types.ts
@@ -182,7 +182,7 @@ export type HoudiniFetchContext = {
 	url: () => URL | null
 	session: () => App.Session | null
 	variables: () => {}
-	stuff: App.Stuff
+	stuff: () => App.Stuff
 }
 
 export type SubscriptionStore<_Shape, _Input> = Readable<_Shape> & {

--- a/src/runtime/stores/query.ts
+++ b/src/runtime/stores/query.ts
@@ -402,7 +402,7 @@ function fetchContext<_Data, _Input>(
 	}
 
 	// find the right stuff
-	let stuff = houdiniContext?.stuff || {}
+	let stuff = houdiniContext?.stuff?.() || {}
 	if (params && 'event' in params && params.event && 'stuff' in params.event) {
 		stuff = params.event.stuff
 	}


### PR DESCRIPTION
This PR fixes a bug with the values passed to the variable function for component queries


closes #421 