### PR TITLE
Fix NPM packages exports and metadata

### DIFF
--- a/packages/houdini-react/package.json
+++ b/packages/houdini-react/package.json
@@ -2,7 +2,20 @@
     "name": "houdini-react",
     "version": "0.17.9",
     "private": true,
-    "description": "The disappearing GraphQL clients",
+    "description": "The React plugin for houdini",
+    "keywords": [
+        "typescript",
+        "react",
+        "graphql",
+        "graphql-client"
+    ],
+    "homepage": "https://github.com/HoudiniGraphql/houdini",
+    "funding": "https://github.com/sponsors/HoudiniGraphql",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/HoudiniGraphql/houdini.git"
+    },
+    "license": "MIT",
     "scripts": {
         "compile": "scripts build --plugin",
         "typedefs": "scripts typedefs --plugin"
@@ -21,6 +34,9 @@
         "houdini": "workspace:^",
         "recast": "^0.21.5"
     },
+    "files": [
+        "build"
+    ],
     "exports": {
         "./package.json": "./package.json",
         "./next": {

--- a/packages/houdini-svelte/package.json
+++ b/packages/houdini-svelte/package.json
@@ -2,6 +2,20 @@
     "name": "houdini-svelte",
     "version": "0.17.9",
     "description": "The svelte plugin for houdini",
+    "keywords": [
+        "typescript",
+        "svelte",
+        "sveltekit",
+        "graphql",
+        "graphql-client"
+    ],
+    "homepage": "https://github.com/HoudiniGraphql/houdini",
+    "funding": "https://github.com/sponsors/HoudiniGraphql",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/HoudiniGraphql/houdini.git"
+    },
+    "license": "MIT",
     "type": "module",
     "scripts": {
         "tests": "vitest",
@@ -27,6 +41,9 @@
     "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0"
     },
+    "files": [
+        "build"
+    ],
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/houdini/package.json
+++ b/packages/houdini/package.json
@@ -2,6 +2,18 @@
     "name": "houdini",
     "version": "0.17.9",
     "description": "The disappearing GraphQL clients",
+    "keywords": [
+        "typescript",
+        "graphql",
+        "graphql-client"
+    ],
+    "homepage": "https://github.com/HoudiniGraphql/houdini",
+    "funding": "https://github.com/sponsors/HoudiniGraphql",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/HoudiniGraphql/houdini.git"
+    },
+    "license": "MIT",
     "type": "module",
     "scripts": {
         "compile": "scripts build",
@@ -42,6 +54,9 @@
         "recast": "^0.21.5",
         "vite-plugin-watch-and-run": "^1.0.3"
     },
+    "files": [
+        "build"
+    ],
     "exports": {
         "./package.json": "./package.json",
         "./codegen": {


### PR DESCRIPTION
Fixes #698

- Add NPM packages `files` setting with only `./build` package folder.
- Add NPM packages metadata.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [ ] Includes a changeset if your fix affects the user with `pnpm changeset`
