### PR TITLE
pass all of server.js data from root layout

### DIFF
--- a/.changeset/neat-jokes-lick.md
+++ b/.changeset/neat-jokes-lick.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+fix a bug hiding +layout.server data from client

--- a/src/vite/transforms/kit/load.test.ts
+++ b/src/vite/transforms/kit/load.test.ts
@@ -1010,7 +1010,7 @@ test('layout loads', async function () {
 		    };
 
 		    return {
-		        __houdini__session__: context.data?.__houdini__session__,
+		        ...context.data,
 		        ...__houdini__vite__plugin__return__value__
 		    };
 		}
@@ -1095,7 +1095,7 @@ test('layout inline query', async function () {
 		    };
 
 		    return {
-		        __houdini__session__: context.data?.__houdini__session__,
+		        ...context.data,
 		        ...__houdini__vite__plugin__return__value__
 		    };
 		}

--- a/src/vite/transforms/kit/session.test.ts
+++ b/src/vite/transforms/kit/session.test.ts
@@ -260,7 +260,7 @@ test('passes session from root client-side layout', async function () {
 		    const __houdini__vite__plugin__return__value__ = {};
 
 		    return {
-		        __houdini__session__: event.data?.__houdini__session__,
+		        ...event.data,
 		        ...__houdini__vite__plugin__return__value__
 		    };
 		}

--- a/src/vite/transforms/kit/session.ts
+++ b/src/vite/transforms/kit/session.ts
@@ -44,13 +44,7 @@ function process_root_layout_server(page: TransformPage) {
 // threading the value through the return
 function process_root_layout_script(page: TransformPage) {
 	add_load_return(page, (event_id) => [
-		AST.objectProperty(
-			AST.identifier('__houdini__session__'),
-			AST.optionalMemberExpression(
-				AST.memberExpression(event_id, AST.identifier('data')),
-				AST.identifier('__houdini__session__')
-			)
-		),
+		AST.spreadElement(AST.memberExpression(event_id, AST.identifier('data'))),
 	])
 }
 


### PR DESCRIPTION
Fixes #544 

This PR fixes an issue introduced in #542 that hid the data returned from `+layout.server.js` 

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
  -  this is tricky because we also want a test that we are able to fake the file if it doesn't exist. I'm opting to leave things how they are now since the changes are pretty clear 
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

