### PR TITLE
FIX: onError and beforeLoad have hardcoded imports

### DIFF
--- a/.changeset/many-trainers-warn.md
+++ b/.changeset/many-trainers-warn.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix onError and beforeLoad types

--- a/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
@@ -296,7 +296,7 @@ function append_afterLoad(
 ) {
 	return afterLoad
 		? `
-type AfterLoadReturn = ReturnType<typeof import('./+${type.toLowerCase()}').afterLoad>;
+type AfterLoadReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase()}').afterLoad>>;
 type AfterLoadData = {
 	${internal_append_afterLoad(queries)}
 };
@@ -325,7 +325,7 @@ function append_beforeLoad(beforeLoad: boolean, type: 'Layout' | 'Page') {
 	return beforeLoad
 		? `
 export type BeforeLoadEvent = PageLoadEvent;
-type BeforeLoadReturn = ReturnType<typeof import('./+${type.toLowerCase()}').beforeLoad>;
+type BeforeLoadReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase()}').beforeLoad>>;
 `
 		: ''
 }
@@ -333,7 +333,7 @@ type BeforeLoadReturn = ReturnType<typeof import('./+${type.toLowerCase()}').bef
 function append_onError(onError: boolean, type: 'Layout' | 'Page', hasLoadInput: boolean) {
 	return onError
 		? `
-type OnErrorReturn = ReturnType<typeof import('./+${type.toLowerCase()}').onError>;
+type OnErrorReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase()}').onError>>;
 export type OnErrorEvent =  { event: Kit.LoadEvent, input: ${
 				hasLoadInput ? 'LoadInput' : '{}'
 		  }, error: Error | Error[] };

--- a/packages/houdini-svelte/src/plugin/codegen/routes/kit.test.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/kit.test.ts
@@ -8,96 +8,6 @@ import { type_route_dir } from '../../kit'
 const config = testConfig()
 const plugin_root = config.pluginDirectory('test-plugin')
 
-test('generates types for inline page queries', async function () {
-	// create the mock filesystem
-	await fs.mock({
-		[config.routesDir]: {
-			myProfile: {
-				'+page.svelte': `
-<script>
-    import { query, graphql } from '$houdini'
-
-    const result = query(graphql\`query MyInlineQuery { viewer { id } } \`)
-</script>
-`,
-			},
-		},
-	})
-
-	await fs.mock({
-		[path.join(config.projectRoot, '.svelte-kit')]: {
-			types: {
-				src: {
-					routes: {
-						myProfile: {
-							'$types.d.ts': `import type * as Kit from '@sveltejs/kit';
-
-type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
-type RouteParams = {  }
-type MaybeWithVoid<T> = {} extends T ? T | void : T;
-export type RequiredKeys<T> = { [K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K; }[keyof T];
-type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>
-type EnsureDefined<T> = T extends null | undefined ? {} : T;
-type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? { [P in Exclude<A, keyof U>]?: never } & U : never;
-type PageParentData = EnsureDefined<import('../$types.js').LayoutData>;
-
-export type PageServerData = null;
-export type PageData = Expand<PageParentData>;
-`,
-						},
-					},
-				},
-			},
-		},
-	})
-
-	// execute the generator
-	await generate({ config, documents: [], framework: 'kit', plugin_root })
-
-	// load the contents of the file
-	const queryContents = await fs.readFile(
-		path.join(path.join(type_route_dir(config), 'myProfile', '$houdini.d.ts'))
-	)
-
-	expect(queryContents).toBeTruthy()
-
-	//the parser doesn't work right but the type imports are correct.
-	const parsedQuery = (await parseJS(queryContents!))?.script
-
-	// verify contents
-	expect(parsedQuery).toMatchInlineSnapshot(`import type * as Kit from "@sveltejs/kit";
-import { MyInlineQuery$result, MyInlineQuery$input } from "../../../../artifacts/MyInlineQuery";
-import { MyInlineQueryStore } from "../../../../plugins/houdini-svelte/stores/MyInlineQuery";
-
-type Expand<T> = T extends infer O ? {
-    [K in keyof O]: O[K];
-} : never;
-
-type RouteParams = {};
-type MaybeWithVoid<T> = {} extends T ? T | void : T;
-
-export type RequiredKeys<T> = {
-    [K in keyof T]?: {} extends {
-        [P in K]: T[K];
-    } ? never : K;
-}[keyof T];
-
-type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>;
-type EnsureDefined<T> = T extends null | undefined ? {} : T;
-
-type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? {
-    [P in Exclude<A, keyof U>]?: never;
-} & U : never;
-
-type PageParentData = EnsureDefined<import("../$houdini").LayoutData>;
-type PageParams = PageLoadEvent["params"];
-export type PageServerData = null;
-
-export type PageData = Expand<Expand<PageParentData> & {
-    MyInlineQuery: MyInlineQueryStore
-}>;`)
-})
-
 test('generates types for inline layout queries', async function () {
 	// create the mock filesystem
 	await fs.mock({
@@ -193,17 +103,17 @@ export type LayoutData = Expand<Expand<Omit<LayoutParentData, keyof LayoutParent
 }>;`)
 })
 
-test('generates types for page queries', async function () {
+test('generates types for inline page queries', async function () {
 	// create the mock filesystem
 	await fs.mock({
 		[config.routesDir]: {
 			myProfile: {
-				'+page.gql': `
-query MyPageQuery {
-    viewer {
-        id
-    }
-}
+				'+page.svelte': `
+<script>
+    import { query, graphql } from '$houdini'
+
+    const result = query(graphql\`query MyInlineQuery { viewer { id } } \`)
+</script>
 `,
 			},
 		},
@@ -227,9 +137,7 @@ type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends 
 type PageParentData = EnsureDefined<import('../$types.js').LayoutData>;
 
 export type PageServerData = null;
-export type PageLoad<OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>> = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
-export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Expand<Omit<PageParentData, keyof PageParentData & EnsureDefined<PageServerData>> & OptionalUnion<EnsureDefined<PageParentData & EnsureDefined<PageServerData>>>>;
+export type PageData = Expand<PageParentData>;
 `,
 						},
 					},
@@ -245,14 +153,16 @@ export type PageData = Expand<Omit<PageParentData, keyof PageParentData & Ensure
 	const queryContents = await fs.readFile(
 		path.join(path.join(type_route_dir(config), 'myProfile', '$houdini.d.ts'))
 	)
+
 	expect(queryContents).toBeTruthy()
 
+	//the parser doesn't work right but the type imports are correct.
 	const parsedQuery = (await parseJS(queryContents!))?.script
 
-	//verify contents
+	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`import type * as Kit from "@sveltejs/kit";
-import { MyPageQuery$result, MyPageQuery$input } from "../../../../artifacts/MyPageQuery";
-import { MyPageQueryStore } from "../../../../plugins/houdini-svelte/stores/MyPageQuery";
+import { MyInlineQuery$result, MyInlineQuery$input } from "../../../../artifacts/MyInlineQuery";
+import { MyInlineQueryStore } from "../../../../plugins/houdini-svelte/stores/MyInlineQuery";
 
 type Expand<T> = T extends infer O ? {
     [K in keyof O]: O[K];
@@ -277,13 +187,10 @@ type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends 
 type PageParentData = EnsureDefined<import("../$houdini").LayoutData>;
 type PageParams = PageLoadEvent["params"];
 export type PageServerData = null;
-export type PageLoad<OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>> = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
-export type PageLoadEvent = Parameters<PageLoad>[0];
 
-export type PageData = Expand<Expand<Omit<PageParentData, keyof PageParentData & EnsureDefined<PageServerData>> & OptionalUnion<EnsureDefined<PageParentData & EnsureDefined<PageServerData>>>> & {
-    MyPageQuery: MyPageQueryStore
-}>;
-`)
+export type PageData = Expand<Expand<PageParentData> & {
+    MyInlineQuery: MyInlineQueryStore
+}>;`)
 })
 
 test('generates types for layout queries', async function () {
@@ -375,6 +282,99 @@ export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
 
 export type LayoutData = Expand<Expand<Omit<LayoutParentData, keyof LayoutParentData & EnsureDefined<LayoutServerData>> & OptionalUnion<EnsureDefined<LayoutParentData & EnsureDefined<LayoutServerData>>>> & {
     MyLayoutQuery: MyLayoutQueryStore
+}>;
+`)
+})
+
+test('generates types for page queries', async function () {
+	// create the mock filesystem
+	await fs.mock({
+		[config.routesDir]: {
+			myProfile: {
+				'+page.gql': `
+query MyPageQuery {
+    viewer {
+        id
+    }
+}
+`,
+			},
+		},
+	})
+
+	await fs.mock({
+		[path.join(config.projectRoot, '.svelte-kit')]: {
+			types: {
+				src: {
+					routes: {
+						myProfile: {
+							'$types.d.ts': `import type * as Kit from '@sveltejs/kit';
+
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+type RouteParams = {  }
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
+export type RequiredKeys<T> = { [K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K; }[keyof T];
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
+type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? { [P in Exclude<A, keyof U>]?: never } & U : never;
+type PageParentData = EnsureDefined<import('../$types.js').LayoutData>;
+
+export type PageServerData = null;
+export type PageLoad<OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>> = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
+export type PageLoadEvent = Parameters<PageLoad>[0];
+export type PageData = Expand<Omit<PageParentData, keyof PageParentData & EnsureDefined<PageServerData>> & OptionalUnion<EnsureDefined<PageParentData & EnsureDefined<PageServerData>>>>;
+`,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	// execute the generator
+	await generate({ config, documents: [], framework: 'kit', plugin_root })
+
+	// load the contents of the file
+	const queryContents = await fs.readFile(
+		path.join(path.join(type_route_dir(config), 'myProfile', '$houdini.d.ts'))
+	)
+	expect(queryContents).toBeTruthy()
+
+	const parsedQuery = (await parseJS(queryContents!))?.script
+
+	//verify contents
+	expect(parsedQuery).toMatchInlineSnapshot(`import type * as Kit from "@sveltejs/kit";
+import { MyPageQuery$result, MyPageQuery$input } from "../../../../artifacts/MyPageQuery";
+import { MyPageQueryStore } from "../../../../plugins/houdini-svelte/stores/MyPageQuery";
+
+type Expand<T> = T extends infer O ? {
+    [K in keyof O]: O[K];
+} : never;
+
+type RouteParams = {};
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
+
+export type RequiredKeys<T> = {
+    [K in keyof T]?: {} extends {
+        [P in K]: T[K];
+    } ? never : K;
+}[keyof T];
+
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>;
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
+
+type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? {
+    [P in Exclude<A, keyof U>]?: never;
+} & U : never;
+
+type PageParentData = EnsureDefined<import("../$houdini").LayoutData>;
+type PageParams = PageLoadEvent["params"];
+export type PageServerData = null;
+export type PageLoad<OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>> = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
+export type PageLoadEvent = Parameters<PageLoad>[0];
+
+export type PageData = Expand<Expand<Omit<PageParentData, keyof PageParentData & EnsureDefined<PageServerData>> & OptionalUnion<EnsureDefined<PageParentData & EnsureDefined<PageServerData>>>> & {
+    MyPageQuery: MyPageQueryStore
 }>;
 `)
 })
@@ -634,6 +634,128 @@ export type PageData = Expand<Omit<PageParentData, keyof PageParentData & Ensure
 	`)
 })
 
+test('generates types for layout beforeLoad', async function () {
+	// create the mock filesystem
+	await fs.mock({
+		[config.routesDir]: {
+			myProfile: {
+				'+layout.js': `
+                    import { graphql } from '$houdini'
+
+                    const store1 = graphql\`query MyPageLoad1Query($id: ID!) {
+                        viewer(id: $id) {
+                            id
+                        }
+                    }\`
+
+                    const store2 = graphql\`query MyPageLoad2Query {
+                        viewer {
+                            id
+                        }
+                    }\`
+
+                    export const houdini_load = [ store1, store2 ]
+
+                    export function beforeLoad() {
+                        return {
+                            hello: 'world'
+                        }
+                    }
+                `,
+			},
+		},
+	})
+
+	await fs.mock({
+		[path.join(config.projectRoot, '.svelte-kit')]: {
+			types: {
+				src: {
+					routes: {
+						myProfile: {
+							'$types.d.ts': `import type * as Kit from '@sveltejs/kit';
+
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+type RouteParams = {  }
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
+export type RequiredKeys<T> = { [K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K; }[keyof T];
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
+type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? { [P in Exclude<A, keyof U>]?: never } & U : never;
+type LayoutParams = RouteParams & {  }
+type LayoutParentData = EnsureDefined<{}>;
+
+export type LayoutServerData = null;
+export type LayoutLoad<OutputData extends OutputDataShape<LayoutParentData> = OutputDataShape<LayoutParentData>> = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
+export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
+export type LayoutData = Expand<Omit<LayoutParentData, keyof LayoutParentData & EnsureDefined<LayoutServerData>> & OptionalUnion<EnsureDefined<LayoutParentData & EnsureDefined<LayoutServerData>>>>;
+`,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	// execute the generator
+	await generate({ config, documents: [], framework: 'kit', plugin_root })
+
+	// load the contents of the file
+	const queryContents = await fs.readFile(
+		path.join(type_route_dir(config), 'myProfile', '$houdini.d.ts')
+	)
+	expect(queryContents).toBeTruthy()
+
+	const parsedQuery = (await parseJS(queryContents!))?.script
+
+	// verify contents
+	expect(parsedQuery).toMatchInlineSnapshot(`import type * as Kit from "@sveltejs/kit";
+import type { VariableFunction, BeforeLoadFunction } from "../../../../plugins/houdini-svelte/runtime/types";
+import { MyPageLoad1Query$result, MyPageLoad1Query$input } from "../../../../artifacts/MyPageLoad1Query";
+import { MyPageLoad1QueryStore } from "../../../../plugins/houdini-svelte/stores/MyPageLoad1Query";
+import { MyPageLoad2Query$result, MyPageLoad2Query$input } from "../../../../artifacts/MyPageLoad2Query";
+import { MyPageLoad2QueryStore } from "../../../../plugins/houdini-svelte/stores/MyPageLoad2Query";
+
+type Expand<T> = T extends infer O ? {
+    [K in keyof O]: O[K];
+} : never;
+
+type RouteParams = {};
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
+
+export type RequiredKeys<T> = {
+    [K in keyof T]?: {} extends {
+        [P in K]: T[K];
+    } ? never : K;
+}[keyof T];
+
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>;
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
+
+type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? {
+    [P in Exclude<A, keyof U>]?: never;
+} & U : never;
+
+type LayoutParams = RouteParams & {};
+type LayoutParentData = EnsureDefined<{}>;
+export type LayoutServerData = null;
+export type LayoutLoad<OutputData extends OutputDataShape<LayoutParentData> = OutputDataShape<LayoutParentData>> = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
+export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
+
+export type LayoutData = Expand<Expand<Omit<LayoutParentData, keyof LayoutParentData & EnsureDefined<LayoutServerData>> & OptionalUnion<EnsureDefined<LayoutParentData & EnsureDefined<LayoutServerData>>>> & {
+    MyPageLoad1Query: MyPageLoad1QueryStore
+    MyPageLoad2Query: MyPageLoad2QueryStore
+} & BeforeLoadReturn>;
+
+type LoadInput = {
+    MyPageLoad1Query: MyPageLoad1Query$input
+};
+
+export type BeforeLoadEvent = PageLoadEvent;
+type BeforeLoadReturn = Awaited<ReturnType<typeof import("./+layout").beforeLoad>>;
+export type MyPageLoad1QueryVariables = VariableFunction<LayoutParams, MyPageLoad1Query$input>;
+`)
+})
+
 test('generates types for page beforeLoad', async function () {
 	// create the mock filesystem
 	await fs.mock({
@@ -756,7 +878,7 @@ export type PageData = Expand<Omit<PageParentData, keyof PageParentData & Ensure
 	`)
 })
 
-test('generates types for layout beforeLoad', async function () {
+test('generates types for layout afterLoad', async function () {
 	// create the mock filesystem
 	await fs.mock({
 		[config.routesDir]: {
@@ -778,7 +900,7 @@ test('generates types for layout beforeLoad', async function () {
 
                     export const houdini_load = [ store1, store2 ]
 
-                    export function beforeLoad() {
+                    export function afterLoad(event) {
                         return {
                             hello: 'world'
                         }
@@ -830,8 +952,9 @@ export type LayoutData = Expand<Omit<LayoutParentData, keyof LayoutParentData & 
 	const parsedQuery = (await parseJS(queryContents!))?.script
 
 	// verify contents
-	expect(parsedQuery).toMatchInlineSnapshot(`import type * as Kit from "@sveltejs/kit";
-import type { VariableFunction, BeforeLoadFunction } from "../../../../plugins/houdini-svelte/runtime/types";
+	expect(parsedQuery).toMatchInlineSnapshot(`
+import type * as Kit from "@sveltejs/kit";
+import type { VariableFunction, AfterLoadFunction } from "../../../../plugins/houdini-svelte/runtime/types";
 import { MyPageLoad1Query$result, MyPageLoad1Query$input } from "../../../../artifacts/MyPageLoad1Query";
 import { MyPageLoad1QueryStore } from "../../../../plugins/houdini-svelte/stores/MyPageLoad1Query";
 import { MyPageLoad2Query$result, MyPageLoad2Query$input } from "../../../../artifacts/MyPageLoad2Query";
@@ -866,14 +989,25 @@ export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
 export type LayoutData = Expand<Expand<Omit<LayoutParentData, keyof LayoutParentData & EnsureDefined<LayoutServerData>> & OptionalUnion<EnsureDefined<LayoutParentData & EnsureDefined<LayoutServerData>>>> & {
     MyPageLoad1Query: MyPageLoad1QueryStore
     MyPageLoad2Query: MyPageLoad2QueryStore
-} & BeforeLoadReturn>;
+} & AfterLoadReturn>;
 
 type LoadInput = {
     MyPageLoad1Query: MyPageLoad1Query$input
 };
 
-export type BeforeLoadEvent = PageLoadEvent;
-type BeforeLoadReturn = Awaited<ReturnType<typeof import("./+layout").beforeLoad>>;
+type AfterLoadReturn = Awaited<ReturnType<typeof import("./+layout").afterLoad>>;
+
+type AfterLoadData = {
+    MyPageLoad1Query: MyPageLoad1Query$result
+    MyPageLoad2Query: MyPageLoad2Query$result
+};
+
+export type AfterLoadEvent = {
+    event: PageLoadEvent
+    data: AfterLoadData
+    input: LoadInput
+};
+
 export type MyPageLoad1QueryVariables = VariableFunction<LayoutParams, MyPageLoad1Query$input>;
 `)
 })
@@ -1008,139 +1142,5 @@ export type AfterLoadEvent = {
 };
 
 export type MyPageLoad1QueryVariables = VariableFunction<PageParams, MyPageLoad1Query$input>;
-`)
-})
-
-test('generates types for layout afterLoad', async function () {
-	// create the mock filesystem
-	await fs.mock({
-		[config.routesDir]: {
-			myProfile: {
-				'+layout.js': `
-                    import { graphql } from '$houdini'
-
-                    const store1 = graphql\`query MyPageLoad1Query($id: ID!) {
-                        viewer(id: $id) {
-                            id
-                        }
-                    }\`
-
-                    const store2 = graphql\`query MyPageLoad2Query {
-                        viewer {
-                            id
-                        }
-                    }\`
-
-                    export const houdini_load = [ store1, store2 ]
-
-                    export function afterLoad(event) {
-                        return {
-                            hello: 'world'
-                        }
-                    }
-                `,
-			},
-		},
-	})
-
-	await fs.mock({
-		[path.join(config.projectRoot, '.svelte-kit')]: {
-			types: {
-				src: {
-					routes: {
-						myProfile: {
-							'$types.d.ts': `import type * as Kit from '@sveltejs/kit';
-
-type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
-type RouteParams = {  }
-type MaybeWithVoid<T> = {} extends T ? T | void : T;
-export type RequiredKeys<T> = { [K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K; }[keyof T];
-type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>
-type EnsureDefined<T> = T extends null | undefined ? {} : T;
-type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? { [P in Exclude<A, keyof U>]?: never } & U : never;
-type LayoutParams = RouteParams & {  }
-type LayoutParentData = EnsureDefined<{}>;
-
-export type LayoutServerData = null;
-export type LayoutLoad<OutputData extends OutputDataShape<LayoutParentData> = OutputDataShape<LayoutParentData>> = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
-export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
-export type LayoutData = Expand<Omit<LayoutParentData, keyof LayoutParentData & EnsureDefined<LayoutServerData>> & OptionalUnion<EnsureDefined<LayoutParentData & EnsureDefined<LayoutServerData>>>>;
-`,
-						},
-					},
-				},
-			},
-		},
-	})
-
-	// execute the generator
-	await generate({ config, documents: [], framework: 'kit', plugin_root })
-
-	// load the contents of the file
-	const queryContents = await fs.readFile(
-		path.join(type_route_dir(config), 'myProfile', '$houdini.d.ts')
-	)
-	expect(queryContents).toBeTruthy()
-
-	const parsedQuery = (await parseJS(queryContents!))?.script
-
-	// verify contents
-	expect(parsedQuery).toMatchInlineSnapshot(`
-import type * as Kit from "@sveltejs/kit";
-import type { VariableFunction, AfterLoadFunction } from "../../../../plugins/houdini-svelte/runtime/types";
-import { MyPageLoad1Query$result, MyPageLoad1Query$input } from "../../../../artifacts/MyPageLoad1Query";
-import { MyPageLoad1QueryStore } from "../../../../plugins/houdini-svelte/stores/MyPageLoad1Query";
-import { MyPageLoad2Query$result, MyPageLoad2Query$input } from "../../../../artifacts/MyPageLoad2Query";
-import { MyPageLoad2QueryStore } from "../../../../plugins/houdini-svelte/stores/MyPageLoad2Query";
-
-type Expand<T> = T extends infer O ? {
-    [K in keyof O]: O[K];
-} : never;
-
-type RouteParams = {};
-type MaybeWithVoid<T> = {} extends T ? T | void : T;
-
-export type RequiredKeys<T> = {
-    [K in keyof T]?: {} extends {
-        [P in K]: T[K];
-    } ? never : K;
-}[keyof T];
-
-type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>;
-type EnsureDefined<T> = T extends null | undefined ? {} : T;
-
-type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? {
-    [P in Exclude<A, keyof U>]?: never;
-} & U : never;
-
-type LayoutParams = RouteParams & {};
-type LayoutParentData = EnsureDefined<{}>;
-export type LayoutServerData = null;
-export type LayoutLoad<OutputData extends OutputDataShape<LayoutParentData> = OutputDataShape<LayoutParentData>> = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
-export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
-
-export type LayoutData = Expand<Expand<Omit<LayoutParentData, keyof LayoutParentData & EnsureDefined<LayoutServerData>> & OptionalUnion<EnsureDefined<LayoutParentData & EnsureDefined<LayoutServerData>>>> & {
-    MyPageLoad1Query: MyPageLoad1QueryStore
-    MyPageLoad2Query: MyPageLoad2QueryStore
-} & AfterLoadReturn>;
-
-type LoadInput = {
-    MyPageLoad1Query: MyPageLoad1Query$input
-};
-
-type AfterLoadReturn = Awaited<ReturnType<typeof import("./+layout").afterLoad>>;
-
-type AfterLoadData = {
-    MyPageLoad1Query: MyPageLoad1Query$result
-    MyPageLoad2Query: MyPageLoad2Query$result
-};
-
-export type AfterLoadEvent = {
-    event: PageLoadEvent
-    data: AfterLoadData
-    input: LoadInput
-};
-
-export type MyPageLoad1QueryVariables = VariableFunction<LayoutParams, MyPageLoad1Query$input>;
 `)
 })

--- a/packages/houdini-svelte/src/plugin/codegen/routes/kit.test.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/kit.test.ts
@@ -8,7 +8,7 @@ import { type_route_dir } from '../../kit'
 const config = testConfig()
 const plugin_root = config.pluginDirectory('test-plugin')
 
-test('generates types for inline queries', async function () {
+test('generates types for inline page queries', async function () {
 	// create the mock filesystem
 	await fs.mock({
 		[config.routesDir]: {
@@ -98,6 +98,101 @@ export type PageData = Expand<Expand<PageParentData> & {
 }>;`)
 })
 
+test('generates types for inline layout queries', async function () {
+	// create the mock filesystem
+	await fs.mock({
+		[config.routesDir]: {
+			myProfile: {
+				'+layout.svelte': `
+<script>
+    import { query, graphql } from '$houdini'
+
+    const result = query(graphql\`query MyInlineQuery { viewer { id } } \`)
+</script>
+`,
+			},
+		},
+	})
+
+	await fs.mock({
+		[path.join(config.projectRoot, '.svelte-kit')]: {
+			types: {
+				src: {
+					routes: {
+						myProfile: {
+							'$types.d.ts': `import type * as Kit from '@sveltejs/kit';
+
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+type RouteParams = {  }
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
+export type RequiredKeys<T> = { [K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K; }[keyof T];
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
+type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? { [P in Exclude<A, keyof U>]?: never } & U : never;
+type LayoutParams = RouteParams & {  }
+type LayoutParentData = EnsureDefined<{}>;
+
+export type LayoutServerData = null;
+export type LayoutLoad<OutputData extends OutputDataShape<LayoutParentData> = OutputDataShape<LayoutParentData>> = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
+export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
+export type LayoutData = Expand<Omit<LayoutParentData, keyof LayoutParentData & EnsureDefined<LayoutServerData>> & OptionalUnion<EnsureDefined<LayoutParentData & EnsureDefined<LayoutServerData>>>>;
+`,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	// execute the generator
+	await generate({ config, documents: [], framework: 'kit', plugin_root })
+
+	// load the contents of the file
+	const queryContents = await fs.readFile(
+		path.join(path.join(type_route_dir(config), 'myProfile', '$houdini.d.ts'))
+	)
+
+	expect(queryContents).toBeTruthy()
+
+	//the parser doesn't work right but the type imports are correct.
+	const parsedQuery = (await parseJS(queryContents!))?.script
+
+	// verify contents
+	expect(parsedQuery).toMatchInlineSnapshot(`import type * as Kit from "@sveltejs/kit";
+import { MyInlineQuery$result, MyInlineQuery$input } from "../../../../artifacts/MyInlineQuery";
+import { MyInlineQueryStore } from "../../../../plugins/houdini-svelte/stores/MyInlineQuery";
+
+type Expand<T> = T extends infer O ? {
+    [K in keyof O]: O[K];
+} : never;
+
+type RouteParams = {};
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
+
+export type RequiredKeys<T> = {
+    [K in keyof T]?: {} extends {
+        [P in K]: T[K];
+    } ? never : K;
+}[keyof T];
+
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>;
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
+
+type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? {
+    [P in Exclude<A, keyof U>]?: never;
+} & U : never;
+
+type LayoutParams = RouteParams & {};
+type LayoutParentData = EnsureDefined<{}>;
+export type LayoutServerData = null;
+export type LayoutLoad<OutputData extends OutputDataShape<LayoutParentData> = OutputDataShape<LayoutParentData>> = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
+export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
+
+export type LayoutData = Expand<Expand<Omit<LayoutParentData, keyof LayoutParentData & EnsureDefined<LayoutServerData>> & OptionalUnion<EnsureDefined<LayoutParentData & EnsureDefined<LayoutServerData>>>> & {
+    MyInlineQuery: MyInlineQueryStore
+}>;`)
+})
+
 test('generates types for page queries', async function () {
 	// create the mock filesystem
 	await fs.mock({
@@ -134,10 +229,7 @@ type PageParentData = EnsureDefined<import('../$types.js').LayoutData>;
 export type PageServerData = null;
 export type PageLoad<OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>> = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-
-export type PageData = Expand<Expand<Omit<PageParentData, keyof PageParentData & EnsureDefined<PageServerData>> & OptionalUnion<EnsureDefined<PageParentData & EnsureDefined<PageServerData>>>> & {
-    MyPageQuery: MyPageQueryStore
-}>;"
+export type PageData = Expand<Omit<PageParentData, keyof PageParentData & EnsureDefined<PageServerData>> & OptionalUnion<EnsureDefined<PageParentData & EnsureDefined<PageServerData>>>>;
 `,
 						},
 					},
@@ -187,6 +279,10 @@ type PageParams = PageLoadEvent["params"];
 export type PageServerData = null;
 export type PageLoad<OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>> = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
+
+export type PageData = Expand<Expand<Omit<PageParentData, keyof PageParentData & EnsureDefined<PageServerData>> & OptionalUnion<EnsureDefined<PageParentData & EnsureDefined<PageServerData>>>> & {
+    MyPageQuery: MyPageQueryStore
+}>;
 `)
 })
 
@@ -283,7 +379,134 @@ export type LayoutData = Expand<Expand<Omit<LayoutParentData, keyof LayoutParent
 `)
 })
 
-test('generates types for onError', async function () {
+test('generates types for layout onError', async function () {
+	// create the mock filesystem
+	await fs.mock({
+		[config.routesDir]: {
+			myProfile: {
+				'+layout.js': `
+                    import { graphql } from '$houdini'
+
+                    const store1 = graphql\`query MyPageLoad1Query($id: ID!) {
+                        viewer(id: $id) {
+                            id
+                        }
+                    }\`
+
+                    const store2 = graphql\`query MyPageLoad2Query {
+                        viewer {
+                            id
+                        }
+                    }\`
+
+                    export const houdini_load = [ store1, store2 ]
+
+                    export function onError() {
+                        return {
+                            hello: 'world'
+                        }
+                    }
+                `,
+			},
+		},
+	})
+
+	await fs.mock({
+		[path.join(config.projectRoot, '.svelte-kit')]: {
+			types: {
+				src: {
+					routes: {
+						myProfile: {
+							'$types.d.ts': `import type * as Kit from '@sveltejs/kit';
+
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+type RouteParams = {  }
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
+export type RequiredKeys<T> = { [K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K; }[keyof T];
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
+type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? { [P in Exclude<A, keyof U>]?: never } & U : never;
+type LayoutParams = RouteParams & {  }
+type LayoutParentData = EnsureDefined<{}>;
+
+export type LayoutServerData = null;
+export type LayoutLoad<OutputData extends OutputDataShape<LayoutParentData> = OutputDataShape<LayoutParentData>> = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
+export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
+export type LayoutData = Expand<Omit<LayoutParentData, keyof LayoutParentData & EnsureDefined<LayoutServerData>> & OptionalUnion<EnsureDefined<LayoutParentData & EnsureDefined<LayoutServerData>>>>;
+`,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	// execute the generator
+	await generate({ config, documents: [], framework: 'kit', plugin_root })
+
+	// load the contents of the file
+	const queryContents = await fs.readFile(
+		path.join(path.join(type_route_dir(config), 'myProfile', '$houdini.d.ts'))
+	)
+	expect(queryContents).toBeTruthy()
+
+	const parsedQuery = (await parseJS(queryContents!))?.script
+	// verify contents
+	expect(parsedQuery).toMatchInlineSnapshot(`import type * as Kit from "@sveltejs/kit";
+import type { VariableFunction } from "../../../../plugins/houdini-svelte/runtime/types";
+import { MyPageLoad1Query$result, MyPageLoad1Query$input } from "../../../../artifacts/MyPageLoad1Query";
+import { MyPageLoad1QueryStore } from "../../../../plugins/houdini-svelte/stores/MyPageLoad1Query";
+import { MyPageLoad2Query$result, MyPageLoad2Query$input } from "../../../../artifacts/MyPageLoad2Query";
+import { MyPageLoad2QueryStore } from "../../../../plugins/houdini-svelte/stores/MyPageLoad2Query";
+
+type Expand<T> = T extends infer O ? {
+    [K in keyof O]: O[K];
+} : never;
+
+type RouteParams = {};
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
+
+export type RequiredKeys<T> = {
+    [K in keyof T]?: {} extends {
+        [P in K]: T[K];
+    } ? never : K;
+}[keyof T];
+
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>;
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
+
+type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? {
+    [P in Exclude<A, keyof U>]?: never;
+} & U : never;
+
+type LayoutParams = RouteParams & {};
+type LayoutParentData = EnsureDefined<{}>;
+export type LayoutServerData = null;
+export type LayoutLoad<OutputData extends OutputDataShape<LayoutParentData> = OutputDataShape<LayoutParentData>> = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
+export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
+
+export type LayoutData = Expand<Expand<Omit<LayoutParentData, keyof LayoutParentData & EnsureDefined<LayoutServerData>> & OptionalUnion<EnsureDefined<LayoutParentData & EnsureDefined<LayoutServerData>>>> & {
+    MyPageLoad1Query: MyPageLoad1QueryStore
+    MyPageLoad2Query: MyPageLoad2QueryStore
+} & OnErrorReturn>;
+
+type LoadInput = {
+    MyPageLoad1Query: MyPageLoad1Query$input
+};
+
+type OnErrorReturn = ReturnType<typeof import("./+layout").onError>;
+
+export type OnErrorEvent = {
+    event: Kit.LoadEvent
+    input: LoadInput
+    error: Error | Error[]
+};
+
+export type MyPageLoad1QueryVariables = VariableFunction<LayoutParams, MyPageLoad1Query$input>;
+`)
+})
+
+test('generates types for page onError', async function () {
 	// create the mock filesystem
 	await fs.mock({
 		[config.routesDir]: {
@@ -399,7 +622,7 @@ export type PageData = Expand<Omit<PageParentData, keyof PageParentData & Ensure
 		    MyPageLoad1Query: MyPageLoad1Query$input
 		};
 
-		type OnErrorReturn = ReturnType<typeof import("../../../../../src/routes/myProfile/+page").onError>;
+		type OnErrorReturn = ReturnType<typeof import("./+page").onError>;
 
 		export type OnErrorEvent = {
 		    event: Kit.LoadEvent
@@ -411,7 +634,7 @@ export type PageData = Expand<Omit<PageParentData, keyof PageParentData & Ensure
 	`)
 })
 
-test('generates types for beforeLoad', async function () {
+test('generates types for page beforeLoad', async function () {
 	// create the mock filesystem
 	await fs.mock({
 		[config.routesDir]: {
@@ -528,12 +751,134 @@ export type PageData = Expand<Omit<PageParentData, keyof PageParentData & Ensure
 		};
 
 		export type BeforeLoadEvent = PageLoadEvent;
-		type BeforeLoadReturn = ReturnType<typeof import("../../../../../src/routes/myProfile/+page").beforeLoad>;
+		type BeforeLoadReturn = ReturnType<typeof import("./+page").beforeLoad>;
 		export type MyPageLoad1QueryVariables = VariableFunction<PageParams, MyPageLoad1Query$input>;
 	`)
 })
 
-test('generates types for afterLoad', async function () {
+test('generates types for layout beforeLoad', async function () {
+	// create the mock filesystem
+	await fs.mock({
+		[config.routesDir]: {
+			myProfile: {
+				'+layout.js': `
+                    import { graphql } from '$houdini'
+
+                    const store1 = graphql\`query MyPageLoad1Query($id: ID!) {
+                        viewer(id: $id) {
+                            id
+                        }
+                    }\`
+
+                    const store2 = graphql\`query MyPageLoad2Query {
+                        viewer {
+                            id
+                        }
+                    }\`
+
+                    export const houdini_load = [ store1, store2 ]
+
+                    export function beforeLoad() {
+                        return {
+                            hello: 'world'
+                        }
+                    }
+                `,
+			},
+		},
+	})
+
+	await fs.mock({
+		[path.join(config.projectRoot, '.svelte-kit')]: {
+			types: {
+				src: {
+					routes: {
+						myProfile: {
+							'$types.d.ts': `import type * as Kit from '@sveltejs/kit';
+
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+type RouteParams = {  }
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
+export type RequiredKeys<T> = { [K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K; }[keyof T];
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
+type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? { [P in Exclude<A, keyof U>]?: never } & U : never;
+type LayoutParams = RouteParams & {  }
+type LayoutParentData = EnsureDefined<{}>;
+
+export type LayoutServerData = null;
+export type LayoutLoad<OutputData extends OutputDataShape<LayoutParentData> = OutputDataShape<LayoutParentData>> = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
+export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
+export type LayoutData = Expand<Omit<LayoutParentData, keyof LayoutParentData & EnsureDefined<LayoutServerData>> & OptionalUnion<EnsureDefined<LayoutParentData & EnsureDefined<LayoutServerData>>>>;
+`,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	// execute the generator
+	await generate({ config, documents: [], framework: 'kit', plugin_root })
+
+	// load the contents of the file
+	const queryContents = await fs.readFile(
+		path.join(type_route_dir(config), 'myProfile', '$houdini.d.ts')
+	)
+	expect(queryContents).toBeTruthy()
+
+	const parsedQuery = (await parseJS(queryContents!))?.script
+
+	// verify contents
+	expect(parsedQuery).toMatchInlineSnapshot(`import type * as Kit from "@sveltejs/kit";
+import type { VariableFunction, BeforeLoadFunction } from "../../../../plugins/houdini-svelte/runtime/types";
+import { MyPageLoad1Query$result, MyPageLoad1Query$input } from "../../../../artifacts/MyPageLoad1Query";
+import { MyPageLoad1QueryStore } from "../../../../plugins/houdini-svelte/stores/MyPageLoad1Query";
+import { MyPageLoad2Query$result, MyPageLoad2Query$input } from "../../../../artifacts/MyPageLoad2Query";
+import { MyPageLoad2QueryStore } from "../../../../plugins/houdini-svelte/stores/MyPageLoad2Query";
+
+type Expand<T> = T extends infer O ? {
+    [K in keyof O]: O[K];
+} : never;
+
+type RouteParams = {};
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
+
+export type RequiredKeys<T> = {
+    [K in keyof T]?: {} extends {
+        [P in K]: T[K];
+    } ? never : K;
+}[keyof T];
+
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>;
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
+
+type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? {
+    [P in Exclude<A, keyof U>]?: never;
+} & U : never;
+
+type LayoutParams = RouteParams & {};
+type LayoutParentData = EnsureDefined<{}>;
+export type LayoutServerData = null;
+export type LayoutLoad<OutputData extends OutputDataShape<LayoutParentData> = OutputDataShape<LayoutParentData>> = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
+export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
+
+export type LayoutData = Expand<Expand<Omit<LayoutParentData, keyof LayoutParentData & EnsureDefined<LayoutServerData>> & OptionalUnion<EnsureDefined<LayoutParentData & EnsureDefined<LayoutServerData>>>> & {
+    MyPageLoad1Query: MyPageLoad1QueryStore
+    MyPageLoad2Query: MyPageLoad2QueryStore
+} & BeforeLoadReturn>;
+
+type LoadInput = {
+    MyPageLoad1Query: MyPageLoad1Query$input
+};
+
+export type BeforeLoadEvent = PageLoadEvent;
+type BeforeLoadReturn = ReturnType<typeof import("./+layout").beforeLoad>;
+export type MyPageLoad1QueryVariables = VariableFunction<LayoutParams, MyPageLoad1Query$input>;
+`)
+})
+
+test('generates types for page afterLoad', async function () {
 	// create the mock filesystem
 	await fs.mock({
 		[config.routesDir]: {
@@ -649,30 +994,29 @@ type LoadInput = {
     MyPageLoad1Query: MyPageLoad1Query$input
 };
 
+type AfterLoadReturn = ReturnType<typeof import("./+page").afterLoad>;
+
 type AfterLoadData = {
-   MyPageLoad1Query: MyPageLoad1Query$result
-   MyPageLoad2Query: MyPageLoad2Query$result
+    MyPageLoad1Query: MyPageLoad1Query$result
+    MyPageLoad2Query: MyPageLoad2Query$result
 };
 
 export type AfterLoadEvent = {
-	event: PageLoadEvent
-	data: AfterLoadData
-  input: LoadInput
+    event: PageLoadEvent
+    data: AfterLoadData
+    input: LoadInput
 };
 
-
-export type BeforeLoadEvent = PageLoadEvent;
-type BeforeLoadReturn = ReturnType<typeof import("../../../../../src/routes/myProfile/+page").beforeLoad>;
 export type MyPageLoad1QueryVariables = VariableFunction<PageParams, MyPageLoad1Query$input>;
 `)
 })
 
-test('generates types for afterLoad', async function () {
+test('generates types for layout afterLoad', async function () {
 	// create the mock filesystem
 	await fs.mock({
 		[config.routesDir]: {
 			myProfile: {
-				'+page.js': `
+				'+layout.js': `
                     import { graphql } from '$houdini'
 
                     const store1 = graphql\`query MyPageLoad1Query($id: ID!) {
@@ -689,7 +1033,7 @@ test('generates types for afterLoad', async function () {
 
                     export const houdini_load = [ store1, store2 ]
 
-                    export function afterLoad() {
+                    export function afterLoad(event) {
                         return {
                             hello: 'world'
                         }
@@ -714,12 +1058,13 @@ export type RequiredKeys<T> = { [K in keyof T]-?: {} extends { [P in K]: T[K] } 
 type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>
 type EnsureDefined<T> = T extends null | undefined ? {} : T;
 type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? { [P in Exclude<A, keyof U>]?: never } & U : never;
-type PageParentData = EnsureDefined<import('../$types.js').LayoutData>;
+type LayoutParams = RouteParams & {  }
+type LayoutParentData = EnsureDefined<{}>;
 
-export type PageServerData = null;
-export type PageLoad<OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>> = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
-export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Expand<Omit<PageParentData, keyof PageParentData & EnsureDefined<PageServerData>> & OptionalUnion<EnsureDefined<PageParentData & EnsureDefined<PageServerData>>>>;
+export type LayoutServerData = null;
+export type LayoutLoad<OutputData extends OutputDataShape<LayoutParentData> = OutputDataShape<LayoutParentData>> = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
+export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
+export type LayoutData = Expand<Omit<LayoutParentData, keyof LayoutParentData & EnsureDefined<LayoutServerData>> & OptionalUnion<EnsureDefined<LayoutParentData & EnsureDefined<LayoutServerData>>>>;
 `,
 						},
 					},
@@ -741,61 +1086,61 @@ export type PageData = Expand<Omit<PageParentData, keyof PageParentData & Ensure
 
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		import type * as Kit from "@sveltejs/kit";
-		import type { VariableFunction, AfterLoadFunction } from "../../../../plugins/houdini-svelte/runtime/types";
-		import { MyPageLoad1Query$result, MyPageLoad1Query$input } from "../../../../artifacts/MyPageLoad1Query";
-		import { MyPageLoad1QueryStore } from "../../../../plugins/houdini-svelte/stores/MyPageLoad1Query";
-		import { MyPageLoad2Query$result, MyPageLoad2Query$input } from "../../../../artifacts/MyPageLoad2Query";
-		import { MyPageLoad2QueryStore } from "../../../../plugins/houdini-svelte/stores/MyPageLoad2Query";
+import type * as Kit from "@sveltejs/kit";
+import type { VariableFunction, AfterLoadFunction } from "../../../../plugins/houdini-svelte/runtime/types";
+import { MyPageLoad1Query$result, MyPageLoad1Query$input } from "../../../../artifacts/MyPageLoad1Query";
+import { MyPageLoad1QueryStore } from "../../../../plugins/houdini-svelte/stores/MyPageLoad1Query";
+import { MyPageLoad2Query$result, MyPageLoad2Query$input } from "../../../../artifacts/MyPageLoad2Query";
+import { MyPageLoad2QueryStore } from "../../../../plugins/houdini-svelte/stores/MyPageLoad2Query";
 
-		type Expand<T> = T extends infer O ? {
-		    [K in keyof O]: O[K];
-		} : never;
+type Expand<T> = T extends infer O ? {
+    [K in keyof O]: O[K];
+} : never;
 
-		type RouteParams = {};
-		type MaybeWithVoid<T> = {} extends T ? T | void : T;
+type RouteParams = {};
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
 
-		export type RequiredKeys<T> = {
-		    [K in keyof T]?: {} extends {
-		        [P in K]: T[K];
-		    } ? never : K;
-		}[keyof T];
+export type RequiredKeys<T> = {
+    [K in keyof T]?: {} extends {
+        [P in K]: T[K];
+    } ? never : K;
+}[keyof T];
 
-		type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>;
-		type EnsureDefined<T> = T extends null | undefined ? {} : T;
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>;
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
 
-		type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? {
-		    [P in Exclude<A, keyof U>]?: never;
-		} & U : never;
+type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? {
+    [P in Exclude<A, keyof U>]?: never;
+} & U : never;
 
-		type PageParentData = EnsureDefined<import("../$houdini").LayoutData>;
-		type PageParams = PageLoadEvent["params"];
-		export type PageServerData = null;
-		export type PageLoad<OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>> = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
-		export type PageLoadEvent = Parameters<PageLoad>[0];
+type LayoutParams = RouteParams & {};
+type LayoutParentData = EnsureDefined<{}>;
+export type LayoutServerData = null;
+export type LayoutLoad<OutputData extends OutputDataShape<LayoutParentData> = OutputDataShape<LayoutParentData>> = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
+export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
 
-		export type PageData = Expand<Expand<Omit<PageParentData, keyof PageParentData & EnsureDefined<PageServerData>> & OptionalUnion<EnsureDefined<PageParentData & EnsureDefined<PageServerData>>>> & {
-		    MyPageLoad1Query: MyPageLoad1QueryStore
-		    MyPageLoad2Query: MyPageLoad2QueryStore
-		} & AfterLoadReturn>;
+export type LayoutData = Expand<Expand<Omit<LayoutParentData, keyof LayoutParentData & EnsureDefined<LayoutServerData>> & OptionalUnion<EnsureDefined<LayoutParentData & EnsureDefined<LayoutServerData>>>> & {
+    MyPageLoad1Query: MyPageLoad1QueryStore
+    MyPageLoad2Query: MyPageLoad2QueryStore
+} & AfterLoadReturn>;
 
-		type LoadInput = {
-		    MyPageLoad1Query: MyPageLoad1Query$input
-		};
+type LoadInput = {
+    MyPageLoad1Query: MyPageLoad1Query$input
+};
 
-		type AfterLoadReturn = ReturnType<typeof import("./+page").afterLoad>;
+type AfterLoadReturn = ReturnType<typeof import("./+layout").afterLoad>;
 
-		type AfterLoadData = {
-		    MyPageLoad1Query: MyPageLoad1Query$result
-		    MyPageLoad2Query: MyPageLoad2Query$result
-		};
+type AfterLoadData = {
+    MyPageLoad1Query: MyPageLoad1Query$result
+    MyPageLoad2Query: MyPageLoad2Query$result
+};
 
-		export type AfterLoadEvent = {
-		    event: PageLoadEvent
-		    data: AfterLoadData
-		    input: LoadInput
-		};
+export type AfterLoadEvent = {
+    event: PageLoadEvent
+    data: AfterLoadData
+    input: LoadInput
+};
 
-		export type MyPageLoad1QueryVariables = VariableFunction<PageParams, MyPageLoad1Query$input>;
-	`)
+export type MyPageLoad1QueryVariables = VariableFunction<LayoutParams, MyPageLoad1Query$input>;
+`)
 })

--- a/packages/houdini-svelte/src/plugin/codegen/routes/kit.test.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/kit.test.ts
@@ -494,7 +494,7 @@ type LoadInput = {
     MyPageLoad1Query: MyPageLoad1Query$input
 };
 
-type OnErrorReturn = ReturnType<typeof import("./+layout").onError>;
+type OnErrorReturn = Awaited<ReturnType<typeof import("./+layout").onError>>;
 
 export type OnErrorEvent = {
     event: Kit.LoadEvent
@@ -622,7 +622,7 @@ export type PageData = Expand<Omit<PageParentData, keyof PageParentData & Ensure
 		    MyPageLoad1Query: MyPageLoad1Query$input
 		};
 
-		type OnErrorReturn = ReturnType<typeof import("./+page").onError>;
+		type OnErrorReturn = Awaited<ReturnType<typeof import("./+page").onError>>;
 
 		export type OnErrorEvent = {
 		    event: Kit.LoadEvent
@@ -751,7 +751,7 @@ export type PageData = Expand<Omit<PageParentData, keyof PageParentData & Ensure
 		};
 
 		export type BeforeLoadEvent = PageLoadEvent;
-		type BeforeLoadReturn = ReturnType<typeof import("./+page").beforeLoad>;
+		type BeforeLoadReturn = Awaited<ReturnType<typeof import("./+page").beforeLoad>>;
 		export type MyPageLoad1QueryVariables = VariableFunction<PageParams, MyPageLoad1Query$input>;
 	`)
 })
@@ -873,7 +873,7 @@ type LoadInput = {
 };
 
 export type BeforeLoadEvent = PageLoadEvent;
-type BeforeLoadReturn = ReturnType<typeof import("./+layout").beforeLoad>;
+type BeforeLoadReturn = Awaited<ReturnType<typeof import("./+layout").beforeLoad>>;
 export type MyPageLoad1QueryVariables = VariableFunction<LayoutParams, MyPageLoad1Query$input>;
 `)
 })
@@ -994,7 +994,7 @@ type LoadInput = {
     MyPageLoad1Query: MyPageLoad1Query$input
 };
 
-type AfterLoadReturn = ReturnType<typeof import("./+page").afterLoad>;
+type AfterLoadReturn = Awaited<ReturnType<typeof import("./+page").afterLoad>>;
 
 type AfterLoadData = {
     MyPageLoad1Query: MyPageLoad1Query$result
@@ -1128,7 +1128,7 @@ type LoadInput = {
     MyPageLoad1Query: MyPageLoad1Query$input
 };
 
-type AfterLoadReturn = ReturnType<typeof import("./+layout").afterLoad>;
+type AfterLoadReturn = Awaited<ReturnType<typeof import("./+layout").afterLoad>>;
 
 type AfterLoadData = {
     MyPageLoad1Query: MyPageLoad1Query$result


### PR DESCRIPTION
fixes #713, fixed #712

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

Hi there, was reviewing the code and I realised that beforeLoad and onError didn't have the correct type imports if they came from a layout. I modified the function to accept an input + some minor structural changes. 

I also increased test coverage to prevent this in the future.

All tests pass locally.