### PR TITLE
Fix error when unsubscribing from cache between fetch and render

### DIFF
--- a/.changeset/tidy-foxes-melt.md
+++ b/.changeset/tidy-foxes-melt.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix bug when unsubscribing between load and render

--- a/integration/src/routes/stores/mutation-update/+page.svelte
+++ b/integration/src/routes/stores/mutation-update/+page.svelte
@@ -1,16 +1,13 @@
 <script lang="ts">
-  import { GQL_UpdateUser, graphql, MutationUpdateUsersListStore } from '$houdini';
+  import { GQL_UpdateUser, graphql } from '$houdini';
   import { stry } from '@kitql/helper';
+  import type { PageData } from './$types';
 
-  const usersList: MutationUpdateUsersListStore = graphql`
-    query MutationUpdateUsersList {
-      usersList(limit: 5, snapshot: "update-user-mutation") {
-        id
-        name
-        ...UserInfo
-      }
-    }
-  `;
+  export let data: PageData;
+
+  // leave this awkward pattern to make sure this doesn't come back: https://github.com/HoudiniGraphql/houdini/issues/543
+  let { TestMutationUpdateUsersList } = data;
+  $: ({ TestMutationUpdateUsersList } = data);
 
   async function update() {
     await GQL_UpdateUser.mutate({
@@ -32,7 +29,7 @@
 <button id="revert" on:click={revert}>Reset User</button>
 
 <ul>
-  {#each $usersList.data?.usersList ?? [] as user}
+  {#each $TestMutationUpdateUsersList.data?.usersList ?? [] as user}
     <li>
       {user.id} - {user.name}
     </li>

--- a/integration/src/routes/stores/mutation-update/+page.ts
+++ b/integration/src/routes/stores/mutation-update/+page.ts
@@ -1,0 +1,18 @@
+import { graphql, load_TestMutationUpdateUsersList } from '$houdini';
+import type { LoadEvent } from '@sveltejs/kit';
+
+export async function load(event: LoadEvent) {
+  return {
+    ...(await load_TestMutationUpdateUsersList({ event }))
+  };
+}
+
+graphql`
+  query TestMutationUpdateUsersList {
+    usersList(limit: 5, snapshot: "update-user-mutation") {
+      id
+      name
+      ...UserInfo
+    }
+  }
+`;

--- a/src/runtime/stores/query.ts
+++ b/src/runtime/stores/query.ts
@@ -166,6 +166,11 @@ If this is leftovers from old versions of houdini, you can safely remove this \`
 		// we have a new subscriber
 		this.subscriberCount = (this.subscriberCount ?? 0) + 1
 
+		// make sure that the store is always listening to the cache (on the browser)
+		if (isBrowser && !this.subscriptionSpec) {
+			this.refreshSubscription(this.lastVariables!)
+		}
+
 		// Handle unsubscribe
 		return () => {
 			// we lost a subscriber

--- a/src/runtime/stores/query.ts
+++ b/src/runtime/stores/query.ts
@@ -168,7 +168,7 @@ If this is leftovers from old versions of houdini, you can safely remove this \`
 
 		// make sure that the store is always listening to the cache (on the browser)
 		if (isBrowser && !this.subscriptionSpec) {
-			this.refreshSubscription(this.lastVariables!)
+			this.refreshSubscription(this.lastVariables ?? ({} as _Input))
 		}
 
 		// Handle unsubscribe


### PR DESCRIPTION
Fixes #543 

This was a good find @fehnomenal! Turns out if unsubscribe ran after `fetch` we were left with no subscription to the cache

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

