### PR TITLE
only add data prop with inline queries

### DIFF
--- a/.changeset/smart-singers-battle.md
+++ b/.changeset/smart-singers-battle.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Avoid unnecessary data prop being added to route

--- a/packages/houdini-svelte/src/plugin/transforms/kit/load.test.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/kit/load.test.ts
@@ -441,10 +441,9 @@ describe('kit route processor', function () {
 			`,
 		})
 
-		expect(route.component).toMatchInlineSnapshot(`
-			import GQL_TestPageQuery from "$houdini/plugins/houdini-svelte/stores/TestPageQuery";
-			export let data;
-		`)
+		expect(route.component).toMatchInlineSnapshot(
+			'import GQL_TestPageQuery from "$houdini/plugins/houdini-svelte/stores/TestPageQuery";'
+		)
 		expect(route.script).toMatchInlineSnapshot(`
 			import { load_TestPageQuery } from "$houdini/plugins/houdini-svelte/stores/TestPageQuery";
 			import { getCurrentConfig } from "$houdini/runtime/lib/config";
@@ -491,10 +490,9 @@ describe('kit route processor', function () {
 			`,
 		})
 
-		expect(route.component).toMatchInlineSnapshot(`
-			import GQL_TestLayoutQuery from "$houdini/plugins/houdini-svelte/stores/TestLayoutQuery";
-			export let data;
-		`)
+		expect(route.component).toMatchInlineSnapshot(
+			'import GQL_TestLayoutQuery from "$houdini/plugins/houdini-svelte/stores/TestLayoutQuery";'
+		)
 		expect(route.layout_script).toMatchInlineSnapshot(`
 			import { load_TestLayoutQuery } from "$houdini/plugins/houdini-svelte/stores/TestLayoutQuery";
 			import { getCurrentConfig } from "$houdini/runtime/lib/config";
@@ -1074,7 +1072,6 @@ test('layout loads', async function () {
 		import { extractSession, setClientSession } from "$houdini/plugins/houdini-svelte/runtime/session";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/plugins/houdini-svelte/runtime/adapter";
-		export let data;
 		onMount(() => setClientStarted());
 
 		page.subscribe(val => {

--- a/packages/houdini-svelte/src/plugin/transforms/kit/load.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/kit/load.ts
@@ -82,8 +82,7 @@ export default async function kit_load_generator(page: SvelteTransformPage) {
 		})
 	}
 
-	// we need this to happen last so it that the context always gets injected first
-	if (route && queries.length > 0) {
+	if (route && inline_queries.length > 0) {
 		// we need to check if there is a declared data prop
 		const has_data = page.script.body.find(
 			(statement) =>


### PR DESCRIPTION
Fixes #602 

This PR tweaks the load generator so that it only adds enforces a `data` prop when there are inline queries that would use it

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

