### PR TITLE
Node interface - warning if not properly defined && error on usage

### DIFF
--- a/.changeset/slow-rats-repeat.md
+++ b/.changeset/slow-rats-repeat.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+warn user when Node interface is not properly defined and throw an error on Node usage (when not properly defined)

--- a/src/cmd/transforms/paginate.ts
+++ b/src/cmd/transforms/paginate.ts
@@ -5,6 +5,7 @@ import { ArtifactKind } from '../../runtime/lib/types'
 // locals
 import { CollectedGraphQLDocument, RefetchUpdateMode } from '../types'
 import { unwrapType, wrapType } from '../utils'
+import { getAndVerifyNodeInterface } from '../validators/typeCheck'
 
 // the paginate transform is responsible for preparing a fragment marked for pagination
 // to be embedded in the query that will be used to fetch additional data. That means it
@@ -288,7 +289,7 @@ export default async function paginate(
 			// figure out the 'target' type of the refetch
 			let targetType = config.schema.getQueryType()?.name || ''
 			if (fragment) {
-				const nodeInterface = config.schema.getType('Node') as graphql.GraphQLInterfaceType
+				const nodeInterface = getAndVerifyNodeInterface(config)
 				if (nodeInterface) {
 					const { objects, interfaces } = config.schema.getImplementations(nodeInterface)
 

--- a/src/cmd/transforms/paginate.ts
+++ b/src/cmd/transforms/paginate.ts
@@ -1,11 +1,11 @@
 // externals
-import * as graphql from 'graphql'
 import { Config, parentTypeFromAncestors } from '../../common'
 import { ArtifactKind } from '../../runtime/lib/types'
 // locals
 import { CollectedGraphQLDocument, RefetchUpdateMode } from '../types'
 import { unwrapType, wrapType } from '../utils'
 import { getAndVerifyNodeInterface } from '../validators/typeCheck'
+import * as graphql from 'graphql'
 
 // the paginate transform is responsible for preparing a fragment marked for pagination
 // to be embedded in the query that will be used to fetch additional data. That means it
@@ -289,7 +289,7 @@ export default async function paginate(
 			// figure out the 'target' type of the refetch
 			let targetType = config.schema.getQueryType()?.name || ''
 			if (fragment) {
-				const nodeInterface = getAndVerifyNodeInterface(config)
+				const nodeInterface = config.schema.getType('Node') as graphql.GraphQLInterfaceType
 				if (nodeInterface) {
 					const { objects, interfaces } = config.schema.getImplementations(nodeInterface)
 

--- a/src/cmd/validators/typeCheck.ts
+++ b/src/cmd/validators/typeCheck.ts
@@ -1,15 +1,15 @@
 // externals
 import * as graphql from 'graphql'
 // locals
-import { Config, definitionFromAncestors, parentTypeFromAncestors } from '../../common'
-import { CollectedGraphQLDocument, HoudiniError, HoudiniErrorTodo } from '../types'
+import { Config, definitionFromAncestors, LogLevel, parentTypeFromAncestors } from '../../common'
 import {
 	FragmentArgument,
 	fragmentArguments as collectFragmentArguments,
 	withArguments,
 } from '../transforms/fragmentVariables'
-import { unwrapType } from '../utils'
 import { connectionSelection } from '../transforms/list'
+import { CollectedGraphQLDocument, HoudiniError, HoudiniErrorTodo } from '../types'
+import { unwrapType } from '../utils'
 
 // typeCheck verifies that the documents are valid instead of waiting
 // for the compiler to fail later down the line.
@@ -20,14 +20,9 @@ export default async function typeCheck(
 	// wrap the errors we run into in a HoudiniError
 	const errors: HoudiniError[] = []
 
-	// verify the node interface (if it exists)
-	try {
-		verifyNodeInterface(config)
-	} catch (e) {
-		throw HoudiniErrorTodo(
-			"There is a problem with your project's schema: " + ((e as unknown) as Error).message
-		)
-	}
+	// verify the node interface (if everything is fine)
+	// log a warning if it's not properly defined and continue.
+	getAndVerifyNodeInterface(config)
 
 	// we need to catch errors in the list API. this means that a user
 	// must provide parentID if they are using a list that is not all-objects
@@ -849,7 +844,7 @@ function nodeDirectives(config: Config, directives: string[]) {
 	const customTypes = Object.keys(config.typeConfig || {})
 
 	// check if there's a node interface
-	const nodeInterface = config.schema.getType('Node') as graphql.GraphQLInterfaceType
+	const nodeInterface = getAndVerifyNodeInterface(config)
 	if (nodeInterface) {
 		const { objects, interfaces } = config.schema.getImplementations(nodeInterface)
 		possibleNodes.push(
@@ -901,7 +896,7 @@ function nodeDirectives(config: Config, directives: string[]) {
 	}
 }
 
-function verifyNodeInterface(config: Config) {
+export function getAndVerifyNodeInterface(config: Config): graphql.GraphQLInterfaceType | null {
 	const { schema } = config
 
 	// look for Node
@@ -909,54 +904,77 @@ function verifyNodeInterface(config: Config) {
 
 	// if there is no node interface don't do anything else
 	if (!nodeInterface) {
-		return
+		return null
 	}
 
 	// make sure its an interface
 	if (!graphql.isInterfaceType(nodeInterface)) {
-		throw new Error(invalidNodeFieldMessage)
+		displayInvalidNodeFieldMessage(config.logLevel)
+		return null
 	}
 
 	// look for a field on the query type to look up a node by id
 	const queryType = schema.getQueryType()
 	if (!queryType) {
-		throw new Error(invalidNodeFieldMessage)
+		displayInvalidNodeFieldMessage(config.logLevel)
+		return null
 	}
 
 	// look for a node field
 	const nodeField = queryType.getFields()['node']
 	if (!nodeField) {
-		throw new Error(invalidNodeFieldMessage)
+		displayInvalidNodeFieldMessage(config.logLevel)
+		return null
 	}
 
 	// there needs to be an arg on the field called id
 	const args = nodeField.args
 	if (args.length === 0) {
-		throw new Error(invalidNodeFieldMessage)
+		displayInvalidNodeFieldMessage(config.logLevel)
+		return null
 	}
 
 	// look for the id arg
 	const idArg = args.find((arg) => arg.name === 'id')
 	if (!idArg) {
-		throw new Error(invalidNodeFieldMessage)
+		displayInvalidNodeFieldMessage(config.logLevel)
+		return null
 	}
 
 	// make sure that the id arg takes an ID
 	const idType = unwrapType(config, idArg.type)
 	// make sure its an ID
 	if (idType.type.name !== 'ID') {
-		throw new Error(invalidNodeFieldMessage)
+		displayInvalidNodeFieldMessage(config.logLevel)
+		return null
 	}
 
 	// make sure that the node field returns a Node
 	const fieldReturnType = unwrapType(config, nodeField.type)
 	if (fieldReturnType.type.name !== 'Node') {
-		throw new Error(invalidNodeFieldMessage)
+		displayInvalidNodeFieldMessage(config.logLevel)
+		return null
 	}
+
+	return nodeInterface as graphql.GraphQLInterfaceType
 }
 
-const invalidNodeFieldMessage = `
-Your project defines a Node interface but it does not conform to the Global Identification Spec.
+let nbInvalidNodeFieldMessageDisplayed = 0
+function displayInvalidNodeFieldMessage(logLevel: LogLevel) {
+	// We want to display the message only once.
+	if (nbInvalidNodeFieldMessageDisplayed === 0) {
+		if (logLevel === LogLevel.Full) {
+			console.warn(invalidNodeFieldMessage)
+		} else {
+			console.warn(invalidNodeFieldMessageLight)
+		}
+	}
+	nbInvalidNodeFieldMessageDisplayed++
+}
+
+const invalidNodeFieldMessageLight = `⚠️  Your Node interface is not properly defined, please fix your schema to be able to use this interface. (For more info, add flag "-l full")`
+
+const invalidNodeFieldMessage = `⚠️  Your project defines a Node interface but it does not conform to the Global Identification Spec.
 
 If you are trying to provide the Node interface and its field, they must look like the following:
 

--- a/src/cmd/validators/typeCheck.ts
+++ b/src/cmd/validators/typeCheck.ts
@@ -1,5 +1,4 @@
 // externals
-import * as graphql from 'graphql'
 // locals
 import { Config, definitionFromAncestors, LogLevel, parentTypeFromAncestors } from '../../common'
 import {
@@ -10,6 +9,7 @@ import {
 import { connectionSelection } from '../transforms/list'
 import { CollectedGraphQLDocument, HoudiniError, HoudiniErrorTodo } from '../types'
 import { unwrapType } from '../utils'
+import * as graphql from 'graphql'
 
 // typeCheck verifies that the documents are valid instead of waiting
 // for the compiler to fail later down the line.
@@ -19,10 +19,6 @@ export default async function typeCheck(
 ): Promise<void> {
 	// wrap the errors we run into in a HoudiniError
 	const errors: HoudiniError[] = []
-
-	// verify the node interface (if everything is fine)
-	// log a warning if it's not properly defined and continue.
-	getAndVerifyNodeInterface(config)
 
 	// we need to catch errors in the list API. this means that a user
 	// must provide parentID if they are using a list that is not all-objects


### PR DESCRIPTION
Linked to https://github.com/HoudiniGraphql/houdini/issues/433

---

- [x] Depending on `logLevel`, the warning displays more or less info.

- [x] If your Node interface is not properly defined, but you don't use it:
![image](https://user-images.githubusercontent.com/5312607/181905087-37759365-7f39-4eaf-9ccf-25dbb84555c4.png)

- [x] If your Node interface is not properly defined, and you try to use it explicitly:
![10](https://user-images.githubusercontent.com/5312607/181905140-85a29143-6738-425f-ab92-5ac90d0bf1ec.png)

- [x] If your Node interface is not properly defined, and you try to use it implicitly (paginate for example):
![11](https://user-images.githubusercontent.com/5312607/181905166-ae23f176-245f-4c2b-9c2d-b4426bb2eac6.png)

- [x] as as before, with with `logLevel: full`
![12](https://user-images.githubusercontent.com/5312607/181905188-db042772-5403-4398-9088-159d266b9b60.png)

