### PR TITLE
Nested list cache bug

### DIFF
--- a/integration/src/routes/stores/nested-lists/+layout.svelte
+++ b/integration/src/routes/stores/nested-lists/+layout.svelte
@@ -5,6 +5,9 @@
     query NestedListLayoutQuery {
       usersList(snapshot: "nested-list") {
         id
+        nested {
+          something
+        }
       }
     }
   `;

--- a/integration/src/routes/stores/nested-lists/inner/+page.svelte
+++ b/integration/src/routes/stores/nested-lists/inner/+page.svelte
@@ -6,6 +6,9 @@
       user(id: "1", snapshot: "nested-lists") {
         id
         name
+        nested {
+          something
+        }
       }
     }
   `;


### PR DESCRIPTION
Hey @Alec

I'm not sure what the data format is for these queries but is there some nested information available on the User that we can use to test this? In this example **only** the nested->something value is mutated on the parent store when the child query changes, and the other values (e.g. id, name) are fine