### PR TITLE
Add an explicit hostname to e2e/_api/server.mjs to make the end-to-end tests work on macOS

### DIFF
--- a/.changeset/fifty-feet-prove.md
+++ b/.changeset/fifty-feet-prove.md
@@ -1,0 +1,5 @@
+---
+'e2e-api': patch
+---
+
+Changed a hostname to make the end-to-end tests work on macOS

--- a/e2e/_api/server.mjs
+++ b/e2e/_api/server.mjs
@@ -6,6 +6,7 @@ import { resolvers, typeDefs } from './graphql.mjs'
 
 async function main() {
 	const yogaApp = createServer({
+		hostname: "::",
 		logging: true,
 		schema: {
 			typeDefs,


### PR DESCRIPTION
Refs #695

Fixes #695

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [N/A] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` ~and `cd integration && pnpm run tests`~ The folder _integration_ does not exist.
- [x] Includes a changeset if your fix affects the user with `pnpm changeset` ~`pnpm changeset` added a file to `.changeset` but I can't see any other changeset files so I have not included it.~ I added a changeset file as changeset-bot complained about it.