### PR TITLE
Fix unsubscribing inside `load` breaks updates from mutations

### DIFF
--- a/.changeset/rotten-peaches-lie.md
+++ b/.changeset/rotten-peaches-lie.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix unsubscribing inside `load` functions

--- a/integration/api/graphql.mjs
+++ b/integration/api/graphql.mjs
@@ -35,6 +35,8 @@ function getSnapshot(snapshot) {
   return snapshots[snapshot];
 }
 
+let mutationUpdateFragmentDataCounter = 0;
+
 export const resolvers = {
   Query: {
     hello: () => {
@@ -87,7 +89,8 @@ export const resolvers = {
         ...user,
         __typename: 'User'
       };
-    }
+    },
+    mutationUpdateFragmentData: () => ({})
   },
 
   User: {
@@ -132,7 +135,16 @@ export const resolvers = {
         list[userIndex].name = args.name;
       }
       return list[userIndex];
+    },
+    mutationUpdateFragmentInc: () => {
+      mutationUpdateFragmentDataCounter++;
+
+      return {};
     }
+  },
+
+  MutationUpdateFragmentData: {
+    data: () => mutationUpdateFragmentDataCounter
   },
 
   DateTime: new GraphQLScalarType({

--- a/integration/api/graphql.mjs
+++ b/integration/api/graphql.mjs
@@ -144,6 +144,7 @@ export const resolvers = {
   },
 
   MutationUpdateFragmentData: {
+    id: () => 4812,
     data: () => mutationUpdateFragmentDataCounter
   },
 

--- a/integration/api/schema.graphql
+++ b/integration/api/schema.graphql
@@ -27,6 +27,7 @@ type Mutation {
 }
 
 type MutationUpdateFragmentData {
+  id: ID!
   data: Int!
 }
 

--- a/integration/api/schema.graphql
+++ b/integration/api/schema.graphql
@@ -23,6 +23,11 @@ type Mutation {
     types: [TypeOfUser!]
   ): User!
   updateUser(id: ID!, name: String, snapshot: String!, birthDate: DateTime, delay: Int): User!
+  mutationUpdateFragmentInc: MutationUpdateFragmentData!
+}
+
+type MutationUpdateFragmentData {
+  data: Int!
 }
 
 interface Node {
@@ -49,6 +54,7 @@ type Query {
   ): UserConnection!
   usersList(limit: Int = 4, offset: Int, snapshot: String!): [User!]!
   session: String
+  mutationUpdateFragmentData: MutationUpdateFragmentData!
 }
 
 type User implements Node {

--- a/integration/src/lib/utils/routes.ts
+++ b/integration/src/lib/utils/routes.ts
@@ -8,6 +8,7 @@ export const routes = {
   Stores_Prefetch_UserId_2: '/stores/prefetch-2',
   Stores_Mutation: '/stores/mutation',
   Stores_Mutation_Update: '/stores/mutation-update',
+  Stores_Mutation_Update_Fragment: '/stores/mutation-update-fragment',
   Stores_Mutation_Scalars: '/stores/mutation-scalars',
   Stores_Mutation_Enums: '/stores/mutation-enums',
   Stores_Network_One_Store_Multivariables: '/stores/network-one-store-multivariables',

--- a/integration/src/routes/stores/mutation-update-fragment/+page.svelte
+++ b/integration/src/routes/stores/mutation-update-fragment/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { graphql,MutationUpdateFragmentIncStore } from '$houdini';
+  import { graphql, MutationUpdateFragmentIncStore } from '$houdini';
   import { stry } from '@kitql/helper';
   import type { PageData } from './$types';
   import Component from './Component.svelte';
@@ -15,6 +15,8 @@
       }
     }
   `;
+
+  $: pageCounter = ($MutationUpdateFragment.data?.mutationUpdateFragmentData as any)?.data;
 </script>
 
 <h1>Mutation update with fragment</h1>
@@ -23,10 +25,8 @@
 
 <p>Data (<code>+page.svelte</code>):</p>
 <pre>{stry($MutationUpdateFragment)}</pre>
+<p>Counter (<code>+page.svelte</code>): <span id="counter-page">{pageCounter}</span></p>
 
-<p>Data (component):</p>
 {#if $MutationUpdateFragment.data?.mutationUpdateFragmentData}
   <Component data={$MutationUpdateFragment.data.mutationUpdateFragmentData} />
-{:else}
-  <pre>-</pre>
 {/if}

--- a/integration/src/routes/stores/mutation-update-fragment/+page.svelte
+++ b/integration/src/routes/stores/mutation-update-fragment/+page.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { graphql,MutationUpdateFragmentIncStore } from '$houdini';
+  import { stry } from '@kitql/helper';
+  import type { PageData } from './$types';
+  import Component from './Component.svelte';
+
+  export let data: PageData;
+
+  $: ({ MutationUpdateFragment } = data);
+
+  const increment: MutationUpdateFragmentIncStore = graphql`
+    mutation MutationUpdateFragmentInc {
+      mutationUpdateFragmentInc {
+        ...MutationUpdateFragmentFragment
+      }
+    }
+  `;
+</script>
+
+<h1>Mutation update with fragment</h1>
+
+<button on:click={() => increment.mutate(null)}>Increment counter</button>
+
+<p>Data (<code>+page.svelte</code>):</p>
+<pre>{stry($MutationUpdateFragment)}</pre>
+
+<p>Data (component):</p>
+{#if $MutationUpdateFragment.data?.mutationUpdateFragmentData}
+  <Component data={$MutationUpdateFragment.data.mutationUpdateFragmentData} />
+{:else}
+  <pre>-</pre>
+{/if}

--- a/integration/src/routes/stores/mutation-update-fragment/+page.ts
+++ b/integration/src/routes/stores/mutation-update-fragment/+page.ts
@@ -1,0 +1,16 @@
+import { graphql, load_MutationUpdateFragment } from '$houdini';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async (event) => {
+  return {
+    ...(await load_MutationUpdateFragment({ event }))
+  };
+};
+
+graphql`
+  query MutationUpdateFragment {
+    mutationUpdateFragmentData {
+      ...MutationUpdateFragmentFragment
+    }
+  }
+`;

--- a/integration/src/routes/stores/mutation-update-fragment/+page.ts
+++ b/integration/src/routes/stores/mutation-update-fragment/+page.ts
@@ -2,8 +2,13 @@ import { graphql, load_MutationUpdateFragment } from '$houdini';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async (event) => {
+  const result = await load_MutationUpdateFragment({ event, blocking: true });
+
+  const unsub = result.MutationUpdateFragment.subscribe(() => {});
+  unsub();
+
   return {
-    ...(await load_MutationUpdateFragment({ event }))
+    ...result
   };
 };
 

--- a/integration/src/routes/stores/mutation-update-fragment/Component.svelte
+++ b/integration/src/routes/stores/mutation-update-fragment/Component.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { fragment, graphql, type MutationUpdateFragmentFragment } from '$houdini';
+  import { stry } from '@kitql/helper';
+
+  export let data: MutationUpdateFragmentFragment;
+
+  $: fragmentData = fragment(
+    data,
+    graphql`
+      fragment MutationUpdateFragmentFragment on MutationUpdateFragmentData {
+        data
+      }
+    `
+  );
+</script>
+
+<pre>{stry($fragmentData)}</pre>

--- a/integration/src/routes/stores/mutation-update-fragment/Component.svelte
+++ b/integration/src/routes/stores/mutation-update-fragment/Component.svelte
@@ -14,4 +14,6 @@
   );
 </script>
 
+<p>Data (component):</p>
 <pre>{stry($fragmentData)}</pre>
+<p>Counter (component): <span id="counter-component">{$fragmentData.data}</span></p>

--- a/integration/src/routes/stores/mutation-update-fragment/spec.ts
+++ b/integration/src/routes/stores/mutation-update-fragment/spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+import { routes } from '../../../lib/utils/routes.js';
+import { expect_1_gql, goto } from '../../../lib/utils/testsHelper.js';
+
+test.describe('Mutation Update Fragment Page', () => {
+  test('Right Data, update', async ({ page }) => {
+    await goto(page, routes.Stores_Mutation_Update_Fragment);
+
+    const pageCounter = page.locator('#counter-page');
+    const componentCounter = page.locator('#counter-component');
+
+    // 1 Right initial data
+    expect(await pageCounter.textContent(), 'initial page counter').toBe('0');
+    expect(await componentCounter.textContent(), 'initial page counter').toBe('0');
+
+    // 2 Updated data
+    // 2.1 One request should happen
+    await expect_1_gql(page, 'button');
+
+    // 2.2 Right incremented data
+    expect(await pageCounter.textContent(), 'incremented page counter').toBe('1');
+    expect(await componentCounter.textContent(), 'incremented page counter').toBe('1');
+  });
+});

--- a/src/runtime/stores/query.ts
+++ b/src/runtime/stores/query.ts
@@ -175,7 +175,7 @@ If this is leftovers from old versions of houdini, you can safely remove this \`
 			// or when there is still an active subscriber
 			if (this.subscriberCount <= 0) {
 				// clean up any cache subscriptions
-				if (isBrowser && this.subscriptionSpec) {
+				if (clientStarted && isBrowser && this.subscriptionSpec) {
 					cache.unsubscribe(this.subscriptionSpec, this.lastVariables || {})
 				}
 


### PR DESCRIPTION
Fixes https://github.com/HoudiniGraphql/houdini/discussions/475#discussioncomment-3478273

Well this :arrow_up: and the title are ~kind of a stretch because this does not yet fix anything but displays the problem~ now actually the truth :tada:.

What is missing in the comment linked above is that I'm `get($store).data` inside the route `load` function. `get()` from `svelte/stores` subscribes to a store, assigns the data to a variable and immediately unsubscribes. I recreated this logic inside the `load` function here.

In the integration app at `http://127.0.0.1:5173/stores/mutation-update-fragment` a press on the button should increment the counter. But this is only happening after reloading the page.
If you comment the unsubscribe call inside the `load` function everything is working as expected.

I guess the problem lies in `QueryStore.subscribe` or rather the returned unsubscribe handler. Probably this part https://github.com/HoudiniGraphql/houdini/blob/a8b33c11ef91754561f339d289360cdb7126625d/src/runtime/stores/query.ts#L176-L185 But haven't confirmed as I wanted to report this first.

It was actually the problem. Now we only unsub from the cache on the client to respect the comment `// don't clear the store state on the server (breaks SSR)`.


### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

