### PR TITLE
Fix issue removing store subscriptions

### DIFF
--- a/.changeset/healthy-ladybugs-speak.md
+++ b/.changeset/healthy-ladybugs-speak.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix error causing subscriptions to be removed

--- a/.changeset/tame-peaches-stare.md
+++ b/.changeset/tame-peaches-stare.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+fix bug when importing store classes

--- a/integration/src/routes/stores/ssr-[userId]/+page.ts
+++ b/integration/src/routes/stores/ssr-[userId]/+page.ts
@@ -1,4 +1,4 @@
-import { load_User } from '$houdini';
+import { UserStore } from '$houdini';
 import { routes } from '$lib/utils/routes';
 import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
@@ -8,9 +8,11 @@ export const load: PageLoad = async (event) => {
     throw redirect(307, routes.Home);
   }
 
-  const variables = { id: event.params.userId, tmp: false };
+  // instantiate a store using the class so we can see it work somewhere
+  const User = new UserStore();
+  await User.fetch({ event, variables: { id: event.params.userId, tmp: false } });
 
   return {
-    ...(await load_User({ event, variables }))
+    User
   };
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,10 +2,8 @@ import commonjs from '@rollup/plugin-commonjs'
 import json from '@rollup/plugin-json'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import replace from '@rollup/plugin-replace'
-import fs from 'node:fs'
 import typescript from 'rollup-plugin-typescript2'
 
-import changesetConfig from './.changeset/config.json'
 import packgeJSON from './package.json'
 
 // grab the environment variables

--- a/src/common/extractLoadFunction.ts
+++ b/src/common/extractLoadFunction.ts
@@ -90,7 +90,7 @@ async function processScript(
 
 				// if we are importing a store factory
 				else if (name.endsWith(config.storeSuffix)) {
-					query = name.substring(0, name.length - config.globalStorePrefix.length - 1)
+					query = name.substring(0, name.length - config.storeSuffix.length)
 				}
 
 				// if we are import directly from a store path

--- a/src/runtime/stores/query.ts
+++ b/src/runtime/stores/query.ts
@@ -184,8 +184,7 @@ If this is leftovers from old versions of houdini, you can safely remove this \`
 					cache.unsubscribe(this.subscriptionSpec, this.lastVariables || {})
 				}
 
-				// clear the variable counter
-				this.lastVariables = null
+				// clear the active subscription
 				this.subscriptionSpec = null
 			}
 


### PR DESCRIPTION
Fixes #570

This PR fixes an issue I was debugging with @endigma that was causing subscriptions to be cleared when `lastVariables` was null. The first version of this PR just removes that check since its no longer a leak for a store to remember its last variables (stores aren't global). If everything passes, I'm going to poke around the integration tests to make sure nothing is funky.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

