### PR TITLE
address trailing statsh in is_root_route

### DIFF
--- a/.changeset/great-pens-return.md
+++ b/.changeset/great-pens-return.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix error preventing session in certain node versions

--- a/e2e/sveltekit/playwright.config.ts
+++ b/e2e/sveltekit/playwright.config.ts
@@ -1,4 +1,3 @@
-import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices as replayDevices } from '@replayio/playwright';
 
 // manual switch for now until replayio is fixed (currently breaking our tests)

--- a/packages/houdini-svelte/src/plugin/fsPatch.ts
+++ b/packages/houdini-svelte/src/plugin/fsPatch.ts
@@ -228,10 +228,17 @@ function virtual_file(name: string, options: Parameters<typeof filesystem.readdi
 }
 
 function is_root_route(filepath: PathLike): boolean {
+	filepath = filepath.toString()
+
+	// if the filepath ends with / we need to strip that away
+	if (filepath.toString().endsWith('/')) {
+		filepath = filepath.slice(0, -1)
+	}
+
 	return (
-		filepath.toString().endsWith(path.join('src', 'routes')) &&
+		filepath.endsWith(path.join('src', 'routes')) &&
 		// ignore the src/routes that exists in the
-		!filepath.toString().includes(path.join('.svelte-kit', 'types'))
+		!filepath.includes(path.join('.svelte-kit', 'types'))
 	)
 }
 

--- a/packages/houdini-svelte/src/plugin/fsPatch.ts
+++ b/packages/houdini-svelte/src/plugin/fsPatch.ts
@@ -237,8 +237,9 @@ function is_root_route(filepath: PathLike): boolean {
 
 	return (
 		filepath.endsWith(path.join('src', 'routes')) &&
-		// ignore the src/routes that exists in the
-		!filepath.includes(path.join('.svelte-kit', 'types'))
+		// ignore the src/routes that exists in the type roots
+		!filepath.includes('.svelte-kit') &&
+		!filepath.includes('$houdini')
 	)
 }
 


### PR DESCRIPTION
Fixes #640 

Turns out that with some versions of node, the directory gets a trailing stash which confused the fsPatch. This PR fixes it by trimming the trailing stash

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

