### PR TITLE
Allow passing session data to the fetch function

### DIFF
--- a/src/cmd/generators/runtime/adapter.ts
+++ b/src/cmd/generators/runtime/adapter.ts
@@ -18,7 +18,7 @@ export default async function generateAdapter(config: Config) {
 
 const sveltekitAdapter = `import { goto as go } from '$app/navigation'
 import { get } from 'svelte/store';
-import { browser, prerendering } from '$app/env'
+import { browser, dev, prerendering } from '$app/env'
 import { error as svelteKitError } from '@sveltejs/kit'
 
 
@@ -42,6 +42,7 @@ export const isPrerender = prerendering
 
 export const error = svelteKitError
 
+export const isDev = dev
 `
 
 const svelteAdapter = `
@@ -62,4 +63,7 @@ export const error = (code, message) => {
 	error.code = code
 	return err
 }
+
+// Hopefully everybody is already sing vite...
+export const isDev = import.meta.env.DEV
 `

--- a/src/runtime/adapter.ts
+++ b/src/runtime/adapter.ts
@@ -18,3 +18,5 @@ export let clientStarted = false // Will be true on a client side navigation
 export let isPrerender = false
 
 export const error = (code: number, message: string) => message
+
+export const isDev = true

--- a/src/runtime/lib/network.ts
+++ b/src/runtime/lib/network.ts
@@ -53,7 +53,7 @@ export class HoudiniClient<SessionData = undefined> {
 			},
 			...params,
 			metadata: ctx.metadata,
-			session: session || this.clientSideSession,
+			session: this.clientSideSession || session,
 		})
 
 		// return the result

--- a/src/runtime/lib/network.ts
+++ b/src/runtime/lib/network.ts
@@ -1,5 +1,4 @@
 import { error, LoadEvent, redirect, RequestEvent } from '@sveltejs/kit'
-import { get_current_component } from 'svelte/internal'
 import { get } from 'svelte/store'
 
 import { isBrowser, isDev } from '../adapter'
@@ -80,13 +79,10 @@ export class HoudiniClient<SessionData = undefined> {
 	}
 
 	receiveServerSession(data: {}) {
-		// This may only be called during initialization of a component.
-		// This is not really a technical limitation but to prevent users from sharing data on the server.
-
-		// This call will throw outside of component initialization.
-		get_current_component()
-
-		this.clientSideSession = (data as any)[sessionKeyName]
+		// This may only be called in the browser. But instead of throwing we must ignore calls on the server because otherwise ssr would also break.
+		if (isBrowser) {
+			this.clientSideSession = (data as any)[sessionKeyName]
+		}
 	}
 
 	setSession(session: SessionData) {

--- a/src/runtime/lib/network.ts
+++ b/src/runtime/lib/network.ts
@@ -38,6 +38,10 @@ export class HoudiniClient<SessionData = undefined> {
 	): Promise<RequestPayloadMagic<_Data>> {
 		let url = ''
 
+		if (isBrowser) {
+			session = this.clientSideSession
+		}
+
 		// invoke the function
 		const result = await this.fetchFn({
 			// wrap the user's fetch function so we can identify SSR by checking
@@ -52,7 +56,7 @@ export class HoudiniClient<SessionData = undefined> {
 			},
 			...params,
 			metadata: ctx.metadata,
-			session: this.clientSideSession || session,
+			session,
 		})
 
 		// return the result

--- a/src/runtime/lib/network.ts
+++ b/src/runtime/lib/network.ts
@@ -1,6 +1,8 @@
-import { LoadEvent, error, redirect } from '@sveltejs/kit'
+import { error, LoadEvent, redirect, RequestEvent } from '@sveltejs/kit'
+import { get_current_component } from 'svelte/internal'
 import { get } from 'svelte/store'
 
+import { isBrowser, isDev } from '../adapter'
 import cache from '../cache'
 import { QueryResult } from '../stores/query'
 import type { ConfigFile } from './config'
@@ -15,18 +17,25 @@ import {
 	SubscriptionArtifact,
 } from './types'
 
-export class HoudiniClient {
-	private fetchFn: RequestHandler<any>
-	socket: SubscriptionHandler | null | undefined
+export const sessionKeyName = 'HOUDINI_SESSION_KEY_NAME'
 
-	constructor(networkFn: RequestHandler<any>, subscriptionHandler?: SubscriptionHandler | null) {
+export class HoudiniClient<SessionData = undefined> {
+	private fetchFn: RequestHandler<any, SessionData | undefined>
+	socket: SubscriptionHandler | null | undefined
+	private clientSideSession: SessionData | undefined
+
+	constructor(
+		networkFn: RequestHandler<any, SessionData | undefined>,
+		subscriptionHandler?: SubscriptionHandler | null
+	) {
 		this.fetchFn = networkFn
 		this.socket = subscriptionHandler
 	}
 
 	async sendRequest<_Data>(
 		ctx: FetchContext,
-		params: FetchParams
+		params: FetchParams,
+		session: SessionData | undefined
 	): Promise<RequestPayloadMagic<_Data>> {
 		let url = ''
 
@@ -44,6 +53,7 @@ export class HoudiniClient {
 			},
 			...params,
 			metadata: ctx.metadata,
+			session: session || this.clientSideSession,
 		})
 
 		// return the result
@@ -54,6 +64,40 @@ export class HoudiniClient {
 	}
 
 	init() {}
+
+	setServerSession(event: RequestEvent, session: SessionData) {
+		;(event.locals as any)[sessionKeyName] = session
+	}
+
+	passServerSession(event: RequestEvent): {} {
+		if (isDev && !(sessionKeyName in event.locals)) {
+			// todo: Warn the user that houdini session is not setup correctly.
+		}
+
+		return {
+			[sessionKeyName]: (event.locals as any)[sessionKeyName],
+		}
+	}
+
+	receiveServerSession(data: {}) {
+		// This may only be called during initialization of a component.
+		// This is not really a technical limitation but to prevent users from sharing data on the server.
+
+		// This call will throw outside of component initialization.
+		get_current_component()
+
+		this.clientSideSession = (data as any)[sessionKeyName]
+	}
+
+	setSession(session: SessionData) {
+		// This may not be called on the server. Otherwise multiple requests would share the session as this class is a global singleton on the server.
+		if (!isBrowser) {
+			// todo: Warn the user about the above fact.
+			throw new Error()
+		}
+
+		this.clientSideSession = session
+	}
 }
 
 export class Environment extends HoudiniClient {
@@ -140,22 +184,25 @@ export type RequestPayload<_Data = any> = {
  * ```
  *
  */
-export type RequestHandlerArgs = Omit<FetchContext & FetchParams, 'stuff'>
+export type RequestHandlerArgs<SessionData> = FetchContext & FetchParams & { session: SessionData }
 
-export type RequestHandler<_Data> = (args: RequestHandlerArgs) => Promise<RequestPayload<_Data>>
+export type RequestHandler<_Data, SessionData> = (
+	args: RequestHandlerArgs<SessionData>
+) => Promise<RequestPayload<_Data>>
 
 // This function is responsible for simulating the fetch context and executing the query with fetchQuery.
 // It is mainly used for mutations, refetch and possible other client side operations in the future.
 export async function executeQuery<_Data extends GraphQLObject, _Input>({
 	artifact,
 	variables,
+	session,
 	cached,
-	config,
 	fetch,
 	metadata,
 }: {
 	artifact: QueryArtifact | MutationArtifact
 	variables: _Input
+	session: any
 	cached: boolean
 	config: ConfigFile
 	fetch?: typeof globalThis.fetch
@@ -166,9 +213,9 @@ export async function executeQuery<_Data extends GraphQLObject, _Input>({
 			fetch: fetch ?? globalThis.fetch.bind(globalThis),
 			metadata,
 		},
-		config,
 		artifact,
 		variables,
+		session,
 		cached,
 	})
 
@@ -191,7 +238,7 @@ export type FetchQueryResult<_Data> = {
 
 export type QueryInputs<_Data> = FetchQueryResult<_Data> & { variables: { [key: string]: any } }
 
-export async function getCurrentClient(): Promise<HoudiniClient> {
+export async function getCurrentClient(): Promise<HoudiniClient<any>> {
 	// @ts-ignore
 	return (await import('HOUDINI_CLIENT_PATH')).default
 }
@@ -199,14 +246,15 @@ export async function getCurrentClient(): Promise<HoudiniClient> {
 export async function fetchQuery<_Data extends GraphQLObject, _Input>({
 	artifact,
 	variables,
+	session,
 	cached = true,
 	policy,
 	context,
 }: {
-	config: ConfigFile
 	context: FetchContext
 	artifact: QueryArtifact | MutationArtifact
 	variables: _Input
+	session: any
 	cached?: boolean
 	policy?: CachePolicy
 }): Promise<FetchQueryResult<_Data>> {
@@ -269,11 +317,15 @@ export async function fetchQuery<_Data extends GraphQLObject, _Input>({
 	}, 0)
 
 	// the request must be resolved against the network
-	const result = await client.sendRequest<_Data>(context, {
-		text: artifact.raw,
-		hash: artifact.hash,
-		variables,
-	})
+	const result = await client.sendRequest<_Data>(
+		context,
+		{
+			text: artifact.raw,
+			hash: artifact.hash,
+			variables,
+		},
+		session
+	)
 
 	return {
 		result: result.body,

--- a/src/runtime/stores/mutation.ts
+++ b/src/runtime/stores/mutation.ts
@@ -89,6 +89,7 @@ export class MutationStore<_Data extends GraphQLObject, _Input> extends BaseStor
 				config,
 				artifact: this.artifact,
 				variables: newVariables,
+				session: undefined,
 				cached: false,
 				metadata,
 				fetch,

--- a/src/runtime/stores/pagination/cursor.ts
+++ b/src/runtime/stores/pagination/cursor.ts
@@ -61,6 +61,7 @@ export function cursorHandlers<_Data extends GraphQLObject, _Input>({
 		const { result } = await executeQuery<GraphQLObject, {}>({
 			artifact,
 			variables: loadVariables,
+			session: undefined,
 			cached: false,
 			config,
 			fetch,

--- a/src/runtime/stores/pagination/offset.ts
+++ b/src/runtime/stores/pagination/offset.ts
@@ -67,6 +67,7 @@ export function offsetHandlers<_Data extends GraphQLObject, _Input>({
 			const { result } = await executeQuery<GraphQLObject, {}>({
 				artifact,
 				variables: queryVariables,
+				session: undefined,
 				cached: false,
 				config,
 				fetch,


### PR DESCRIPTION
This is the first implementation of #488.

Locally everything works as expected and also client-side refreshes of the session work flawlessly.


## Some highlights
- [ ] New tests are passing
  - [ ]
  - [ ]
- [ ] New settings are available
  - [ ] Name the variable where houdini stores its session. Maybe this is unneeded?
  - [ ]
- [ ] The doc has been updated



--- 

During implementation I noticed that mutations do not take an event object, so I had no easy way to access `event.locals`/`event.parent`. I will tackle this tomorrow.

Probably there should also be more tests.