### PR TITLE
added extra config info to docs

### DIFF
--- a/site/src/routes/guides/faq.svx
+++ b/site/src/routes/guides/faq.svx
@@ -94,17 +94,6 @@ If you have a route directory that does not contain a `+page.js` file and does n
 plugin will generate an empty `+page.js` file that is never used. This confuses vite hence the warning. Don't worry - since this empty
 file is never imported there are no performance implications.
 
-### My IDE is complaining that the internal directives and fragments don't exist.
-
-Every plugin and editor is different so we can't give you an exact answer but Houdini will write 2 files inside of the `$houdini` directory that contain all of the schema definitions that it relies on. Be default these files are located at `$houdini/graphql/schema.graphql` and `$houdini/graphql/documents.gql`. You can configure this value in your [config file](/api/config) with `definitionsPath`.
-
-### When will version `1.0` be released?
-
-Quick answer is when SvelteKit gets to `1.0`. Until then, we want to be able to break the API in order to create the most convenient experience for the majority of users.
-
-### Does Houdini support Framework X?
-
-At the moment, Houdini only support SvelteKit and vanilla Svelte projects. If you are interested in integrating Houdini into another framework, please reach out! We are very interested in adding support for additional frameworks, we just don't have an abundance of time 😅
 
 ### Can I use .env files for pre-processing?
 
@@ -136,3 +125,16 @@ const config: UserConfigExport = defineConfig(({ mode }) => {
 
 export default config;
 ```
+
+### My IDE is complaining that the internal directives and fragments don't exist.
+
+Every plugin and editor is different so we can't give you an exact answer but Houdini will write 2 files inside of the `$houdini` directory that contain all of the schema definitions that it relies on. Be default these files are located at `$houdini/graphql/schema.graphql` and `$houdini/graphql/documents.gql`. You can configure this value in your [config file](/api/config) with `definitionsPath`.
+
+### When will version `1.0` be released?
+
+Quick answer is when SvelteKit gets to `1.0`. Until then, we want to be able to break the API in order to create the most convenient experience for the majority of users.
+
+### Does Houdini support Framework X?
+
+At the moment, Houdini only support SvelteKit and vanilla Svelte projects. If you are interested in integrating Houdini into another framework, please reach out! We are very interested in adding support for additional frameworks, we just don't have an abundance of time 😅
+

--- a/site/src/routes/guides/faq.svx
+++ b/site/src/routes/guides/faq.svx
@@ -105,3 +105,34 @@ Quick answer is when SvelteKit gets to `1.0`. Until then, we want to be able to 
 ### Does Houdini support Framework X?
 
 At the moment, Houdini only support SvelteKit and vanilla Svelte projects. If you are interested in integrating Houdini into another framework, please reach out! We are very interested in adding support for additional frameworks, we just don't have an abundance of time 😅
+
+### Can I use .env files for pre-processing?
+
+Yes you can! The vite plugin supports passing additional config during the pre-processing stage. Any config present in the [houdini config](/api/config#fields) is a valid input.
+
+```typescript
+import { sveltekit } from '@sveltejs/kit/vite';
+import houdini from 'houdini/vite';
+import type { UserConfigExport } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
+
+const config: UserConfigExport = defineConfig(({ mode }) => {
+        // loads env files
+        // supports the use of seperate .env, .env.production, and .env.development files
+      	const env = loadEnv(mode, process.cwd());
+
+        return {
+                plugins: [
+                        houdini({
+                        				apiUrl: env.VITE_SECRET_ENDPOINT
+                                schemaPollHeaders: {
+                                        'X-Header': env.VITE_CUSTOM_HEADER
+                                }
+                        }),
+                        sveltekit()
+                ]
+        };
+});
+
+export default config;
+```

--- a/site/src/routes/guides/faq.svx
+++ b/site/src/routes/guides/faq.svx
@@ -90,7 +90,7 @@ please visit [the query store docs](/api/query#passing-metadata).
 
 ### Can I use .env files for pre-processing?
 
-Yes you can! The vite plugin supports passing additional config during the pre-processing stage. Any config present in the [houdini config](/api/config#fields) is a valid input.
+Yes you can! You can pass any [valid configuration value](/api/config#fields) to the vite plugin to use your environment variable:
 
 ```typescript
 import { sveltekit } from '@sveltejs/kit/vite';

--- a/site/src/routes/guides/faq.svx
+++ b/site/src/routes/guides/faq.svx
@@ -94,7 +94,6 @@ If you have a route directory that does not contain a `+page.js` file and does n
 plugin will generate an empty `+page.js` file that is never used. This confuses vite hence the warning. Don't worry - since this empty
 file is never imported there are no performance implications.
 
-
 ### Can I use .env files for pre-processing?
 
 Yes you can! The vite plugin supports passing additional config during the pre-processing stage. Any config present in the [houdini config](/api/config#fields) is a valid input.
@@ -137,4 +136,3 @@ Quick answer is when SvelteKit gets to `1.0`. Until then, we want to be able to 
 ### Does Houdini support Framework X?
 
 At the moment, Houdini only support SvelteKit and vanilla Svelte projects. If you are interested in integrating Houdini into another framework, please reach out! We are very interested in adding support for additional frameworks, we just don't have an abundance of time 😅
-

--- a/site/src/routes/guides/faq.svx
+++ b/site/src/routes/guides/faq.svx
@@ -88,12 +88,6 @@ If you haven't seen Houdini's document stores before, please check out the [Work
 You should use the `metadata` parameter in the document store to pass arbitrary information into your client's network function. For more information,
 please visit [the query store docs](/api/query#passing-metadata).
 
-### What is this `Generated an empty chunk...` warning from vite?
-
-If you have a route directory that does not contain a `+page.js` file and does not have an inline query in your `+page.svelte`, the
-plugin will generate an empty `+page.js` file that is never used. This confuses vite hence the warning. Don't worry - since this empty
-file is never imported there are no performance implications.
-
 ### Can I use .env files for pre-processing?
 
 Yes you can! The vite plugin supports passing additional config during the pre-processing stage. Any config present in the [houdini config](/api/config#fields) is a valid input.
@@ -112,7 +106,7 @@ const config: UserConfigExport = defineConfig(({ mode }) => {
         return {
                 plugins: [
                         houdini({
-                        apiUrl: env.VITE_SECRET_ENDPOINT,
+                        				apiUrl: env.VITE_SECRET_ENDPOINT,
                                 schemaPollHeaders: {
                                         'X-Header': env.VITE_CUSTOM_HEADER
                                 }
@@ -124,6 +118,12 @@ const config: UserConfigExport = defineConfig(({ mode }) => {
 
 export default config;
 ```
+
+### What is this `Generated an empty chunk...` warning from vite?
+
+If you have a route directory that does not contain a `+page.js` file and does not have an inline query in your `+page.svelte`, the
+plugin will generate an empty `+page.js` file that is never used. This confuses vite hence the warning. Don't worry - since this empty
+file is never imported there are no performance implications.
 
 ### My IDE is complaining that the internal directives and fragments don't exist.
 

--- a/site/src/routes/guides/faq.svx
+++ b/site/src/routes/guides/faq.svx
@@ -106,7 +106,7 @@ const config: UserConfigExport = defineConfig(({ mode }) => {
         return {
                 plugins: [
                         houdini({
-                        				apiUrl: env.VITE_SECRET_ENDPOINT,
+                        	apiUrl: env.VITE_SECRET_ENDPOINT,
                                 schemaPollHeaders: {
                                         'X-Header': env.VITE_CUSTOM_HEADER
                                 }

--- a/site/src/routes/guides/faq.svx
+++ b/site/src/routes/guides/faq.svx
@@ -112,7 +112,7 @@ const config: UserConfigExport = defineConfig(({ mode }) => {
         return {
                 plugins: [
                         houdini({
-                        				apiUrl: env.VITE_SECRET_ENDPOINT
+                        apiUrl: env.VITE_SECRET_ENDPOINT,
                                 schemaPollHeaders: {
                                         'X-Header': env.VITE_CUSTOM_HEADER
                                 }


### PR DESCRIPTION
Docs edit referenced in #589

Added information about using .env files during the vite preprocessing step.

Not sure if I need to add a changeset so I haven't yet. Please inform me if I do, as it doesn't directly affect the user API.

I also just placed this at the bottom. Please feel free to edit  the order to your liking.