### PR TITLE
mix config headers when pulling schema

### DIFF
--- a/.changeset/fast-timers-allow.md
+++ b/.changeset/fast-timers-allow.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Configured pull headers are included in pull-schema command

--- a/src/cmd/pullSchema.ts
+++ b/src/cmd/pullSchema.ts
@@ -16,7 +16,7 @@ export default async function (args: { headers: string[] }) {
 	// The target path -> current working directory by default. Should we allow passing custom paths?
 	const targetPath = process.cwd()
 
-	let headers = {}
+	let headers = config.pullHeaders
 	let headerStrings: string[] = []
 
 	if (args.headers) {
@@ -29,7 +29,7 @@ export default async function (args: { headers: string[] }) {
 				...total,
 				[key]: value,
 			}
-		}, {})
+		}, headers)
 	}
 
 	// Write the schema

--- a/src/cmd/pullSchema.ts
+++ b/src/cmd/pullSchema.ts
@@ -8,9 +8,10 @@ export default async function (args: { headers: string[] }) {
 
 	// Check if apiUrl is set in config
 	if (!config.apiUrl) {
-		throw new Error(
+		console.log(
 			'❌ Your project does not have a remote endpoint configured. Please provide one with the `apiUrl` value in your houdini.config.js file.'
 		)
+		return
 	}
 
 	// The target path -> current working directory by default. Should we allow passing custom paths?

--- a/src/cmd/pullSchema.ts
+++ b/src/cmd/pullSchema.ts
@@ -11,6 +11,7 @@ export default async function (args: { headers: string[] }) {
 		console.log(
 			'❌ Your project does not have a remote endpoint configured. Please provide one with the `apiUrl` value in your houdini.config.js file.'
 		)
+		process.exit(1)
 		return
 	}
 


### PR DESCRIPTION
Fixes #549 

This PR fixes an issue that was preventing the configured pull headers from being included when using the `pull-schema` command

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] ~If applicable, add a test that would fail without this fix~
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

