### PR TITLE
Svelte plugin loads env vars from vite with kit config

### DIFF
--- a/.changeset/green-tables-share.md
+++ b/.changeset/green-tables-share.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Load env from .env files

--- a/.changeset/pretty-experts-fly.md
+++ b/.changeset/pretty-experts-fly.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Add env hook to plugins

--- a/packages/houdini-svelte/package.json
+++ b/packages/houdini-svelte/package.json
@@ -35,7 +35,8 @@
         "graphql": "^15.8.0",
         "houdini": "workspace:^",
         "recast": "^0.23.1",
-        "svelte": "^3.55.0"
+        "svelte": "^3.55.0",
+        "vite": "^4.0.1"
     },
     "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0"

--- a/packages/houdini-svelte/src/plugin/index.ts
+++ b/packages/houdini-svelte/src/plugin/index.ts
@@ -164,11 +164,15 @@ export const error = svelteKitError
 	},
 
 	async env({ config }) {
+		if (_env) {
+			return _env
+		}
+
 		// the first thing we have to do is load the sveltekit config file
 		const config_file = path.join(config.projectRoot, 'svelte.config.js')
 
 		// load the SvelteKit config file
-		let svelte_kit_cfg = {}
+		let svelte_kit_cfg: Record<string, Record<string, string>> = {}
 		try {
 			svelte_kit_cfg = !fs.existsSync(config_file)
 				? {}
@@ -176,7 +180,9 @@ export const error = svelteKitError
 		} catch {}
 
 		// load the vite config
-		return loadEnv('dev', svelte_kit_cfg.kit?.dir || '.', '')
+		_env = loadEnv('dev', svelte_kit_cfg.kit?.dir || '.', '')
+
+		return _env
 	},
 })
 

--- a/packages/houdini-svelte/src/plugin/index.ts
+++ b/packages/houdini-svelte/src/plugin/index.ts
@@ -1,4 +1,6 @@
 import { HoudiniError, PluginFactory, path, fs } from 'houdini'
+import * as url from 'url'
+import { loadEnv } from 'vite'
 
 import generate from './codegen'
 import extract from './extract'
@@ -160,7 +162,22 @@ export const error = svelteKitError
 			framework = 'kit'
 		} catch {}
 	},
+
+	async env({ config }) {
+		// the first thing we have to do is load the sveltekit config file
+		const config_file = path.join(config.projectRoot, 'svelte.config.js')
+
+		// load the SvelteKit config file
+		let svelte_kit_cfg = !fs.existsSync(config_file)
+			? {}
+			: await import(`${url.pathToFileURL(config_file).href}?ts=${Date.now()}`)
+
+		// load the vite config
+		return loadEnv('dev', svelte_kit_cfg.kit?.dir || '.', '')
+	},
 })
+
+let _env: Record<string, string>
 
 export default HoudiniSveltePlugin
 

--- a/packages/houdini-svelte/src/plugin/index.ts
+++ b/packages/houdini-svelte/src/plugin/index.ts
@@ -168,9 +168,12 @@ export const error = svelteKitError
 		const config_file = path.join(config.projectRoot, 'svelte.config.js')
 
 		// load the SvelteKit config file
-		let svelte_kit_cfg = !fs.existsSync(config_file)
-			? {}
-			: await import(`${url.pathToFileURL(config_file).href}?ts=${Date.now()}`)
+		let svelte_kit_cfg = {}
+		try {
+			svelte_kit_cfg = !fs.existsSync(config_file)
+				? {}
+				: await import(`${url.pathToFileURL(config_file).href}?ts=${Date.now()}`)
+		} catch {}
 
 		// load the vite config
 		return loadEnv('dev', svelte_kit_cfg.kit?.dir || '.', '')

--- a/packages/houdini/src/cmd/generate.ts
+++ b/packages/houdini/src/cmd/generate.ts
@@ -32,8 +32,9 @@ export async function generate(
 		if (args.output) {
 			config.persistedQueryPath = args.output
 		}
+
 		// Pull the newest schema if the flag is set
-		if (args.pullSchema && config.apiUrl) {
+		if (args.pullSchema && (await config.apiURL())) {
 			// backwards compat
 			if (args.pullHeader) {
 				console.log('⚠️ --pull-headers has been replaced by --headers (abbreviated -h)')

--- a/packages/houdini/src/cmd/pullSchema.ts
+++ b/packages/houdini/src/cmd/pullSchema.ts
@@ -2,9 +2,9 @@ import { getConfig, pullSchema, path } from '../lib'
 
 export default async function (args: { headers: string[] }) {
 	const config = await getConfig({ noSchema: true })
-
+	const apiURL = await config.apiURL()
 	// Check if apiUrl is set in config
-	if (!config.apiUrl) {
+	if (!apiURL) {
 		console.log(
 			'❌ Your project does not have a remote endpoint configured. Please provide one with the `apiUrl` value in your houdini.config.js file.'
 		)
@@ -33,7 +33,7 @@ export default async function (args: { headers: string[] }) {
 
 	// Write the schema
 	await pullSchema(
-		config.apiUrl,
+		apiURL,
 		config.schemaPath ? config.schemaPath : path.resolve(targetPath, 'schema.json'),
 		headers
 	)

--- a/packages/houdini/src/cmd/pullSchema.ts
+++ b/packages/houdini/src/cmd/pullSchema.ts
@@ -15,7 +15,7 @@ export default async function (args: { headers: string[] }) {
 	// The target path -> current working directory by default. Should we allow passing custom paths?
 	const targetPath = process.cwd()
 
-	let headers = config.pullHeaders
+	let headers = await config.pullHeaders()
 	let headerStrings: string[] = []
 
 	if (args.headers) {

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -158,7 +158,6 @@ export class Config {
 		}
 
 		const env = await this.getEnv()
-
 		return this.processEnvValues(env, this.configFile.apiUrl)
 	}
 

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -83,7 +83,6 @@ export class Config {
 			schema,
 			schemaPath = './schema.graphql',
 			exclude = [],
-			apiUrl,
 			module = 'esm',
 			scalars,
 			cacheBufferSize,

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -201,12 +201,10 @@ export class Config {
 		const headers = Object.fromEntries(
 			Object.entries(this.schemaPollHeaders || {})
 				.map(([key, value]) => {
-					console.log(key, value)
 					let headerValue
 					if (typeof value === 'function') {
 						headerValue = value(env)
 					} else if (value.startsWith('env:')) {
-						console.log(env[''])
 						headerValue = env[value.slice('env:'.length)]
 					} else {
 						headerValue = value

--- a/packages/houdini/src/runtime/lib/config.ts
+++ b/packages/houdini/src/runtime/lib/config.ts
@@ -87,7 +87,7 @@ export type ConfigFile = {
 	/**
 	 * A url to use to pull the schema. For more information: https://www.houdinigraphql.com/api/cli#generate
 	 */
-	apiUrl?: string | ((env: any) => string)
+	apiUrl?: string | ((env: Record<string, string | undefined>) => string)
 
 	/**
 	 * An object describing custom scalars for your project. For more information: https://www.houdinigraphql.com/api/config#custom-scalars
@@ -172,7 +172,9 @@ export type ConfigFile = {
 	 * directly. If the value is a function, the current environment will be passed to your function so you can perform any
 	 * logic you need
 	 */
-	schemaPollHeaders?: Record<string, string | ((env: NodeJS.ProcessEnv) => string)>
+	schemaPollHeaders?:
+		| Record<string, string | ((env: Record<string, string | undefined>) => string)>
+		| ((env: Record<string, string | undefined>) => Record<string, string>)
 
 	/**
 	 * An object describing the plugins enabled for the project

--- a/packages/houdini/src/runtime/lib/config.ts
+++ b/packages/houdini/src/runtime/lib/config.ts
@@ -87,7 +87,7 @@ export type ConfigFile = {
 	/**
 	 * A url to use to pull the schema. For more information: https://www.houdinigraphql.com/api/cli#generate
 	 */
-	apiUrl?: string
+	apiUrl?: string | ((env: any) => string)
 
 	/**
 	 * An object describing custom scalars for your project. For more information: https://www.houdinigraphql.com/api/config#custom-scalars

--- a/packages/houdini/src/vite/schema.ts
+++ b/packages/houdini/src/vite/schema.ts
@@ -14,9 +14,10 @@ export default function HoudiniWatchSchemaPlugin(opts: PluginConfig = {}): Plugi
 			let nbPullError = 0
 
 			// validate the config
+			const apiURL = await config.apiURL()
 
 			// if there's no api url set, there's nothing to poll
-			if (!config.apiUrl) {
+			if (!apiURL) {
 				return
 			}
 
@@ -37,7 +38,7 @@ export default function HoudiniWatchSchemaPlugin(opts: PluginConfig = {}): Plugi
 				try {
 					// Write the schema
 					const schemaState = await pullSchema(
-						config.apiUrl!,
+						apiURL!,
 						config.schemaPath ?? path.resolve(process.cwd(), 'schema.json'),
 						await config.pullHeaders()
 					)

--- a/packages/houdini/src/vite/schema.ts
+++ b/packages/houdini/src/vite/schema.ts
@@ -39,7 +39,7 @@ export default function HoudiniWatchSchemaPlugin(opts: PluginConfig = {}): Plugi
 					const schemaState = await pullSchema(
 						config.apiUrl!,
 						config.schemaPath ?? path.resolve(process.cwd(), 'schema.json'),
-						config.pullHeaders
+						await config.pullHeaders()
 					)
 
 					nbPullError = schemaState ? 0 : nbPullError + 1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,6 +313,7 @@ importers:
             recast: ^0.23.1
             scripts: workspace:^
             svelte: ^3.55.0
+            vite: ^4.0.1
             vitest: ^0.23.4
         dependencies:
             '@kitql/helper': 0.5.0
@@ -323,6 +324,7 @@ importers:
             houdini: link:../houdini
             recast: 0.23.1
             svelte: 3.55.0
+            vite: 4.0.1
         devDependencies:
             '@types/minimatch': 5.1.2
             scripts: link:../_scripts

--- a/site/src/routes/api/config/+page.svx
+++ b/site/src/routes/api/config/+page.svx
@@ -13,7 +13,9 @@ All configuration for your houdini application is defined in a single file that 
 export default {
 	apiUrl: 'http://localhost:4000/graphql'
 	schemaPollHeaders: {
-		Authentication: "Bearer XYZ",
+		Authentication(env) {
+			return `Bearer ${env.AUTH_TOKEN}`
+		}
 	}
 }
 ```
@@ -25,7 +27,7 @@ By default, your config file can contain the following values:
 - `include` (optional, default: `"src/**/*.{svelte,graphql,gql,ts,js}"`): a pattern (or list of patterns) to identify source code files.
 - `exclude` (optional): a pattern (or list of patterns) that filters out files that match the include pattern
 - `schemaPath` (optional, default: `"./schema.graphql"`): the path to the static representation of your schema, can be a glob pointing to multiple files
-- `apiUrl` (optional): A url to use to pull the schema. If you don't pass an `apiUrl`, the kit plugin will not poll for schema changes. If you want to access an environment variable, prefix your string with `env:`, ie `env:PUBLIC_GRAPHQL_ENDPOINT`. For more information see the [pull-schema command docs](/api/cli#pull-schema).
+- `apiUrl` (optional, a string or function): Configures the url to use to pull the schema. If you don't pass an `apiUrl`, the kit plugin will not poll for schema changes. If you want to access an environment variable, you can either prefix your string with `env:` or set it to a function that takes the current environment and returns a string. For more information see the [section below](#environment-variables).
 - `module` (optional, default: `"esm"`): One of `"esm"` or `"commonjs"`. Used to tell the artifact generator what kind of modules to create. (default: `esm`)
 - `definitionsPath` (optional, default: `"$houdini/graphql"`): a path that the generator will use to write `schema.graphql` and `documents.gql` files containing all of the internal fragment and directive definitions used in the project.
 - `scalars` (optional): An object describing custom scalars for your project (see below).
@@ -36,7 +38,7 @@ By default, your config file can contain the following values:
 - `types` (optional): an object that customizes the resolution behavior for a specific type. For more information see the [Caching Guide](/guides/caching-data#custom-ids).
 - `logLevel` (optional, default: `"summary"`): Specifies the style of logging houdini will use when generating your file. One of "quiet", "full", "summary", or "short-summary".
 - `defaultFragmentMasking` (optional, default: `enable`): `"enable"` to mask fragment and use collocated data requirement as best or `"disable"` to access fragment data directly in operation. Can be overridden individually at fragment level.
-- `schemaPollHeaders` (optional): An object specifying the headers to use when pulling your schema. Keys of the object are header names and its values can be either a strings or a function that takes the current `process.env` and returns the the value to use. If you want to access an environment variable, prefix your string with `env:`, ie `env:API_KEY`.
+- `schemaPollHeaders` (optional): An object specifying the headers to use when pulling your schema. Keys of the object are header names and its values can be either a strings or a function that takes the current `process.env` and returns the the value to use. If you want to access an environment variable, prefix your string with `env:`, ie `env:API_KEY`. For more information see the [section below](#environment-variables).
 - `schemaPollInterval` (optional, default: `2000`): Configures the schema polling behavior for the kit plugin. If its value is greater than `0`, the plugin will poll the set number of milliseconds. If set to `0`, the plugin will only pull the schema when you first run `dev`. If you set to `null`, the plugin will never look for schema changes. You can see use the [pull-schema command](/api/cli#pull-schema) to get updates.
 - `defaultListTarget` (optional): Can be set to `all` for all list operations to ignore parent ID and affect all lists with the name.
 - `defaultListPosition` (optional, default: "first"): One of `"first"` or `"last"` to indicate the default location for list operations.

--- a/site/src/routes/api/config/+page.svx
+++ b/site/src/routes/api/config/+page.svx
@@ -92,3 +92,31 @@ export default {
 	}
 }
 ```
+
+## Environment Variables
+
+There are a few different options for using environment variables in your `apiUrl` and `schemaPollHeaders`
+config values. Keep in mind that Houdini will look for `.env` and `.env.local` files for environment variables.
+For simple cases, you can just prepend `env:` to the value:
+
+```javascript
+export default {
+	schemaPollHeaders: {
+		Authentication: "env:AUTH_TOKEN",
+	}
+}
+```
+
+In other situations, the environment variable can't be used directly. For example to prepend `Bearer` to the
+value. For these situations, the values of the object should get set to a function that will receive the current
+environment variables:
+
+```javascript
+export default {
+	schemaPollHeaders: {
+		Authentication: function(env) {
+			return `Bearer ${env.AUTH_TOKEN}`
+		},
+	}
+}
+```


### PR DESCRIPTION
Fixes #759 #780 

This PR adds a new hook to the plugin setup `env` that lets plugins define custom environment variables. The svelte plugin uses this hook to load environment variables using vite's `loadEnv` util and follows any configuration values set by the user's `svelte.config.js` file

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] ~If applicable, add a test that would fail without this fix~
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

