### PR TITLE
Do not force all users to set a session

### DIFF
--- a/.changeset/nine-cherries-bow.md
+++ b/.changeset/nine-cherries-bow.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Do not force setting session data

--- a/src/cmd/generators/runtime/adapter.ts
+++ b/src/cmd/generators/runtime/adapter.ts
@@ -25,7 +25,6 @@ import { get } from 'svelte/store';
 import { browser, prerendering } from '$app/environment'
 import { page } from '$app/stores'
 import { error as svelteKitError } from '@sveltejs/kit'
-import { sessionKeyName } from './lib/network'
 
 export function goTo(location, options) {
     go(location, options)

--- a/src/runtime/lib/network.ts
+++ b/src/runtime/lib/network.ts
@@ -64,13 +64,6 @@ export class HoudiniClient {
 	}
 
 	passServerSession(event: RequestEvent): {} {
-		if (!(sessionKeyName in event.locals)) {
-			// todo: Warn the user that houdini session is not setup correctly.
-			console.log(
-				`Could not find session in event.locals. This should never happen. Please open a ticket on Github and we'll sort it out.`
-			)
-		}
-
 		return {
 			[sessionKeyName]: (event.locals as any)[sessionKeyName],
 		}

--- a/src/runtime/lib/network.ts
+++ b/src/runtime/lib/network.ts
@@ -15,7 +15,7 @@ import {
 	SubscriptionArtifact,
 } from './types'
 
-export const sessionKeyName = 'HOUDINI_SESSION_KEY_NAME'
+export const sessionKeyName = '__houdini__session__'
 
 export class HoudiniClient {
 	private fetchFn: RequestHandler<any>

--- a/src/runtime/lib/network.ts
+++ b/src/runtime/lib/network.ts
@@ -62,12 +62,6 @@ export class HoudiniClient {
 	setSession(event: RequestEvent, session: App.Session) {
 		;(event.locals as any)[sessionKeyName] = session
 	}
-
-	passServerSession(event: RequestEvent): {} {
-		return {
-			[sessionKeyName]: (event.locals as any)[sessionKeyName],
-		}
-	}
 }
 
 export class Environment extends HoudiniClient {

--- a/src/runtime/lib/network.ts
+++ b/src/runtime/lib/network.ts
@@ -18,13 +18,10 @@ import {
 
 export const sessionKeyName = 'HOUDINI_SESSION_KEY_NAME'
 
-// @ts-ignore
-type SessionData = App.Session
-
 export class HoudiniClient {
 	private fetchFn: RequestHandler<any>
 	socket: SubscriptionHandler | null | undefined
-	private clientSideSession: SessionData | undefined
+	private clientSideSession: App.Session | undefined
 
 	constructor(networkFn: RequestHandler<any>, subscriptionHandler?: SubscriptionHandler | null) {
 		this.fetchFn = networkFn
@@ -63,7 +60,8 @@ export class HoudiniClient {
 
 	init() {}
 
-	setSession(event: RequestEvent, session: SessionData) {
+	// @ts-ignore
+	setSession(event: RequestEvent, session: App.Session) {
 		;(event.locals as any)[sessionKeyName] = session
 	}
 
@@ -169,7 +167,8 @@ export type RequestPayload<_Data = any> = {
  * ```
  *
  */
-export type RequestHandlerArgs = FetchContext & FetchParams & { session?: SessionData }
+// @ts-ignore
+export type RequestHandlerArgs = FetchContext & FetchParams & { session?: App.Session }
 
 export type RequestHandler<_Data> = (args: RequestHandlerArgs) => Promise<RequestPayload<_Data>>
 

--- a/src/runtime/lib/network.ts
+++ b/src/runtime/lib/network.ts
@@ -46,7 +46,15 @@ export class HoudiniClient {
 			},
 			...params,
 			metadata: ctx.metadata,
-			session: ctx.session ?? {},
+			get session() {
+				if (ctx.session === sessionSentinel) {
+					console.log(
+						`Session was not passed correctly. This should never happen. Please open a ticket on Github and we'll sort it out.`
+					)
+				}
+
+				return ctx.session ?? {}
+			},
 		})
 
 		// return the result
@@ -402,8 +410,9 @@ type KitBeforeLoad = (ctx: BeforeLoadArgs) => Record<string, any> | Promise<Reco
 type KitAfterLoad = (ctx: AfterLoadArgs) => Record<string, any>
 type KitOnError = (ctx: OnErrorArgs) => Record<string, any>
 
+export const sessionSentinel = {}
 // @ts-ignore
-let session: App.Session | {} = {}
+let session: App.Session | {} = sessionSentinel
 
 // @ts-ignore
 export function setSession(val: App.Session) {

--- a/src/runtime/lib/network.ts
+++ b/src/runtime/lib/network.ts
@@ -1,7 +1,6 @@
 import { error, LoadEvent, redirect, RequestEvent } from '@sveltejs/kit'
 import { get } from 'svelte/store'
 
-import { isBrowser } from '../adapter'
 import cache from '../cache'
 import { QueryResult } from '../stores/query'
 import type { ConfigFile } from './config'
@@ -21,7 +20,6 @@ export const sessionKeyName = 'HOUDINI_SESSION_KEY_NAME'
 export class HoudiniClient {
 	private fetchFn: RequestHandler<any>
 	socket: SubscriptionHandler | null | undefined
-	private clientSideSession: App.Session | undefined
 
 	constructor(networkFn: RequestHandler<any>, subscriptionHandler?: SubscriptionHandler | null) {
 		this.fetchFn = networkFn
@@ -48,7 +46,7 @@ export class HoudiniClient {
 			},
 			...params,
 			metadata: ctx.metadata,
-			session: (isBrowser ? this.clientSideSession : ctx.session) ?? {},
+			session: ctx.session ?? {},
 		})
 
 		// return the result

--- a/src/runtime/stores/mutation.ts
+++ b/src/runtime/stores/mutation.ts
@@ -80,7 +80,7 @@ export class MutationStore<
 				config,
 				artifact: this.artifact,
 				variables: newVariables,
-				session: getSession(),
+				session: await getSession(),
 				cached: false,
 				metadata,
 				fetch,

--- a/src/runtime/stores/pagination/cursor.ts
+++ b/src/runtime/stores/pagination/cursor.ts
@@ -64,7 +64,7 @@ export function cursorHandlers<_Data extends GraphQLObject, _Input>({
 		const { result } = await executeQuery<GraphQLObject, {}>({
 			artifact,
 			variables: loadVariables,
-			session: getSession(),
+			session: await getSession(),
 			cached: false,
 			config,
 			fetch,

--- a/src/runtime/stores/pagination/offset.ts
+++ b/src/runtime/stores/pagination/offset.ts
@@ -69,7 +69,7 @@ export function offsetHandlers<_Data extends GraphQLObject, _Input>({
 			const { result } = await executeQuery<GraphQLObject, {}>({
 				artifact,
 				variables: queryVariables,
-				session: getSession(),
+				session: await getSession(),
 				cached: false,
 				config,
 				fetch,

--- a/src/runtime/stores/query.ts
+++ b/src/runtime/stores/query.ts
@@ -6,7 +6,7 @@ import cache from '../cache'
 import type { ConfigFile, QueryArtifact } from '../lib'
 import { deepEquals } from '../lib/deepEquals'
 import * as log from '../lib/log'
-import { fetchQuery, sessionKeyName, sessionSentinel } from '../lib/network'
+import { fetchQuery } from '../lib/network'
 import { FetchContext, getSession } from '../lib/network'
 import { marshalInputs, unmarshalSelection } from '../lib/scalars'
 // internals
@@ -399,16 +399,9 @@ export async function fetchParams<_Data extends GraphQLObject, _Input>(
 	// cannot re-use the variable from above
 	// we need to check for ourselves to satisfy typescript
 	if (params && 'event' in params && params.event) {
-		// get the session either from the server side event or the client side event
-		if ('locals' in params.event) {
-			// this is a server side event (RequestEvent) -> extract the session from locals
-			session = (params.event.locals as any)[sessionKeyName] || sessionSentinel
-		} else {
-			// this is a client side event -> await the parent data which include the session
-			session = (await params.event.parent())[sessionKeyName] || sessionSentinel
-		}
+		session = await getSession(params.event)
 	} else if (isBrowser) {
-		session = getSession()
+		session = await getSession()
 	} else {
 		log.error(contextError(storeName))
 

--- a/src/runtime/stores/query.ts
+++ b/src/runtime/stores/query.ts
@@ -6,7 +6,7 @@ import cache from '../cache'
 import type { ConfigFile, QueryArtifact } from '../lib'
 import { deepEquals } from '../lib/deepEquals'
 import * as log from '../lib/log'
-import { fetchQuery, sessionKeyName } from '../lib/network'
+import { fetchQuery, sessionKeyName, sessionSentinel } from '../lib/network'
 import { FetchContext, getSession } from '../lib/network'
 import { marshalInputs, unmarshalSelection } from '../lib/scalars'
 // internals
@@ -402,10 +402,10 @@ export async function fetchParams<_Data extends GraphQLObject, _Input>(
 		// get the session either from the server side event or the client side event
 		if ('locals' in params.event) {
 			// this is a server side event (RequestEvent) -> extract the session from locals
-			session = (params.event.locals as any)[sessionKeyName]
+			session = (params.event.locals as any)[sessionKeyName] || sessionSentinel
 		} else {
 			// this is a client side event -> await the parent data which include the session
-			session = (await params.event.parent())[sessionKeyName]
+			session = (await params.event.parent())[sessionKeyName] || sessionSentinel
 		}
 	} else if (isBrowser) {
 		session = getSession()

--- a/src/vite/transforms/kit/init.test.ts
+++ b/src/vite/transforms/kit/init.test.ts
@@ -15,14 +15,14 @@ test('modifies root +layout.svelte to import adapter', async function () {
 
 	expect(result).toMatchInlineSnapshot(`
 		import { page } from "$app/stores";
-		import { setSession, sessionKeyName } from "$houdini/runtime/lib/network";
+		import { extractSession, setSession } from "$houdini/runtime/lib/network";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/runtime/adapter";
 		export let data;
 		onMount(() => setClientStarted());
 
 		page.subscribe(val => {
-		    setSession(val.data[sessionKeyName]);
+		    setSession(extractSession(val.data));
 		});
 	`)
 })

--- a/src/vite/transforms/kit/init.test.ts
+++ b/src/vite/transforms/kit/init.test.ts
@@ -15,14 +15,14 @@ test('modifies root +layout.svelte to import adapter', async function () {
 
 	expect(result).toMatchInlineSnapshot(`
 		import { page } from "$app/stores";
-		import { setSession } from "$houdini/runtime/lib/network";
+		import { setSession, sessionKeyName } from "$houdini/runtime/lib/network";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/runtime/adapter";
 		export let data;
 		onMount(() => setClientStarted());
 
 		page.subscribe(val => {
-		    setSession(val.data);
+		    setSession(val.data[sessionKeyName]);
 		});
 	`)
 })

--- a/src/vite/transforms/kit/init.ts
+++ b/src/vite/transforms/kit/init.ts
@@ -24,11 +24,11 @@ export default async function kit_init(page: TransformPage) {
 		sourceModule: 'svelte',
 		import: ['onMount'],
 	}).ids[0]
-	const set_session = ensure_imports({
+	const [set_session, session_key_name] = ensure_imports({
 		page,
 		sourceModule: '$houdini/runtime/lib/network',
-		import: ['setSession'],
-	}).ids[0]
+		import: ['setSession', 'sessionKeyName'],
+	}).ids
 
 	// add the onMount at the end of the component
 	page.script.body.push(
@@ -53,7 +53,14 @@ export default async function kit_init(page: TransformPage) {
 					AST.blockStatement([
 						AST.expressionStatement(
 							AST.callExpression(set_session, [
-								AST.memberExpression(AST.identifier('val'), AST.identifier('data')),
+								AST.memberExpression(
+									AST.memberExpression(
+										AST.identifier('val'),
+										AST.identifier('data')
+									),
+									session_key_name,
+									true
+								),
 							])
 						),
 					])

--- a/src/vite/transforms/kit/init.ts
+++ b/src/vite/transforms/kit/init.ts
@@ -24,10 +24,10 @@ export default async function kit_init(page: TransformPage) {
 		sourceModule: 'svelte',
 		import: ['onMount'],
 	}).ids[0]
-	const [set_session, session_key_name] = ensure_imports({
+	const [extract_session, set_session] = ensure_imports({
 		page,
 		sourceModule: '$houdini/runtime/lib/network',
-		import: ['setSession', 'sessionKeyName'],
+		import: ['extractSession', 'setSession'],
 	}).ids
 
 	// add the onMount at the end of the component
@@ -53,14 +53,12 @@ export default async function kit_init(page: TransformPage) {
 					AST.blockStatement([
 						AST.expressionStatement(
 							AST.callExpression(set_session, [
-								AST.memberExpression(
+								AST.callExpression(extract_session, [
 									AST.memberExpression(
 										AST.identifier('val'),
 										AST.identifier('data')
 									),
-									session_key_name,
-									true
-								),
+								]),
 							])
 						),
 					])

--- a/src/vite/transforms/kit/load.test.ts
+++ b/src/vite/transforms/kit/load.test.ts
@@ -1013,14 +1013,14 @@ test('layout loads', async function () {
 
 	expect(route.layout).toMatchInlineSnapshot(`
 		import { page } from "$app/stores";
-		import { setSession } from "$houdini/runtime/lib/network";
+		import { setSession, sessionKeyName } from "$houdini/runtime/lib/network";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/runtime/adapter";
 		export let data;
 		onMount(() => setClientStarted());
 
 		page.subscribe(val => {
-		    setSession(val.data);
+		    setSession(val.data[sessionKeyName]);
 		});
 	`)
 })
@@ -1042,7 +1042,7 @@ test('layout inline query', async function () {
 
 	expect(route.layout).toMatchInlineSnapshot(`
 		import { page } from "$app/stores";
-		import { setSession } from "$houdini/runtime/lib/network";
+		import { setSession, sessionKeyName } from "$houdini/runtime/lib/network";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/runtime/adapter";
 		export let data;
@@ -1053,7 +1053,7 @@ test('layout inline query', async function () {
 		onMount(() => setClientStarted());
 
 		page.subscribe(val => {
-		    setSession(val.data);
+		    setSession(val.data[sessionKeyName]);
 		});
 	`)
 

--- a/src/vite/transforms/kit/load.test.ts
+++ b/src/vite/transforms/kit/load.test.ts
@@ -1013,14 +1013,14 @@ test('layout loads', async function () {
 
 	expect(route.layout).toMatchInlineSnapshot(`
 		import { page } from "$app/stores";
-		import { setSession, sessionKeyName } from "$houdini/runtime/lib/network";
+		import { extractSession, setSession } from "$houdini/runtime/lib/network";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/runtime/adapter";
 		export let data;
 		onMount(() => setClientStarted());
 
 		page.subscribe(val => {
-		    setSession(val.data[sessionKeyName]);
+		    setSession(extractSession(val.data));
 		});
 	`)
 })
@@ -1042,7 +1042,7 @@ test('layout inline query', async function () {
 
 	expect(route.layout).toMatchInlineSnapshot(`
 		import { page } from "$app/stores";
-		import { setSession, sessionKeyName } from "$houdini/runtime/lib/network";
+		import { extractSession, setSession } from "$houdini/runtime/lib/network";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/runtime/adapter";
 		export let data;
@@ -1053,7 +1053,7 @@ test('layout inline query', async function () {
 		onMount(() => setClientStarted());
 
 		page.subscribe(val => {
-		    setSession(val.data[sessionKeyName]);
+		    setSession(extractSession(val.data));
 		});
 	`)
 

--- a/src/vite/transforms/kit/session.test.ts
+++ b/src/vite/transforms/kit/session.test.ts
@@ -15,14 +15,14 @@ test('modifies root +layout.svelte with data prop', async function () {
 
 	expect(result).toMatchInlineSnapshot(`
 		import { page } from "$app/stores";
-		import { setSession } from "$houdini/runtime/lib/network";
+		import { setSession, sessionKeyName } from "$houdini/runtime/lib/network";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/runtime/adapter";
 		export let data;
 		onMount(() => setClientStarted());
 
 		page.subscribe(val => {
-		    setSession(val.data);
+		    setSession(val.data[sessionKeyName]);
 		});
 	`)
 })
@@ -33,13 +33,13 @@ test('modifies root +layout.svelte without data prop', async function () {
 
 	expect(result).toMatchInlineSnapshot(`
 		import { page } from "$app/stores";
-		import { setSession } from "$houdini/runtime/lib/network";
+		import { setSession, sessionKeyName } from "$houdini/runtime/lib/network";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/runtime/adapter";
 		onMount(() => setClientStarted());
 
 		page.subscribe(val => {
-		    setSession(val.data);
+		    setSession(val.data[sessionKeyName]);
 		});
 	`)
 })

--- a/src/vite/transforms/kit/session.test.ts
+++ b/src/vite/transforms/kit/session.test.ts
@@ -48,13 +48,13 @@ test('adds load to +layout.server.js', async function () {
 	const result = await test_transform_js('src/routes/+layout.server.js', ``)
 
 	expect(result).toMatchInlineSnapshot(`
-		import __houdini_client__ from "PROJECT_ROOT/my/client/path";
+		import { sessionKeyName } from "$houdini/runtime/lib/network";
 
 		export async function load(event) {
 		    const __houdini__vite__plugin__return__value__ = {};
 
 		    return {
-		        ...__houdini_client__.passServerSession(event),
+		        [sessionKeyName]: event.locals[sessionKeyName],
 		        ...__houdini__vite__plugin__return__value__
 		    };
 		}
@@ -76,7 +76,7 @@ test('modifies existing load +layout.server.js', async function () {
 	)
 
 	expect(result).toMatchInlineSnapshot(`
-		import __houdini_client__ from "PROJECT_ROOT/my/client/path";
+		import { sessionKeyName } from "$houdini/runtime/lib/network";
 
 		export async function load(event) {
 		    "some random stuff that's valid javascript";
@@ -85,7 +85,7 @@ test('modifies existing load +layout.server.js', async function () {
 		    };
 
 		    return {
-		        ...__houdini_client__.passServerSession(event),
+		        [sessionKeyName]: event.locals[sessionKeyName],
 		        ...__houdini__vite__plugin__return__value__
 		    };
 		}
@@ -103,14 +103,14 @@ test('modifies existing load +layout.server.js - no return', async function () {
 	)
 
 	expect(result).toMatchInlineSnapshot(`
-		import __houdini_client__ from "PROJECT_ROOT/my/client/path";
+		import { sessionKeyName } from "$houdini/runtime/lib/network";
 
 		export async function load(event) {
 		    "some random stuff that's valid javascript";
 		    const __houdini__vite__plugin__return__value__ = {};
 
 		    return {
-		        ...__houdini_client__.passServerSession(event),
+		        [sessionKeyName]: event.locals[sessionKeyName],
 		        ...__houdini__vite__plugin__return__value__
 		    };
 		}
@@ -131,7 +131,7 @@ test('modifies existing load +layout.server.js - rest params', async function ()
 	)
 
 	expect(result).toMatchInlineSnapshot(`
-		import __houdini_client__ from "PROJECT_ROOT/my/client/path";
+		import { sessionKeyName } from "$houdini/runtime/lib/network";
 
 		export async function load(event) {
 		    let {
@@ -147,7 +147,7 @@ test('modifies existing load +layout.server.js - rest params', async function ()
 		    };
 
 		    return {
-		        ...__houdini_client__.passServerSession(event),
+		        [sessionKeyName]: event.locals[sessionKeyName],
 		        ...__houdini__vite__plugin__return__value__
 		    };
 		}
@@ -168,7 +168,7 @@ test('modifies existing load +layout.server.js - const arrow function', async fu
 	)
 
 	expect(result).toMatchInlineSnapshot(`
-		import __houdini_client__ from "PROJECT_ROOT/my/client/path";
+		import { sessionKeyName } from "$houdini/runtime/lib/network";
 
 		export const load = event => {
 		    let {
@@ -184,7 +184,7 @@ test('modifies existing load +layout.server.js - const arrow function', async fu
 		    };
 
 		    return {
-		        ...__houdini_client__.passServerSession(event),
+		        [sessionKeyName]: event.locals[sessionKeyName],
 		        ...__houdini__vite__plugin__return__value__
 		    };
 		};
@@ -205,7 +205,7 @@ test('modifies existing load +layout.server.js - const function', async function
 	)
 
 	expect(result).toMatchInlineSnapshot(`
-		import __houdini_client__ from "PROJECT_ROOT/my/client/path";
+		import { sessionKeyName } from "$houdini/runtime/lib/network";
 
 		export const load = function(event) {
 		    let {
@@ -221,7 +221,7 @@ test('modifies existing load +layout.server.js - const function', async function
 		    };
 
 		    return {
-		        ...__houdini_client__.passServerSession(event),
+		        [sessionKeyName]: event.locals[sessionKeyName],
 		        ...__houdini__vite__plugin__return__value__
 		    };
 		};
@@ -237,7 +237,7 @@ test('modifies existing load +layout.server.js - implicit return', async functio
 	)
 
 	expect(result).toMatchInlineSnapshot(`
-		import __houdini_client__ from "PROJECT_ROOT/my/client/path";
+		import { sessionKeyName } from "$houdini/runtime/lib/network";
 
 		export const load = event => {
 		    const __houdini__vite__plugin__return__value__ = ({
@@ -245,7 +245,7 @@ test('modifies existing load +layout.server.js - implicit return', async functio
 		    });
 
 		    return {
-		        ...__houdini_client__.passServerSession(event),
+		        [sessionKeyName]: event.locals[sessionKeyName],
 		        ...__houdini__vite__plugin__return__value__
 		    };
 		};

--- a/src/vite/transforms/kit/session.test.ts
+++ b/src/vite/transforms/kit/session.test.ts
@@ -15,14 +15,14 @@ test('modifies root +layout.svelte with data prop', async function () {
 
 	expect(result).toMatchInlineSnapshot(`
 		import { page } from "$app/stores";
-		import { setSession, sessionKeyName } from "$houdini/runtime/lib/network";
+		import { extractSession, setSession } from "$houdini/runtime/lib/network";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/runtime/adapter";
 		export let data;
 		onMount(() => setClientStarted());
 
 		page.subscribe(val => {
-		    setSession(val.data[sessionKeyName]);
+		    setSession(extractSession(val.data));
 		});
 	`)
 })
@@ -33,13 +33,13 @@ test('modifies root +layout.svelte without data prop', async function () {
 
 	expect(result).toMatchInlineSnapshot(`
 		import { page } from "$app/stores";
-		import { setSession, sessionKeyName } from "$houdini/runtime/lib/network";
+		import { extractSession, setSession } from "$houdini/runtime/lib/network";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/runtime/adapter";
 		onMount(() => setClientStarted());
 
 		page.subscribe(val => {
-		    setSession(val.data[sessionKeyName]);
+		    setSession(extractSession(val.data));
 		});
 	`)
 })
@@ -48,13 +48,13 @@ test('adds load to +layout.server.js', async function () {
 	const result = await test_transform_js('src/routes/+layout.server.js', ``)
 
 	expect(result).toMatchInlineSnapshot(`
-		import { sessionKeyName } from "$houdini/runtime/lib/network";
+		import { buildSessionObject } from "$houdini/runtime/lib/network";
 
 		export async function load(event) {
 		    const __houdini__vite__plugin__return__value__ = {};
 
 		    return {
-		        [sessionKeyName]: event.locals[sessionKeyName],
+		        ...buildSessionObject(event),
 		        ...__houdini__vite__plugin__return__value__
 		    };
 		}
@@ -76,7 +76,7 @@ test('modifies existing load +layout.server.js', async function () {
 	)
 
 	expect(result).toMatchInlineSnapshot(`
-		import { sessionKeyName } from "$houdini/runtime/lib/network";
+		import { buildSessionObject } from "$houdini/runtime/lib/network";
 
 		export async function load(event) {
 		    "some random stuff that's valid javascript";
@@ -85,7 +85,7 @@ test('modifies existing load +layout.server.js', async function () {
 		    };
 
 		    return {
-		        [sessionKeyName]: event.locals[sessionKeyName],
+		        ...buildSessionObject(event),
 		        ...__houdini__vite__plugin__return__value__
 		    };
 		}
@@ -103,14 +103,14 @@ test('modifies existing load +layout.server.js - no return', async function () {
 	)
 
 	expect(result).toMatchInlineSnapshot(`
-		import { sessionKeyName } from "$houdini/runtime/lib/network";
+		import { buildSessionObject } from "$houdini/runtime/lib/network";
 
 		export async function load(event) {
 		    "some random stuff that's valid javascript";
 		    const __houdini__vite__plugin__return__value__ = {};
 
 		    return {
-		        [sessionKeyName]: event.locals[sessionKeyName],
+		        ...buildSessionObject(event),
 		        ...__houdini__vite__plugin__return__value__
 		    };
 		}
@@ -131,7 +131,7 @@ test('modifies existing load +layout.server.js - rest params', async function ()
 	)
 
 	expect(result).toMatchInlineSnapshot(`
-		import { sessionKeyName } from "$houdini/runtime/lib/network";
+		import { buildSessionObject } from "$houdini/runtime/lib/network";
 
 		export async function load(event) {
 		    let {
@@ -147,7 +147,7 @@ test('modifies existing load +layout.server.js - rest params', async function ()
 		    };
 
 		    return {
-		        [sessionKeyName]: event.locals[sessionKeyName],
+		        ...buildSessionObject(event),
 		        ...__houdini__vite__plugin__return__value__
 		    };
 		}
@@ -168,7 +168,7 @@ test('modifies existing load +layout.server.js - const arrow function', async fu
 	)
 
 	expect(result).toMatchInlineSnapshot(`
-		import { sessionKeyName } from "$houdini/runtime/lib/network";
+		import { buildSessionObject } from "$houdini/runtime/lib/network";
 
 		export const load = event => {
 		    let {
@@ -184,7 +184,7 @@ test('modifies existing load +layout.server.js - const arrow function', async fu
 		    };
 
 		    return {
-		        [sessionKeyName]: event.locals[sessionKeyName],
+		        ...buildSessionObject(event),
 		        ...__houdini__vite__plugin__return__value__
 		    };
 		};
@@ -205,7 +205,7 @@ test('modifies existing load +layout.server.js - const function', async function
 	)
 
 	expect(result).toMatchInlineSnapshot(`
-		import { sessionKeyName } from "$houdini/runtime/lib/network";
+		import { buildSessionObject } from "$houdini/runtime/lib/network";
 
 		export const load = function(event) {
 		    let {
@@ -221,7 +221,7 @@ test('modifies existing load +layout.server.js - const function', async function
 		    };
 
 		    return {
-		        [sessionKeyName]: event.locals[sessionKeyName],
+		        ...buildSessionObject(event),
 		        ...__houdini__vite__plugin__return__value__
 		    };
 		};
@@ -237,7 +237,7 @@ test('modifies existing load +layout.server.js - implicit return', async functio
 	)
 
 	expect(result).toMatchInlineSnapshot(`
-		import { sessionKeyName } from "$houdini/runtime/lib/network";
+		import { buildSessionObject } from "$houdini/runtime/lib/network";
 
 		export const load = event => {
 		    const __houdini__vite__plugin__return__value__ = ({
@@ -245,7 +245,7 @@ test('modifies existing load +layout.server.js - implicit return', async functio
 		    });
 
 		    return {
-		        [sessionKeyName]: event.locals[sessionKeyName],
+		        ...buildSessionObject(event),
 		        ...__houdini__vite__plugin__return__value__
 		    };
 		};

--- a/src/vite/transforms/kit/session.ts
+++ b/src/vite/transforms/kit/session.ts
@@ -21,9 +21,9 @@ export default function (page: TransformPage) {
 		return
 	}
 
-	const session_key_name = ensure_imports({
+	const build_session_object = ensure_imports({
 		page,
-		import: ['sessionKeyName'],
+		import: ['buildSessionObject'],
 		sourceModule: '$houdini/runtime/lib/network',
 	}).ids[0]
 
@@ -116,22 +116,15 @@ export default function (page: TransformPage) {
 		AST.variableDeclarator(local_return_var, return_statement.argument),
 	])
 
-	const sessionProperty = AST.objectProperty(
-		session_key_name,
-		AST.memberExpression(
-			AST.memberExpression(event_id, AST.identifier('locals')),
-			session_key_name,
-			true
-		)
-	)
-	sessionProperty.computed = true
-
 	// its safe to insert a return statement after the declaration that references event
 	body.body.splice(
 		return_statement_index + 1,
 		0,
 		AST.returnStatement(
-			AST.objectExpression([sessionProperty, AST.spreadElement(local_return_var)])
+			AST.objectExpression([
+				AST.spreadElement(AST.callExpression(build_session_object, [event_id])),
+				AST.spreadElement(local_return_var),
+			])
 		)
 	)
 }


### PR DESCRIPTION
Holy cow, so many exciting updates :joy: Thanks @AlecAivazis for pushing the auth/session stuff to the finish :tada: 

Houdini nagged me to always set a session (otherwise it claims there is an error during `passServerSession`) even though the user is not authenticated. Instead of just `houdini.setSession(undefined)` I decided to clean this up and move the check to the usage of `session` in the fetch function. I found no easy way to test this without creating another testing app that does not set the session but I verified the behavior locally.

I also fixed a bug where the session data was not correctly extracted from `$page.data`. And debatable: I inlined the `passServerSession` method to prevent user confusion.


### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

