### PR TITLE
Subscription double import

### DIFF
--- a/.changeset/funny-kings-explode.md
+++ b/.changeset/funny-kings-explode.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix duplicate import for generated subscription stores

--- a/packages/houdini-svelte/src/plugin/codegen/stores/fragment.test.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/stores/fragment.test.ts
@@ -41,7 +41,7 @@ test('generates a store for every query', async function () {
 		import artifact from '$houdini/artifacts/TestFragment1'
 
 
-		// create the query store
+		// create the fragment store
 
 		export class TestFragment1Store extends FragmentStore {
 		    constructor() {

--- a/packages/houdini-svelte/src/plugin/codegen/stores/fragment.test.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/stores/fragment.test.ts
@@ -1,0 +1,62 @@
+import { fs, CollectedGraphQLDocument, path } from 'houdini'
+import { mockCollectedDoc } from 'houdini/test'
+import * as recast from 'recast'
+import * as typeScriptParser from 'recast/parsers/typescript'
+import { test, expect } from 'vitest'
+
+import runPipeline from '..'
+import '../..'
+import { test_config } from '../../../test'
+import { stores_directory } from '../../kit'
+
+test('generates a store for every query', async function () {
+	const config = await test_config()
+	const plugin_root = config.pluginDirectory('test-plugin')
+
+	// the documents to test
+	const docs: CollectedGraphQLDocument[] = [
+		mockCollectedDoc(`fragment TestFragment1 on User { id }`),
+		mockCollectedDoc(`fragment TestFragment2 on User { id }`),
+	]
+
+	// execute the generator
+	await runPipeline({ config, documents: docs, plugin_root, framework: 'kit' })
+
+	// look up the files in the artifact directory
+	const files = await fs.readdir(stores_directory(plugin_root))
+
+	// and they have the right names
+	expect(files).toEqual(expect.arrayContaining(['TestFragment1.js', 'TestFragment2.js']))
+	// and type definitions exist
+	expect(files).toEqual(expect.arrayContaining(['TestFragment1.d.ts', 'TestFragment2.d.ts']))
+
+	const contents = await fs.readFile(path.join(stores_directory(plugin_root), 'TestFragment1.js'))
+	const parsed = recast.parse(contents!, {
+		parser: typeScriptParser,
+	}).program
+
+	await expect(parsed).toMatchInlineSnapshot(
+		`
+		import { FragmentStore } from '$houdini/plugins/houdini-svelte/runtime/stores'
+		import artifact from '$houdini/artifacts/TestFragment1'
+
+
+		// create the query store
+
+		export class TestFragment1Store extends FragmentStore {
+		    constructor() {
+		        super({
+					artifact,
+					storeName: "TestFragment1Store",
+					variables: true,
+					
+				})
+			}
+		}
+
+		export const GQL_TestFragment1 = new TestFragment1Store()
+
+		export default GQL_TestFragment1
+	`
+	)
+})

--- a/packages/houdini-svelte/src/plugin/codegen/stores/fragment.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/stores/fragment.ts
@@ -38,7 +38,7 @@ ${
 		: ''
 }
 
-// create the query store
+// create the fragment store
 
 export class ${storeName} extends ${store_class} {
     constructor() {

--- a/packages/houdini-svelte/src/plugin/codegen/stores/mutation.test.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/stores/mutation.test.ts
@@ -1,0 +1,56 @@
+import { fs, CollectedGraphQLDocument, path } from 'houdini'
+import { mockCollectedDoc } from 'houdini/test'
+import * as recast from 'recast'
+import * as typeScriptParser from 'recast/parsers/typescript'
+import { test, expect } from 'vitest'
+
+import runPipeline from '..'
+import '../..'
+import { test_config } from '../../../test'
+import { stores_directory } from '../../kit'
+
+test('generates a store for every query', async function () {
+	const config = await test_config()
+	const plugin_root = config.pluginDirectory('test-plugin')
+
+	// the documents to test
+	const docs: CollectedGraphQLDocument[] = [
+		mockCollectedDoc(`mutation TestMutation1 { updateUser { id }  }`),
+		mockCollectedDoc(`mutation TestMutation2 { updateUser { id }  }`),
+	]
+
+	// execute the generator
+	await runPipeline({ config, documents: docs, plugin_root, framework: 'kit' })
+
+	// look up the files in the artifact directory
+	const files = await fs.readdir(stores_directory(plugin_root))
+
+	// and they have the right names
+	expect(files).toEqual(expect.arrayContaining(['TestMutation1.js', 'TestMutation2.js']))
+	// and type definitions exist
+	expect(files).toEqual(expect.arrayContaining(['TestMutation1.d.ts', 'TestMutation2.d.ts']))
+
+	const contents = await fs.readFile(path.join(stores_directory(plugin_root), 'TestMutation1.js'))
+	const parsed = recast.parse(contents!, {
+		parser: typeScriptParser,
+	}).program
+
+	await expect(parsed).toMatchInlineSnapshot(
+		`
+		import artifact from '$houdini/artifacts/TestMutation1'
+		import { MutationStore } from '$houdini/plugins/houdini-svelte/runtime/stores'
+
+		export class TestMutation1Store extends MutationStore {
+			constructor() {
+				super({
+					artifact,
+				})
+			}
+		}
+
+		export const GQL_TestMutation1 = new TestMutation1Store()
+
+		export default GQL_TestMutation1
+	`
+	)
+})

--- a/packages/houdini-svelte/src/plugin/codegen/stores/query.test.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/stores/query.test.ts
@@ -9,7 +9,7 @@ import '../..'
 import { pipeline_test, test_config } from '../../../test'
 import { stores_directory } from '../../kit'
 
-test('generates a store for every query', async function () {
+test('generates a query store for every query', async function () {
 	const config = await test_config()
 	const plugin_root = config.pluginDirectory('test-plugin')
 

--- a/packages/houdini-svelte/src/plugin/codegen/stores/subscription.test.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/stores/subscription.test.ts
@@ -1,0 +1,59 @@
+import { fs, CollectedGraphQLDocument, path } from 'houdini'
+import { mockCollectedDoc } from 'houdini/test'
+import * as recast from 'recast'
+import * as typeScriptParser from 'recast/parsers/typescript'
+import { test, expect } from 'vitest'
+
+import runPipeline from '..'
+import '../..'
+import { test_config } from '../../../test'
+import { stores_directory } from '../../kit'
+
+test('generates a store for every query', async function () {
+	const config = await test_config()
+	const plugin_root = config.pluginDirectory('test-plugin')
+
+	// the documents to test
+	const docs: CollectedGraphQLDocument[] = [
+		mockCollectedDoc(`subscription TestSubscription1 { newUser { id }  }`),
+		mockCollectedDoc(`subscription TestSubscription2 { newUser { id }  }`),
+	]
+
+	// execute the generator
+	await runPipeline({ config, documents: docs, plugin_root, framework: 'kit' })
+
+	// look up the files in the artifact directory
+	const files = await fs.readdir(stores_directory(plugin_root))
+
+	// and they have the right names
+	expect(files).toEqual(expect.arrayContaining(['TestSubscription1.js', 'TestSubscription2.js']))
+	// and type definitions exist
+	expect(files).toEqual(
+		expect.arrayContaining(['TestSubscription1.d.ts', 'TestSubscription2.d.ts'])
+	)
+
+	const contents = await fs.readFile(
+		path.join(stores_directory(plugin_root), 'TestSubscription1.js')
+	)
+	const parsed = recast.parse(contents!, {
+		parser: typeScriptParser,
+	}).program
+
+	await expect(parsed).toMatchInlineSnapshot(
+		`
+		import { SubscriptionStore } from '$houdini/plugins/houdini-svelte/runtime/stores'
+
+		export class TestSubscription1Store extends SubscriptionStore {
+			constructor() {
+				super({
+					artifact,
+				})
+			}
+		}
+
+		export const GQL_TestSubscription1 = new TestSubscription1Store()
+
+		export default GQL_TestSubscription1
+	`
+	)
+})

--- a/packages/houdini-svelte/src/plugin/codegen/stores/subscription.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/stores/subscription.ts
@@ -17,7 +17,6 @@ export async function subscriptionStore(
 
 	// the content of the store
 	const storeContent = `${statement}
-import { SubscriptionStore } from '../runtime/stores'
 
 export class ${storeName} extends ${store_class} {
 	constructor() {


### PR DESCRIPTION
Fixes #688 

This PR fixes an issue in the generated subscription stores that was accidentally creating a double import 🤦 While I was there, I also added a few missing tests 

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] ~If applicable, add a test that would fail without this fix~
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

