### PR TITLE
Update example

### DIFF
--- a/.changeset/large-forks-kneel.md
+++ b/.changeset/large-forks-kneel.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Mutation result is never null

--- a/.changeset/sour-students-juggle.md
+++ b/.changeset/sour-students-juggle.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Subscription.listen arguments are optional

--- a/site/src/routes/api/mutation.svx
+++ b/site/src/routes/api/mutation.svx
@@ -122,7 +122,7 @@ and provide an "optimistic response" for the mutation with the second argument t
 
 	export let itemID
 
-	const store: ToggleItemStore = graphql`
+	const toggleItem: ToggleItemStore = graphql`
 		mutation ToggleItem($id: ID!) {
 			toggleItem {
 				item {

--- a/site/src/routes/guides/working-with-graphql.svx
+++ b/site/src/routes/guides/working-with-graphql.svx
@@ -35,8 +35,8 @@ const mutate = mutation(graphql\`
     const externalMutationGraphQL = `
 # src/lib/graphql/UpdateUser.gql
 
-mutation UpdateUser($input: UpdateUserInput!) {
-    updateUser(input: $input) {
+mutation UpdateUser($firstName: String!) {
+    updateUser(firstName: $firstName) {
         user {
             firstName
         }
@@ -49,7 +49,9 @@ mutation UpdateUser($input: UpdateUserInput!) {
 
 import { GQL_UpdateUser } from '$houdini'
 
-const mutate = GQL_UpdateUser.mutate
+async function update() {
+    await GQL_UpdateUser.mutate({ firstName: "..." } )
+}
 `
 
 </script>

--- a/src/runtime/stores/mutation.ts
+++ b/src/runtime/stores/mutation.ts
@@ -35,7 +35,7 @@ export class MutationStore<
 			metadata?: App.Metadata
 			fetch?: typeof globalThis.fetch
 		} & MutationConfig<_Data, _Input, _Optimistic> = {}
-	): Promise<_Data | null> {
+	): Promise<_Data> {
 		const config = await this.getConfig()
 
 		this.store.update((c) => {

--- a/src/runtime/stores/mutation.ts
+++ b/src/runtime/stores/mutation.ts
@@ -132,7 +132,7 @@ export class MutationStore<
 			this.store.set(storeData)
 
 			// return the value to the caller
-			return storeData.data
+			return storeData.data ?? ({} as _Data)
 		} catch (error) {
 			this.store.update((s) => ({
 				...s,

--- a/src/runtime/stores/subscription.ts
+++ b/src/runtime/stores/subscription.ts
@@ -28,10 +28,10 @@ export class SubscriptionStore<_Data, _Input extends {}> extends BaseStore {
 		return this.store?.subscribe(...args)
 	}
 
-	async listen(variables: _Input) {
+	async listen(variables?: _Input) {
 		// @ts-expect-error: typechecking cjs/esm interop is hard
 		// pull the query text out of the compiled artifact
-		const { raw: text, selection } = artifact.default || artifact
+		const { raw: text, selection } = this.artifact.default || this.artifact
 
 		// subscription.listen is a no-op on the server
 		if (!isBrowser) {


### PR DESCRIPTION
Fixes #564 

This PR updates the example to work with the latest version of kit as well as a few small QoL improvements:

 - mutation results are never null (since a mutation either returns something or throws an error)
 - subscription.listen arguments are optional

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] ~If applicable, add a test that would fail without this fix~
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

