### PR TITLE
throw if can not import config file

### DIFF
--- a/.changeset/itchy-sheep-build.md
+++ b/.changeset/itchy-sheep-build.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Warn user when the config file can't be read

--- a/src/common/__mocks__/config.invalid.mock
+++ b/src/common/__mocks__/config.invalid.mock
@@ -1,0 +1,6 @@
+const config = {
+    client: malformed
+  };
+  
+export default config;
+  

--- a/src/common/config.test.ts
+++ b/src/common/config.test.ts
@@ -1,0 +1,13 @@
+import { test, describe, expect } from 'vitest'
+
+import { readConfigFile } from './config'
+
+describe('loadConfifg', function () {
+	test('handles malformed config file', async () => {
+		const INVALID_CONFIG = '__mocks__/config.invalid.mock'
+
+		await expect(async () => {
+			await readConfigFile(INVALID_CONFIG)
+		}).rejects.toThrowError(`Could not load config`)
+	})
+})

--- a/src/common/config.test.ts
+++ b/src/common/config.test.ts
@@ -2,7 +2,7 @@ import { test, describe, expect } from 'vitest'
 
 import { readConfigFile } from './config'
 
-describe('loadConfifg', function () {
+describe('loadConfig', function () {
 	test('handles malformed config file', async () => {
 		const INVALID_CONFIG = '__mocks__/config.invalid.mock'
 

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -867,7 +867,7 @@ export async function readConfigFile(
 	try {
 		imported =  await import(importPath)
 	} catch (e: any) {
-		throw new Error(`Could not load config file at ${configPath}.\n${e.message}`)
+		throw new Error(`Could not load config file at file://${configPath}.\n${e.message}`)
 	}
 
 	// if this is wrapped in a default, use it

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -863,9 +863,9 @@ export async function readConfigFile(
 		importPath = 'file:///' + importPath
 	}
 
-	let imported: any;
+	let imported: any
 	try {
-		imported =  await import(importPath)
+		imported = await import(importPath)
 	} catch (e: any) {
 		throw new Error(`Could not load config file at file://${configPath}.\n${e.message}`)
 	}

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -863,7 +863,12 @@ export async function readConfigFile(
 		importPath = 'file:///' + importPath
 	}
 
-	const imported = await import(importPath)
+	let imported: any;
+	try {
+		imported =  await import(importPath)
+	} catch (e: any) {
+		throw new Error(`Could not load config file at ${configPath}.\n${e.message}`)
+	}
 
 	// if this is wrapped in a default, use it
 	const config = imported.default || imported


### PR DESCRIPTION
Fixes #562

Will throw a usable error when the config file is malformed like:

```
Error: Could not load config file at file:///path-to/houdini.config.js.
Unexpected identifier
     at readConfigFile (file:///Users/danielhritcu/GitHub/houdini/build/vite-esm/index.js:156721:15)
     ...
```

Instead of the generic
```
SyntaxError: Unexpected identifier
    at ESMLoader.moduleStrategy (node:internal/modules/esm/translators:119:18)
    at ESMLoader.moduleProvider (node:internal/modules/esm/loader:469:14)
    at async link (node:internal/modules/esm/module_job:67:21)
```

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

