### PR TITLE
Change signature of schema to enable extraConfig when pulling

### DIFF
--- a/.changeset/mean-mice-help.md
+++ b/.changeset/mean-mice-help.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Format Prettier

--- a/.changeset/short-jeans-roll.md
+++ b/.changeset/short-jeans-roll.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Change signature of schema function in vite plugin to enable extra config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
     .:
@@ -108,7 +108,7 @@ importers:
             '@rollup/plugin-node-resolve': 13.3.0_rollup@2.68.0
             '@rollup/plugin-replace': 4.0.0_rollup@2.68.0
             '@sveltejs/kit': 1.0.0-next.445_svelte@3.49.0+vite@3.0.9
-            '@theguild/eslint-config': 0.0.1_eslint@8.23.0+typescript@4.7.4
+            '@theguild/eslint-config': 0.0.1_sorwav4hsh5vncerguqybud76i
             '@trivago/prettier-plugin-sort-imports': 3.3.0_prettier@2.7.1
             '@types/fs-extra': 9.0.13
             '@types/glob': 7.2.0
@@ -142,8 +142,8 @@ importers:
             pretty-quick: 3.1.3_prettier@2.7.1
             prompts: 2.4.2
             rollup: 2.68.0
-            rollup-plugin-typescript2: 0.31.2_rollup@2.68.0+typescript@4.7.4
-            ts-jest: 26.5.6_jest@26.6.3+typescript@4.7.4
+            rollup-plugin-typescript2: 0.31.2_jrqhcdvvfzmrsc4z5p6zs2uiwy
+            ts-jest: 26.5.6_rnfpnlbz3wqspag7uftsmccrvy
             ts-node: 9.1.1_typescript@4.7.4
             tslib: 2.4.0
             typescript: 4.7.4
@@ -177,7 +177,7 @@ importers:
             graphql: 15.5.0
             houdini: link:..
             svelte: 3.49.0
-            svelte-preprocess: 4.10.7_8865006ef6c5ca9c2621594fcc5b0f9f
+            svelte-preprocess: 4.10.7_uslzfc62di2n2otc2tvfklnwji
             tslib: 2.4.0
             typescript: 4.7.4
             vite: 3.0.9
@@ -224,20 +224,20 @@ importers:
             '@replayio/playwright': 0.2.23_@playwright+test@1.25.0
             '@sveltejs/adapter-auto': 1.0.0-next.66
             '@sveltejs/kit': 1.0.0-next.481_svelte@3.49.0+vite@3.1.0
-            '@typescript-eslint/eslint-plugin': 5.35.1_3e381c73f64a66ea3e0ad47e9c76e5d1
-            '@typescript-eslint/parser': 5.35.1_eslint@8.23.0+typescript@4.6.4
+            '@typescript-eslint/eslint-plugin': 5.35.1_hy4by47wjjtoupqk2r7jy5xf2e
+            '@typescript-eslint/parser': 5.35.1_pyvvhc3zqdua4akflcggygkl44
             concurrently: 7.1.0
             cross-env: 7.0.3
             eslint: 8.23.0
             eslint-config-prettier: 8.5.0_eslint@8.23.0
-            eslint-plugin-svelte3: 4.0.0_eslint@8.23.0+svelte@3.49.0
+            eslint-plugin-svelte3: 4.0.0_sfdub7vxhxkt5wmgvhhmmgyu2e
             graphql: 15.5.0
             houdini: link:..
             prettier: 2.7.1
-            prettier-plugin-svelte: 2.7.0_prettier@2.7.1+svelte@3.49.0
+            prettier-plugin-svelte: 2.7.0_o3ioganyptcsrh6x4hnxvjkpqi
             svelte: 3.49.0
-            svelte-check: 2.8.1_c3e56b326347f79cbefa7b54654977f5
-            svelte-preprocess: 4.10.7_280a73da7875c18e2397c4f760f243fd
+            svelte-check: 2.8.1_svelte@3.49.0
+            svelte-preprocess: 4.10.7_ueozcsexptisi2awlbuwt6eqmq
             tslib: 2.4.0
             typescript: 4.6.4
             vite: 3.1.0
@@ -284,20 +284,20 @@ importers:
             prismjs: 1.29.0
             rehype-autolink-headings: 6.1.1
             rehype-slug: 5.0.1
-            svelte-preprocess: 4.10.7_bcee8d2d2825c991128217423905a22e
+            svelte-preprocess: 4.10.7_vg3dtoa6m5cwrgayrz5b3xtqh4
             vite-plugin-replace: 0.1.1_vite@3.0.9
         devDependencies:
-            '@typescript-eslint/eslint-plugin': 5.35.1_36ed1c84a055476afaa601b60019bc92
-            '@typescript-eslint/parser': 5.35.1_eslint@8.23.0+typescript@4.5.4
+            '@typescript-eslint/eslint-plugin': 5.35.1_g3wrzbfakvdwv6vgag3aagn4si
+            '@typescript-eslint/parser': 5.35.1_svqrduhulcrphxzql7zpeoisfy
             eslint: 8.23.0
             eslint-config-prettier: 8.5.0_eslint@8.23.0
-            eslint-plugin-svelte3: 4.0.0_eslint@8.23.0+svelte@3.49.0
+            eslint-plugin-svelte3: 4.0.0_sfdub7vxhxkt5wmgvhhmmgyu2e
             husky: 7.0.4
             lint-staged: 12.5.0
             prettier: 2.7.1
-            prettier-plugin-svelte: 2.7.0_prettier@2.7.1+svelte@3.49.0
+            prettier-plugin-svelte: 2.7.0_o3ioganyptcsrh6x4hnxvjkpqi
             svelte: 3.49.0
-            svelte-check: 2.8.1_c3e56b326347f79cbefa7b54654977f5
+            svelte-check: 2.8.1_svelte@3.49.0
             svelte-kit-cookie-session: 3.0.6
             tslib: 2.4.0
             typescript: 4.5.4
@@ -2319,7 +2319,7 @@ packages:
             '@envelop/types': 2.3.1_graphql@15.5.0
             graphql: 15.5.0
 
-    /@envelop/parser-cache/4.6.0_116b5e51298b3580e1b5ec2e4f035c9a:
+    /@envelop/parser-cache/4.6.0_cfvv4ujjrm2ybynv5qxe6a24ti:
         resolution:
             {
                 integrity: sha512-Oi3nX76tk5L7K6MdpPr4AjtpMW1XoyISeiaodYD8WxUWY7JzOA7qetuYguUZv/lK5VaLMsJuoWAwxbu1JKEe9A==,
@@ -2342,7 +2342,7 @@ packages:
         dependencies:
             graphql: 15.5.0
 
-    /@envelop/validation-cache/4.6.0_116b5e51298b3580e1b5ec2e4f035c9a:
+    /@envelop/validation-cache/4.6.0_cfvv4ujjrm2ybynv5qxe6a24ti:
         resolution:
             {
                 integrity: sha512-Xn5u/tQHid6GzWDenCJkIn5GsDm2fUCNnAudN1BGjXcRvAEFfTHuchpp1PJxvRAqGdYjznng+NkOcqrP5brQrw==,
@@ -2465,8 +2465,8 @@ packages:
             graphql: ^15.2.0 || ^16.0.0
         dependencies:
             '@envelop/core': 2.5.0_graphql@15.5.0
-            '@envelop/parser-cache': 4.6.0_116b5e51298b3580e1b5ec2e4f035c9a
-            '@envelop/validation-cache': 4.6.0_116b5e51298b3580e1b5ec2e4f035c9a
+            '@envelop/parser-cache': 4.6.0_cfvv4ujjrm2ybynv5qxe6a24ti
+            '@envelop/validation-cache': 4.6.0_cfvv4ujjrm2ybynv5qxe6a24ti
             '@graphql-tools/schema': 8.5.1_graphql@15.5.0
             '@graphql-tools/utils': 8.10.0_graphql@15.5.0
             '@graphql-typed-document-node/core': 3.1.1_graphql@15.5.0
@@ -3023,7 +3023,6 @@ packages:
             {
                 integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==,
             }
-        dev: true
 
     /@repeaterjs/repeater/3.0.4:
         resolution:
@@ -3444,7 +3443,7 @@ packages:
             - supports-color
         dev: true
 
-    /@theguild/eslint-config/0.0.1_eslint@8.23.0+typescript@4.7.4:
+    /@theguild/eslint-config/0.0.1_sorwav4hsh5vncerguqybud76i:
         resolution:
             {
                 integrity: sha512-VnvXqU+xqPI9UXNR4T3Ii/EHYc49Ltk4vExPd726hAsQIXcJlLtVMOxGqJXaUcZgiiaqMVCH6B7Ns6+lp5fa7A==,
@@ -3453,11 +3452,11 @@ packages:
             eslint: ^8
         dependencies:
             '@rushstack/eslint-patch': 1.1.4
-            '@typescript-eslint/eslint-plugin': 5.35.1_9ee15843f434f89835d0a3adcc936f96
-            '@typescript-eslint/parser': 5.35.1_eslint@8.23.0+typescript@4.7.4
+            '@typescript-eslint/eslint-plugin': 5.35.1_t3qvqq7ugt4jqnoquow4ze3psy
+            '@typescript-eslint/parser': 5.35.1_sorwav4hsh5vncerguqybud76i
             eslint: 8.23.0
             eslint-config-prettier: 8.5.0_eslint@8.23.0
-            eslint-plugin-import: 2.26.0_eslint@8.23.0
+            eslint-plugin-import: 2.26.0_kavhtzjob4obuugpatbfgsyfbm
             eslint-plugin-promise: 6.0.1_eslint@8.23.0
             eslint-plugin-sonarjs: 0.13.0_eslint@8.23.0
             eslint-plugin-unicorn: 42.0.0_eslint@8.23.0
@@ -3467,6 +3466,8 @@ packages:
             eslint-plugin-react: 7.31.1_eslint@8.23.0
             eslint-plugin-react-hooks: 4.6.0_eslint@8.23.0
         transitivePeerDependencies:
+            - eslint-import-resolver-typescript
+            - eslint-import-resolver-webpack
             - supports-color
             - typescript
         dev: true
@@ -3864,7 +3865,7 @@ packages:
             '@types/yargs-parser': 21.0.0
         dev: true
 
-    /@typescript-eslint/eslint-plugin/5.35.1_36ed1c84a055476afaa601b60019bc92:
+    /@typescript-eslint/eslint-plugin/5.35.1_g3wrzbfakvdwv6vgag3aagn4si:
         resolution:
             {
                 integrity: sha512-RBZZXZlI4XCY4Wzgy64vB+0slT9+yAPQRjj/HSaRwUot33xbDjF1oN9BLwOLTewoOI0jothIltZRe9uJCHf8gg==,
@@ -3878,10 +3879,10 @@ packages:
             typescript:
                 optional: true
         dependencies:
-            '@typescript-eslint/parser': 5.35.1_eslint@8.23.0+typescript@4.5.4
+            '@typescript-eslint/parser': 5.35.1_svqrduhulcrphxzql7zpeoisfy
             '@typescript-eslint/scope-manager': 5.35.1
-            '@typescript-eslint/type-utils': 5.35.1_eslint@8.23.0+typescript@4.5.4
-            '@typescript-eslint/utils': 5.35.1_eslint@8.23.0+typescript@4.5.4
+            '@typescript-eslint/type-utils': 5.35.1_svqrduhulcrphxzql7zpeoisfy
+            '@typescript-eslint/utils': 5.35.1_svqrduhulcrphxzql7zpeoisfy
             debug: 4.3.4
             eslint: 8.23.0
             functional-red-black-tree: 1.0.1
@@ -3894,7 +3895,7 @@ packages:
             - supports-color
         dev: true
 
-    /@typescript-eslint/eslint-plugin/5.35.1_3e381c73f64a66ea3e0ad47e9c76e5d1:
+    /@typescript-eslint/eslint-plugin/5.35.1_hy4by47wjjtoupqk2r7jy5xf2e:
         resolution:
             {
                 integrity: sha512-RBZZXZlI4XCY4Wzgy64vB+0slT9+yAPQRjj/HSaRwUot33xbDjF1oN9BLwOLTewoOI0jothIltZRe9uJCHf8gg==,
@@ -3908,10 +3909,10 @@ packages:
             typescript:
                 optional: true
         dependencies:
-            '@typescript-eslint/parser': 5.35.1_eslint@8.23.0+typescript@4.6.4
+            '@typescript-eslint/parser': 5.35.1_pyvvhc3zqdua4akflcggygkl44
             '@typescript-eslint/scope-manager': 5.35.1
-            '@typescript-eslint/type-utils': 5.35.1_eslint@8.23.0+typescript@4.6.4
-            '@typescript-eslint/utils': 5.35.1_eslint@8.23.0+typescript@4.6.4
+            '@typescript-eslint/type-utils': 5.35.1_pyvvhc3zqdua4akflcggygkl44
+            '@typescript-eslint/utils': 5.35.1_pyvvhc3zqdua4akflcggygkl44
             debug: 4.3.4
             eslint: 8.23.0
             functional-red-black-tree: 1.0.1
@@ -3924,7 +3925,7 @@ packages:
             - supports-color
         dev: true
 
-    /@typescript-eslint/eslint-plugin/5.35.1_9ee15843f434f89835d0a3adcc936f96:
+    /@typescript-eslint/eslint-plugin/5.35.1_t3qvqq7ugt4jqnoquow4ze3psy:
         resolution:
             {
                 integrity: sha512-RBZZXZlI4XCY4Wzgy64vB+0slT9+yAPQRjj/HSaRwUot33xbDjF1oN9BLwOLTewoOI0jothIltZRe9uJCHf8gg==,
@@ -3938,10 +3939,10 @@ packages:
             typescript:
                 optional: true
         dependencies:
-            '@typescript-eslint/parser': 5.35.1_eslint@8.23.0+typescript@4.7.4
+            '@typescript-eslint/parser': 5.35.1_sorwav4hsh5vncerguqybud76i
             '@typescript-eslint/scope-manager': 5.35.1
-            '@typescript-eslint/type-utils': 5.35.1_eslint@8.23.0+typescript@4.7.4
-            '@typescript-eslint/utils': 5.35.1_eslint@8.23.0+typescript@4.7.4
+            '@typescript-eslint/type-utils': 5.35.1_sorwav4hsh5vncerguqybud76i
+            '@typescript-eslint/utils': 5.35.1_sorwav4hsh5vncerguqybud76i
             debug: 4.3.4
             eslint: 8.23.0
             functional-red-black-tree: 1.0.1
@@ -3954,30 +3955,7 @@ packages:
             - supports-color
         dev: true
 
-    /@typescript-eslint/parser/5.35.1_eslint@8.23.0+typescript@4.5.4:
-        resolution:
-            {
-                integrity: sha512-XL2TBTSrh3yWAsMYpKseBYTVpvudNf69rPOWXWVBI08My2JVT5jR66eTt4IgQFHA/giiKJW5dUD4x/ZviCKyGg==,
-            }
-        engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
-        peerDependencies:
-            eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-            typescript: '*'
-        peerDependenciesMeta:
-            typescript:
-                optional: true
-        dependencies:
-            '@typescript-eslint/scope-manager': 5.35.1
-            '@typescript-eslint/types': 5.35.1
-            '@typescript-eslint/typescript-estree': 5.35.1_typescript@4.5.4
-            debug: 4.3.4
-            eslint: 8.23.0
-            typescript: 4.5.4
-        transitivePeerDependencies:
-            - supports-color
-        dev: true
-
-    /@typescript-eslint/parser/5.35.1_eslint@8.23.0+typescript@4.6.4:
+    /@typescript-eslint/parser/5.35.1_pyvvhc3zqdua4akflcggygkl44:
         resolution:
             {
                 integrity: sha512-XL2TBTSrh3yWAsMYpKseBYTVpvudNf69rPOWXWVBI08My2JVT5jR66eTt4IgQFHA/giiKJW5dUD4x/ZviCKyGg==,
@@ -4000,7 +3978,7 @@ packages:
             - supports-color
         dev: true
 
-    /@typescript-eslint/parser/5.35.1_eslint@8.23.0+typescript@4.7.4:
+    /@typescript-eslint/parser/5.35.1_sorwav4hsh5vncerguqybud76i:
         resolution:
             {
                 integrity: sha512-XL2TBTSrh3yWAsMYpKseBYTVpvudNf69rPOWXWVBI08My2JVT5jR66eTt4IgQFHA/giiKJW5dUD4x/ZviCKyGg==,
@@ -4023,6 +4001,29 @@ packages:
             - supports-color
         dev: true
 
+    /@typescript-eslint/parser/5.35.1_svqrduhulcrphxzql7zpeoisfy:
+        resolution:
+            {
+                integrity: sha512-XL2TBTSrh3yWAsMYpKseBYTVpvudNf69rPOWXWVBI08My2JVT5jR66eTt4IgQFHA/giiKJW5dUD4x/ZviCKyGg==,
+            }
+        engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+        peerDependencies:
+            eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+            typescript: '*'
+        peerDependenciesMeta:
+            typescript:
+                optional: true
+        dependencies:
+            '@typescript-eslint/scope-manager': 5.35.1
+            '@typescript-eslint/types': 5.35.1
+            '@typescript-eslint/typescript-estree': 5.35.1_typescript@4.5.4
+            debug: 4.3.4
+            eslint: 8.23.0
+            typescript: 4.5.4
+        transitivePeerDependencies:
+            - supports-color
+        dev: true
+
     /@typescript-eslint/scope-manager/5.35.1:
         resolution:
             {
@@ -4034,7 +4035,7 @@ packages:
             '@typescript-eslint/visitor-keys': 5.35.1
         dev: true
 
-    /@typescript-eslint/type-utils/5.35.1_eslint@8.23.0+typescript@4.5.4:
+    /@typescript-eslint/type-utils/5.35.1_pyvvhc3zqdua4akflcggygkl44:
         resolution:
             {
                 integrity: sha512-8xT8ljvo43Mp7BiTn1vxLXkjpw8wS4oAc00hMSB4L1/jIiYbjjnc3Qp2GAUOG/v8zsNCd1qwcqfCQ0BuishHkw==,
@@ -4047,29 +4048,7 @@ packages:
             typescript:
                 optional: true
         dependencies:
-            '@typescript-eslint/utils': 5.35.1_eslint@8.23.0+typescript@4.5.4
-            debug: 4.3.4
-            eslint: 8.23.0
-            tsutils: 3.21.0_typescript@4.5.4
-            typescript: 4.5.4
-        transitivePeerDependencies:
-            - supports-color
-        dev: true
-
-    /@typescript-eslint/type-utils/5.35.1_eslint@8.23.0+typescript@4.6.4:
-        resolution:
-            {
-                integrity: sha512-8xT8ljvo43Mp7BiTn1vxLXkjpw8wS4oAc00hMSB4L1/jIiYbjjnc3Qp2GAUOG/v8zsNCd1qwcqfCQ0BuishHkw==,
-            }
-        engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
-        peerDependencies:
-            eslint: '*'
-            typescript: '*'
-        peerDependenciesMeta:
-            typescript:
-                optional: true
-        dependencies:
-            '@typescript-eslint/utils': 5.35.1_eslint@8.23.0+typescript@4.6.4
+            '@typescript-eslint/utils': 5.35.1_pyvvhc3zqdua4akflcggygkl44
             debug: 4.3.4
             eslint: 8.23.0
             tsutils: 3.21.0_typescript@4.6.4
@@ -4078,7 +4057,7 @@ packages:
             - supports-color
         dev: true
 
-    /@typescript-eslint/type-utils/5.35.1_eslint@8.23.0+typescript@4.7.4:
+    /@typescript-eslint/type-utils/5.35.1_sorwav4hsh5vncerguqybud76i:
         resolution:
             {
                 integrity: sha512-8xT8ljvo43Mp7BiTn1vxLXkjpw8wS4oAc00hMSB4L1/jIiYbjjnc3Qp2GAUOG/v8zsNCd1qwcqfCQ0BuishHkw==,
@@ -4091,11 +4070,33 @@ packages:
             typescript:
                 optional: true
         dependencies:
-            '@typescript-eslint/utils': 5.35.1_eslint@8.23.0+typescript@4.7.4
+            '@typescript-eslint/utils': 5.35.1_sorwav4hsh5vncerguqybud76i
             debug: 4.3.4
             eslint: 8.23.0
             tsutils: 3.21.0_typescript@4.7.4
             typescript: 4.7.4
+        transitivePeerDependencies:
+            - supports-color
+        dev: true
+
+    /@typescript-eslint/type-utils/5.35.1_svqrduhulcrphxzql7zpeoisfy:
+        resolution:
+            {
+                integrity: sha512-8xT8ljvo43Mp7BiTn1vxLXkjpw8wS4oAc00hMSB4L1/jIiYbjjnc3Qp2GAUOG/v8zsNCd1qwcqfCQ0BuishHkw==,
+            }
+        engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+        peerDependencies:
+            eslint: '*'
+            typescript: '*'
+        peerDependenciesMeta:
+            typescript:
+                optional: true
+        dependencies:
+            '@typescript-eslint/utils': 5.35.1_svqrduhulcrphxzql7zpeoisfy
+            debug: 4.3.4
+            eslint: 8.23.0
+            tsutils: 3.21.0_typescript@4.5.4
+            typescript: 4.5.4
         transitivePeerDependencies:
             - supports-color
         dev: true
@@ -4180,28 +4181,7 @@ packages:
             - supports-color
         dev: true
 
-    /@typescript-eslint/utils/5.35.1_eslint@8.23.0+typescript@4.5.4:
-        resolution:
-            {
-                integrity: sha512-v6F8JNXgeBWI4pzZn36hT2HXXzoBBBJuOYvoQiaQaEEjdi5STzux3Yj8v7ODIpx36i/5s8TdzuQ54TPc5AITQQ==,
-            }
-        engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
-        peerDependencies:
-            eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-        dependencies:
-            '@types/json-schema': 7.0.11
-            '@typescript-eslint/scope-manager': 5.35.1
-            '@typescript-eslint/types': 5.35.1
-            '@typescript-eslint/typescript-estree': 5.35.1_typescript@4.5.4
-            eslint: 8.23.0
-            eslint-scope: 5.1.1
-            eslint-utils: 3.0.0_eslint@8.23.0
-        transitivePeerDependencies:
-            - supports-color
-            - typescript
-        dev: true
-
-    /@typescript-eslint/utils/5.35.1_eslint@8.23.0+typescript@4.6.4:
+    /@typescript-eslint/utils/5.35.1_pyvvhc3zqdua4akflcggygkl44:
         resolution:
             {
                 integrity: sha512-v6F8JNXgeBWI4pzZn36hT2HXXzoBBBJuOYvoQiaQaEEjdi5STzux3Yj8v7ODIpx36i/5s8TdzuQ54TPc5AITQQ==,
@@ -4222,7 +4202,7 @@ packages:
             - typescript
         dev: true
 
-    /@typescript-eslint/utils/5.35.1_eslint@8.23.0+typescript@4.7.4:
+    /@typescript-eslint/utils/5.35.1_sorwav4hsh5vncerguqybud76i:
         resolution:
             {
                 integrity: sha512-v6F8JNXgeBWI4pzZn36hT2HXXzoBBBJuOYvoQiaQaEEjdi5STzux3Yj8v7ODIpx36i/5s8TdzuQ54TPc5AITQQ==,
@@ -4235,6 +4215,27 @@ packages:
             '@typescript-eslint/scope-manager': 5.35.1
             '@typescript-eslint/types': 5.35.1
             '@typescript-eslint/typescript-estree': 5.35.1_typescript@4.7.4
+            eslint: 8.23.0
+            eslint-scope: 5.1.1
+            eslint-utils: 3.0.0_eslint@8.23.0
+        transitivePeerDependencies:
+            - supports-color
+            - typescript
+        dev: true
+
+    /@typescript-eslint/utils/5.35.1_svqrduhulcrphxzql7zpeoisfy:
+        resolution:
+            {
+                integrity: sha512-v6F8JNXgeBWI4pzZn36hT2HXXzoBBBJuOYvoQiaQaEEjdi5STzux3Yj8v7ODIpx36i/5s8TdzuQ54TPc5AITQQ==,
+            }
+        engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+        peerDependencies:
+            eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+        dependencies:
+            '@types/json-schema': 7.0.11
+            '@typescript-eslint/scope-manager': 5.35.1
+            '@typescript-eslint/types': 5.35.1
+            '@typescript-eslint/typescript-estree': 5.35.1_typescript@4.5.4
             eslint: 8.23.0
             eslint-scope: 5.1.1
             eslint-utils: 3.0.0_eslint@8.23.0
@@ -4283,7 +4284,6 @@ packages:
             }
         dependencies:
             sirv: 2.0.2
-        dev: true
 
     /@yarn-tool/resolve-package/1.0.47:
         resolution:
@@ -4473,6 +4473,8 @@ packages:
         dependencies:
             micromatch: 3.1.10
             normalize-path: 2.1.1
+        transitivePeerDependencies:
+            - supports-color
         dev: true
 
     /anymatch/3.1.2:
@@ -5005,6 +5007,8 @@ packages:
             snapdragon-node: 2.1.1
             split-string: 3.1.0
             to-regex: 3.0.2
+        transitivePeerDependencies:
+            - supports-color
         dev: true
 
     /braces/3.0.2:
@@ -5919,6 +5923,11 @@ packages:
             {
                 integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==,
             }
+        peerDependencies:
+            supports-color: '*'
+        peerDependenciesMeta:
+            supports-color:
+                optional: true
         dependencies:
             ms: 2.0.0
         dev: true
@@ -5928,6 +5937,11 @@ packages:
             {
                 integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==,
             }
+        peerDependencies:
+            supports-color: '*'
+        peerDependenciesMeta:
+            supports-color:
+                optional: true
         dependencies:
             ms: 2.1.2
         dev: true
@@ -6974,6 +6988,8 @@ packages:
         dependencies:
             debug: 3.2.7
             resolve: 1.22.1
+        transitivePeerDependencies:
+            - supports-color
         dev: true
 
     /eslint-mdx/1.17.1_eslint@8.23.0:
@@ -6997,38 +7013,59 @@ packages:
         dev: true
         optional: true
 
-    /eslint-module-utils/2.7.4_eslint@8.23.0:
+    /eslint-module-utils/2.7.4_623cbjb5syc5t6zi3e23jxeu34:
         resolution:
             {
                 integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==,
             }
         engines: { node: '>=4' }
         peerDependencies:
+            '@typescript-eslint/parser': '*'
             eslint: '*'
+            eslint-import-resolver-node: '*'
+            eslint-import-resolver-typescript: '*'
+            eslint-import-resolver-webpack: '*'
         peerDependenciesMeta:
+            '@typescript-eslint/parser':
+                optional: true
             eslint:
                 optional: true
+            eslint-import-resolver-node:
+                optional: true
+            eslint-import-resolver-typescript:
+                optional: true
+            eslint-import-resolver-webpack:
+                optional: true
         dependencies:
+            '@typescript-eslint/parser': 5.35.1_sorwav4hsh5vncerguqybud76i
             debug: 3.2.7
             eslint: 8.23.0
+            eslint-import-resolver-node: 0.3.6
+        transitivePeerDependencies:
+            - supports-color
         dev: true
 
-    /eslint-plugin-import/2.26.0_eslint@8.23.0:
+    /eslint-plugin-import/2.26.0_kavhtzjob4obuugpatbfgsyfbm:
         resolution:
             {
                 integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==,
             }
         engines: { node: '>=4' }
         peerDependencies:
+            '@typescript-eslint/parser': '*'
             eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+        peerDependenciesMeta:
+            '@typescript-eslint/parser':
+                optional: true
         dependencies:
+            '@typescript-eslint/parser': 5.35.1_sorwav4hsh5vncerguqybud76i
             array-includes: 3.1.5
             array.prototype.flat: 1.3.0
             debug: 2.6.9
             doctrine: 2.1.0
             eslint: 8.23.0
             eslint-import-resolver-node: 0.3.6
-            eslint-module-utils: 2.7.4_eslint@8.23.0
+            eslint-module-utils: 2.7.4_623cbjb5syc5t6zi3e23jxeu34
             has: 1.0.3
             is-core-module: 2.10.0
             is-glob: 4.0.3
@@ -7036,6 +7073,10 @@ packages:
             object.values: 1.1.5
             resolve: 1.22.1
             tsconfig-paths: 3.14.1
+        transitivePeerDependencies:
+            - eslint-import-resolver-typescript
+            - eslint-import-resolver-webpack
+            - supports-color
         dev: true
 
     /eslint-plugin-jsx-a11y/6.6.1_eslint@8.23.0:
@@ -7168,7 +7209,7 @@ packages:
             eslint: 8.23.0
         dev: true
 
-    /eslint-plugin-svelte3/4.0.0_eslint@8.23.0+svelte@3.49.0:
+    /eslint-plugin-svelte3/4.0.0_sfdub7vxhxkt5wmgvhhmmgyu2e:
         resolution:
             {
                 integrity: sha512-OIx9lgaNzD02+MDFNLw0GEUbuovNcglg+wnd/UY0fbZmlQSz7GlQiQ1f+yX0XvC07XPcDOnFcichqI3xCwp71g==,
@@ -7480,6 +7521,8 @@ packages:
             regex-not: 1.0.2
             snapdragon: 0.8.2
             to-regex: 3.0.2
+        transitivePeerDependencies:
+            - supports-color
         dev: true
 
     /expect/26.6.2:
@@ -7571,6 +7614,8 @@ packages:
             regex-not: 1.0.2
             snapdragon: 0.8.2
             to-regex: 3.0.2
+        transitivePeerDependencies:
+            - supports-color
         dev: true
 
     /fast-deep-equal/3.1.3:
@@ -9422,6 +9467,8 @@ packages:
             walker: 1.0.8
         optionalDependencies:
             fsevents: 2.3.2
+        transitivePeerDependencies:
+            - supports-color
         dev: true
 
     /jest-haste-map/28.1.3:
@@ -9604,6 +9651,8 @@ packages:
             '@jest/types': 26.6.2
             jest-regex-util: 26.0.0
             jest-snapshot: 26.6.2
+        transitivePeerDependencies:
+            - supports-color
         dev: true
 
     /jest-resolve/26.6.2:
@@ -9735,6 +9784,8 @@ packages:
             natural-compare: 1.4.0
             pretty-format: 26.6.2
             semver: 7.3.7
+        transitivePeerDependencies:
+            - supports-color
         dev: true
 
     /jest-snapshot/28.1.3:
@@ -10588,6 +10639,8 @@ packages:
             regex-not: 1.0.2
             snapdragon: 0.8.2
             to-regex: 3.0.2
+        transitivePeerDependencies:
+            - supports-color
         dev: true
 
     /micromatch/4.0.5:
@@ -10821,6 +10874,8 @@ packages:
             regex-not: 1.0.2
             snapdragon: 0.8.2
             to-regex: 3.0.2
+        transitivePeerDependencies:
+            - supports-color
         dev: true
 
     /natural-compare/1.4.0:
@@ -11625,7 +11680,7 @@ packages:
         engines: { node: '>= 0.8.0' }
         dev: true
 
-    /prettier-plugin-svelte/2.7.0_prettier@2.7.1+svelte@3.49.0:
+    /prettier-plugin-svelte/2.7.0_o3ioganyptcsrh6x4hnxvjkpqi:
         resolution:
             {
                 integrity: sha512-fQhhZICprZot2IqEyoiUYLTRdumULGRvw0o4dzl5jt0jfzVWdGqeYW27QTWAeXhoupEZJULmNoH3ueJwUWFLIA==,
@@ -12311,7 +12366,7 @@ packages:
         dependencies:
             glob: 7.2.3
 
-    /rollup-plugin-typescript2/0.31.2_rollup@2.68.0+typescript@4.7.4:
+    /rollup-plugin-typescript2/0.31.2_jrqhcdvvfzmrsc4z5p6zs2uiwy:
         resolution:
             {
                 integrity: sha512-hRwEYR1C8xDGVVMFJQdEVnNAeWRvpaY97g5mp3IeLnzhNXzSVq78Ye/BJ9PAaUfN4DXa/uDnqerifMOaMFY54Q==,
@@ -12488,6 +12543,8 @@ packages:
             micromatch: 3.1.10
             minimist: 1.2.6
             walker: 1.0.8
+        transitivePeerDependencies:
+            - supports-color
         dev: true
 
     /saxes/5.0.1:
@@ -12644,7 +12701,6 @@ packages:
             '@polka/url': 1.0.0-next.21
             mrmime: 1.0.1
             totalist: 3.0.0
-        dev: true
 
     /sisteransi/1.0.5:
         resolution:
@@ -12749,6 +12805,8 @@ packages:
             source-map: 0.5.7
             source-map-resolve: 0.5.3
             use: 3.1.1
+        transitivePeerDependencies:
+            - supports-color
         dev: true
 
     /sorcery/0.10.0:
@@ -13183,7 +13241,7 @@ packages:
             }
         engines: { node: '>= 0.4' }
 
-    /svelte-check/2.8.1_c3e56b326347f79cbefa7b54654977f5:
+    /svelte-check/2.8.1_svelte@3.49.0:
         resolution:
             {
                 integrity: sha512-cibyY1sgt3ONIDnQbSgV2X9AJFhwEslRHNo95lijrYfPzVEvTvbmL2ohsUyqB5L7j1GhLXtQbjCJ4lZZ/fwbeQ==,
@@ -13199,7 +13257,7 @@ packages:
             picocolors: 1.0.0
             sade: 1.8.1
             svelte: 3.49.0
-            svelte-preprocess: 4.10.7_8865006ef6c5ca9c2621594fcc5b0f9f
+            svelte-preprocess: 4.10.7_uslzfc62di2n2otc2tvfklnwji
             typescript: 4.7.4
         transitivePeerDependencies:
             - '@babel/core'
@@ -13234,7 +13292,7 @@ packages:
             zencrypt: 0.0.7
         dev: true
 
-    /svelte-preprocess/4.10.7_280a73da7875c18e2397c4f760f243fd:
+    /svelte-preprocess/4.10.7_ueozcsexptisi2awlbuwt6eqmq:
         resolution:
             {
                 integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==,
@@ -13278,7 +13336,6 @@ packages:
             typescript:
                 optional: true
         dependencies:
-            '@babel/core': 7.18.13
             '@types/pug': 2.0.6
             '@types/sass': 1.43.1
             detect-indent: 6.1.0
@@ -13289,7 +13346,7 @@ packages:
             typescript: 4.6.4
         dev: true
 
-    /svelte-preprocess/4.10.7_8865006ef6c5ca9c2621594fcc5b0f9f:
+    /svelte-preprocess/4.10.7_uslzfc62di2n2otc2tvfklnwji:
         resolution:
             {
                 integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==,
@@ -13333,7 +13390,6 @@ packages:
             typescript:
                 optional: true
         dependencies:
-            '@babel/core': 7.18.13
             '@types/pug': 2.0.6
             '@types/sass': 1.43.1
             detect-indent: 6.1.0
@@ -13344,7 +13400,7 @@ packages:
             typescript: 4.7.4
         dev: true
 
-    /svelte-preprocess/4.10.7_bcee8d2d2825c991128217423905a22e:
+    /svelte-preprocess/4.10.7_vg3dtoa6m5cwrgayrz5b3xtqh4:
         resolution:
             {
                 integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==,
@@ -13388,7 +13444,6 @@ packages:
             typescript:
                 optional: true
         dependencies:
-            '@babel/core': 7.18.13
             '@types/pug': 2.0.6
             '@types/sass': 1.43.1
             detect-indent: 6.1.0
@@ -13587,7 +13642,6 @@ packages:
                 integrity: sha512-eM+pCBxXO/njtF7vdFsHuqb+ElbxqtI4r5EAvk6grfAFyJ6IvWlSkfZ5T9ozC6xWw3Fj1fGoSmrl0gUs46JVIw==,
             }
         engines: { node: '>=6' }
-        dev: true
 
     /tough-cookie/4.1.2:
         resolution:
@@ -13679,7 +13733,7 @@ packages:
             }
         dev: false
 
-    /ts-jest/26.5.6_jest@26.6.3+typescript@4.7.4:
+    /ts-jest/26.5.6_rnfpnlbz3wqspag7uftsmccrvy:
         resolution:
             {
                 integrity: sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==,
@@ -13886,7 +13940,6 @@ packages:
             }
         engines: { node: '>=4.2.0' }
         hasBin: true
-        dev: true
 
     /typescript/4.6.4:
         resolution:

--- a/src/vite/index.ts
+++ b/src/vite/index.ts
@@ -20,7 +20,7 @@ export default function ({
 
 	return [
 		houdini(configPath),
-		schema(configPath),
+		schema({configFile: configPath, ...extraConfig}),
 		fs_patch(configPath),
 		watch_and_run([
 			{

--- a/src/vite/index.ts
+++ b/src/vite/index.ts
@@ -20,7 +20,7 @@ export default function ({
 
 	return [
 		houdini(configPath),
-		schema({configFile: configPath, ...extraConfig}),
+		schema({ configFile: configPath, ...extraConfig }),
 		fs_patch(configPath),
 		watch_and_run([
 			{

--- a/src/vite/schema.ts
+++ b/src/vite/schema.ts
@@ -7,9 +7,12 @@ import { pullSchema } from '../cmd/utils'
 import { formatErrors, getConfig } from '../common'
 import { ConfigFile } from '../runtime'
 
-export default function HoudiniWatchSchemaPlugin({configFile, ...extraConfig}: {configFile?: string} & Partial<ConfigFile> = {}): Plugin {
+export default function HoudiniWatchSchemaPlugin({
+	configFile,
+	...extraConfig
+}: { configFile?: string } & Partial<ConfigFile> = {}): Plugin {
 	let go = true
-	
+
 	return {
 		name: 'houdini-watch-schema',
 		apply: 'serve',

--- a/src/vite/schema.ts
+++ b/src/vite/schema.ts
@@ -5,15 +5,16 @@ import { Plugin } from 'vite'
 
 import { pullSchema } from '../cmd/utils'
 import { formatErrors, getConfig } from '../common'
+import { ConfigFile } from '../runtime'
 
-export default function HoudiniWatchSchemaPlugin(configFile?: string): Plugin {
+export default function HoudiniWatchSchemaPlugin({configFile, ...extraConfig}: {configFile?: string} & Partial<ConfigFile> = {}): Plugin {
 	let go = true
-
+	
 	return {
 		name: 'houdini-watch-schema',
 		apply: 'serve',
 		async buildStart() {
-			const config = await getConfig({ configFile })
+			const config = await getConfig({ configFile, ...extraConfig })
 			let nbPullError = 0
 
 			// validate the config


### PR DESCRIPTION
Addresses possible fix mentioned in #549

Due to not being able to setup the development environment (see #564). I was unable to run pnpm run tests. 

This fix changes the signature of the schema function the vite plugin. This change allows users to define additional user config via the vite plugin. This is beneficial for the end-user as it adds an additional layer of security, through the use of environment variables that are loaded through `.env` files. Currently, must use system-wide environment variables in order to keep data private.

```js
// vite.config.ts
import { sveltekit } from '@sveltejs/kit/vite';
import houdini from 'houdini/vite';
import { defineConfig, loadEnv } from 'vite';

const config = defineConfig(({ mode }) => {
	// loads env files e.g.
	const env = loadEnv(mode, process.cwd());
	return {
		plugins: [houdini({
			schemaPollHeaders: {
				'X-Header': env.API_KEY
			}
		}), sveltekit()]
	};
});

export default config;

```

The above example shows an example config which would allow environment variables to be loaded using vite's loadEnv function. 

Please **do** delete this pull request if you find that my lack of testing is an issue. I would be happy to test this once #564 is resolved, however if anyone has a functional dev environment I would be very happy if they could test it as well.

Sorry and thank you in advance.
