### PR TITLE
Cache list operation types

### DIFF
--- a/.changeset/smart-zebras-turn.md
+++ b/.changeset/smart-zebras-turn.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix error in generated types for list operations

--- a/packages/houdini/src/codegen/generators/typescript/imperativeCache.test.ts
+++ b/packages/houdini/src/codegen/generators/typescript/imperativeCache.test.ts
@@ -297,7 +297,7 @@ test('generates type definitions for the imperative API', async function () {
 		    };
 		    lists: {
 		        All_Users: {
-		            type: "User";
+		            types: "User";
 		            filters: {
 		                filter?: UserFilter | null | undefined;
 		                list?: (UserFilter)[];
@@ -309,7 +309,7 @@ test('generates type definitions for the imperative API', async function () {
 		            };
 		        };
 		        NoArgs: {
-		            type: "User" | "Cat";
+		            types: "User" | "Cat";
 		            filters: never;
 		        };
 		    };

--- a/packages/houdini/src/codegen/generators/typescript/imperativeCache.ts
+++ b/packages/houdini/src/codegen/generators/typescript/imperativeCache.ts
@@ -307,7 +307,7 @@ function listDefinitions(
 						AST.tsTypeAnnotation(
 							AST.tsTypeLiteral([
 								AST.tsPropertySignature(
-									AST.identifier('type'),
+									AST.identifier('types'),
 									AST.tsTypeAnnotation(
 										AST.tsUnionType(
 											possibleTypes.map((possible) =>


### PR DESCRIPTION
This PR fixes an issue with the generated typedefs for lists

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [ ] ~Add a message that clearly describes the fix~
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

