### PR TITLE
don't include the schema path as a source document

### DIFF
--- a/.changeset/brown-onions-smile.md
+++ b/.changeset/brown-onions-smile.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Don't consider the schema path as an source for generation

--- a/src/cmd/generate.ts
+++ b/src/cmd/generate.ts
@@ -1,5 +1,6 @@
 import glob from 'glob'
 import * as graphql from 'graphql'
+import minimatch from 'minimatch'
 import path from 'path'
 import * as recast from 'recast'
 import * as svelte from 'svelte/compiler'
@@ -210,6 +211,8 @@ async function collectDocuments(config: Config): Promise<CollectedGraphQLDocumen
 			)
 				.flat()
 				.filter((filepath) => config.includeFile(filepath))
+				// don't include the schema path as a source file
+				.filter((filepath) => !config.schemaPath || minimatch(filepath, config.schemaPath))
 		),
 	]
 

--- a/src/cmd/generate.ts
+++ b/src/cmd/generate.ts
@@ -212,7 +212,7 @@ async function collectDocuments(config: Config): Promise<CollectedGraphQLDocumen
 				.flat()
 				.filter((filepath) => config.includeFile(filepath))
 				// don't include the schema path as a source file
-				.filter((filepath) => !config.schemaPath || minimatch(filepath, config.schemaPath))
+				.filter((filepath) => !config.schemaPath || !minimatch(filepath, config.schemaPath))
 		),
 	]
 


### PR DESCRIPTION
Fixes #586 

This PR makes the document collection step ignore any paths matching `Config.schemaPath` 

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

