### PR TITLE
Allow setting session data to the client

### DIFF
--- a/.changeset/chilly-rockets-reflect.md
+++ b/.changeset/chilly-rockets-reflect.md
@@ -1,0 +1,5 @@
+---
+'houdini': minor
+---
+
+Allow passing external session data to the fetch function

--- a/src/runtime/lib/network.ts
+++ b/src/runtime/lib/network.ts
@@ -142,14 +142,23 @@ export type RequestPayload<_Data = any> = {
 /**
  * ## Tip 👇
  *
- * To define types for your metadata, create a file `src/app.d.ts` containing the followingI:
+ * To define types for your metadata, create a file `src/app.d.ts` containing the following:
  *
  * ```ts
- * declare namespace App { *
- * 	interface Metadata {}
+ * declare namespace App {
+ * 	 interface Metadata {}
+ *
+ *   interface SessionData {
+ *     accessToken: string
+ *   }
  * }
  * ```
  *
+ * To define the shape of session data, pass a type or type literal as generic to the client constructor:
+ *
+ * ```ts
+ * export default new HoudiniClient<App.SessionData>(fetchFn);
+ * ```
  */
 export type RequestHandlerArgs<SessionData> = FetchContext &
 	FetchParams & {

--- a/src/runtime/lib/network.ts
+++ b/src/runtime/lib/network.ts
@@ -151,9 +151,10 @@ export type RequestPayload<_Data = any> = {
  * ```
  *
  */
-export type RequestHandlerArgs<SessionData> = Omit<FetchContext & FetchParams, 'stuff'> & {
-	session: SessionData | undefined
-}
+export type RequestHandlerArgs<SessionData> = FetchContext &
+	FetchParams & {
+		session: SessionData | undefined
+	}
 
 export type RequestHandler<_Data, SessionData> = (
 	args: RequestHandlerArgs<SessionData>

--- a/src/runtime/lib/network.ts
+++ b/src/runtime/lib/network.ts
@@ -18,7 +18,7 @@ import {
 export class HoudiniClient<SessionData = undefined> {
 	private fetchFn: RequestHandler<any, SessionData>
 	socket: SubscriptionHandler | null | undefined
-	getSession: (() => SessionData | Promise<SessionData>) | undefined
+	private session: SessionData | undefined
 
 	constructor(
 		networkFn: RequestHandler<any, SessionData>,
@@ -34,8 +34,6 @@ export class HoudiniClient<SessionData = undefined> {
 	): Promise<RequestPayloadMagic<_Data>> {
 		let url = ''
 
-		const session = this.getSession ? await this.getSession() : undefined
-
 		// invoke the function
 		const result = await this.fetchFn({
 			// wrap the user's fetch function so we can identify SSR by checking
@@ -50,7 +48,7 @@ export class HoudiniClient<SessionData = undefined> {
 			},
 			...params,
 			metadata: ctx.metadata,
-			session,
+			session: this.session,
 		})
 
 		// return the result
@@ -61,6 +59,10 @@ export class HoudiniClient<SessionData = undefined> {
 	}
 
 	init() {}
+
+	setSession(session: SessionData | undefined) {
+		this.session = session
+	}
 }
 
 export class Environment extends HoudiniClient<any> {


### PR DESCRIPTION
I went ahead and finished my poc for this feature.

Everything is called session which is probably the most accurate name.
Also instead of a function to call the `getSession` is just a prop on the client for simplicity.