### PR TITLE
Fix generated types referencing onError, afterLoad and beforeLoad

### DIFF
--- a/.changeset/new-plums-sing.md
+++ b/.changeset/new-plums-sing.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix generated types referencing onError, afterLoad and beforeLoad

--- a/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
@@ -297,7 +297,7 @@ function append_afterLoad(
 ) {
 	return afterLoad
 		? `
-type AfterLoadReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase()}').afterLoad>>;
+type AfterLoadReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase()}')._houdini_afterLoad>>;
 type AfterLoadData = {
 	${internal_append_afterLoad(queries)}
 };
@@ -326,7 +326,7 @@ function append_beforeLoad(beforeLoad: boolean, type: 'Layout' | 'Page') {
 	return beforeLoad
 		? `
 export type BeforeLoadEvent = ${type}LoadEvent;
-type BeforeLoadReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase()}').beforeLoad>>;
+type BeforeLoadReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase()}')._houdini_beforeLoad>>;
 `
 		: ''
 }
@@ -334,7 +334,7 @@ type BeforeLoadReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase(
 function append_onError(onError: boolean, type: 'Layout' | 'Page', hasLoadInput: boolean) {
 	return onError
 		? `
-type OnErrorReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase()}').onError>>;
+type OnErrorReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase()}')._houdini_onError>>;
 export type OnErrorEvent =  { event: Kit.LoadEvent, input: ${
 				hasLoadInput ? 'LoadInput' : '{}'
 		  }, error: Error | Error[] };

--- a/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
@@ -297,7 +297,7 @@ function append_afterLoad(
 ) {
 	return afterLoad
 		? `
-type AfterLoadReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase()}')._houdini_afterLoad>>;
+type AfterLoadReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase()}').${houdini_after_load_fn}>>;
 type AfterLoadData = {
 	${internal_append_afterLoad(queries)}
 };
@@ -326,7 +326,7 @@ function append_beforeLoad(beforeLoad: boolean, type: 'Layout' | 'Page') {
 	return beforeLoad
 		? `
 export type BeforeLoadEvent = ${type}LoadEvent;
-type BeforeLoadReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase()}')._houdini_beforeLoad>>;
+type BeforeLoadReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase()}').${houdini_before_load_fn}>>;
 `
 		: ''
 }
@@ -334,7 +334,7 @@ type BeforeLoadReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase(
 function append_onError(onError: boolean, type: 'Layout' | 'Page', hasLoadInput: boolean) {
 	return onError
 		? `
-type OnErrorReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase()}')._houdini_onError>>;
+type OnErrorReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase()}').${houdini_on_error_fn}>>;
 export type OnErrorEvent =  { event: Kit.LoadEvent, input: ${
 				hasLoadInput ? 'LoadInput' : '{}'
 		  }, error: Error | Error[] };

--- a/packages/houdini-svelte/src/plugin/codegen/routes/kit.test.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/kit.test.ts
@@ -455,7 +455,7 @@ test('generates types for layout onError', async function () {
 		    MyPageLoad1Query: MyPageLoad1Query$input
 		};
 
-		type OnErrorReturn = Awaited<ReturnType<typeof import("./+layout").onError>>;
+		type OnErrorReturn = Awaited<ReturnType<typeof import("./+layout")._houdini_onError>>;
 
 		export type OnErrorEvent = {
 		    event: Kit.LoadEvent
@@ -568,7 +568,7 @@ test('generates types for page onError', async function () {
 		    MyPageLoad1Query: MyPageLoad1Query$input
 		};
 
-		type OnErrorReturn = Awaited<ReturnType<typeof import("./+page").onError>>;
+		type OnErrorReturn = Awaited<ReturnType<typeof import("./+page")._houdini_onError>>;
 
 		export type OnErrorEvent = {
 		    event: Kit.LoadEvent
@@ -682,7 +682,7 @@ test('generates types for layout beforeLoad', async function () {
 		};
 
 		export type BeforeLoadEvent = LayoutLoadEvent;
-		type BeforeLoadReturn = Awaited<ReturnType<typeof import("./+layout").beforeLoad>>;
+		type BeforeLoadReturn = Awaited<ReturnType<typeof import("./+layout")._houdini_beforeLoad>>;
 		export type MyPageLoad1QueryVariables = VariableFunction<LayoutParams, MyPageLoad1Query$input>;
 	`)
 })
@@ -789,7 +789,7 @@ test('generates types for page beforeLoad', async function () {
 		};
 
 		export type BeforeLoadEvent = PageLoadEvent;
-		type BeforeLoadReturn = Awaited<ReturnType<typeof import("./+page").beforeLoad>>;
+		type BeforeLoadReturn = Awaited<ReturnType<typeof import("./+page")._houdini_beforeLoad>>;
 		export type MyPageLoad1QueryVariables = VariableFunction<PageParams, MyPageLoad1Query$input>;
 	`)
 })
@@ -895,7 +895,7 @@ test('generates types for layout afterLoad', async function () {
 		    MyPageLoad1Query: MyPageLoad1Query$input
 		};
 
-		type AfterLoadReturn = Awaited<ReturnType<typeof import("./+layout").afterLoad>>;
+		type AfterLoadReturn = Awaited<ReturnType<typeof import("./+layout")._houdini_afterLoad>>;
 
 		type AfterLoadData = {
 		    MyPageLoad1Query: MyPageLoad1Query$result
@@ -1013,7 +1013,7 @@ test('generates types for page afterLoad', async function () {
 		    MyPageLoad1Query: MyPageLoad1Query$input
 		};
 
-		type AfterLoadReturn = Awaited<ReturnType<typeof import("./+page").afterLoad>>;
+		type AfterLoadReturn = Awaited<ReturnType<typeof import("./+page")._houdini_afterLoad>>;
 
 		type AfterLoadData = {
 		    MyPageLoad1Query: MyPageLoad1Query$result


### PR DESCRIPTION
Fixes an issue with `AfterLoadReturn`, `BeforeLoadReturn` and `OnErrorReturn` types. 

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

