### PR TITLE
Fix error when prerendering application

### DIFF
--- a/.changeset/dull-starfishes-matter.md
+++ b/.changeset/dull-starfishes-matter.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Static configuration value can now be used to remove session infrastructure from application

--- a/packages/houdini-svelte/src/plugin/fsPatch.ts
+++ b/packages/houdini-svelte/src/plugin/fsPatch.ts
@@ -7,6 +7,7 @@ import {
 	is_root_layout,
 	is_root_layout_server,
 	is_route_script,
+	plugin_config,
 	resolve_relative,
 } from './kit'
 
@@ -197,7 +198,7 @@ filesystem.readdirSync = function (
 	if (
 		is_root_route(posix_filepath) &&
 		!contains('+layout.server.js', '+layout.server.ts') &&
-		!_config.configFile.static
+		!plugin_config(_config).static
 	) {
 		result.push(virtual_file('+layout.server.js', options))
 	}

--- a/packages/houdini-svelte/src/plugin/fsPatch.ts
+++ b/packages/houdini-svelte/src/plugin/fsPatch.ts
@@ -1,6 +1,7 @@
 import filesystem, { Dirent, PathLike } from 'fs'
-import { fs, Plugin, path } from 'houdini'
+import { fs, Plugin, path, Config } from 'houdini'
 
+import { _config } from '.'
 import {
 	Framework,
 	is_root_layout,
@@ -193,7 +194,11 @@ filesystem.readdirSync = function (
 	}
 	// if we are in looking inside of src/routes and there's no +layout.server.js file
 	// we need to create one
-	if (is_root_route(posix_filepath) && !contains('+layout.server.js', '+layout.server.ts')) {
+	if (
+		is_root_route(posix_filepath) &&
+		!contains('+layout.server.js', '+layout.server.ts') &&
+		!_config.configFile.static
+	) {
 		result.push(virtual_file('+layout.server.js', options))
 	}
 

--- a/packages/houdini-svelte/src/plugin/fsPatch.ts
+++ b/packages/houdini-svelte/src/plugin/fsPatch.ts
@@ -1,5 +1,5 @@
 import filesystem, { Dirent, PathLike } from 'fs'
-import { fs, Plugin, path, Config } from 'houdini'
+import { fs, Plugin, path } from 'houdini'
 
 import { _config } from '.'
 import {

--- a/packages/houdini-svelte/src/plugin/index.ts
+++ b/packages/houdini-svelte/src/plugin/index.ts
@@ -1,4 +1,4 @@
-import { HoudiniError, PluginFactory, path, fs } from 'houdini'
+import { HoudiniError, PluginFactory, path, fs, type Config } from 'houdini'
 import * as url from 'url'
 import { loadEnv } from 'vite'
 
@@ -17,6 +17,8 @@ import apply_transforms from './transforms'
 import validate from './validate'
 
 let framework: Framework = 'svelte'
+
+export let _config: Config
 
 const HoudiniSveltePlugin: PluginFactory = async () => ({
 	order: 'core',
@@ -131,6 +133,7 @@ export const error = svelteKitError
 	 */
 
 	async after_load(cfg) {
+		_config = cfg
 		const cfgPlugin = plugin_config(cfg)
 
 		let client_file_exists = false

--- a/packages/houdini/src/runtime/lib/config.ts
+++ b/packages/houdini/src/runtime/lib/config.ts
@@ -192,6 +192,11 @@ export type ConfigFile = {
 	 * you must enable this flag.
 	 */
 	acceptImperativeInstability?: boolean
+
+	/**
+	 * Configure your houdini app to run in without sessions
+	 */
+	static?: boolean
 }
 
 type ScalarMap = { [typeName: string]: ScalarSpec }

--- a/packages/houdini/src/runtime/lib/config.ts
+++ b/packages/houdini/src/runtime/lib/config.ts
@@ -192,11 +192,6 @@ export type ConfigFile = {
 	 * you must enable this flag.
 	 */
 	acceptImperativeInstability?: boolean
-
-	/**
-	 * Configure your houdini app to run in without sessions
-	 */
-	static?: boolean
 }
 
 type ScalarMap = { [typeName: string]: ScalarSpec }

--- a/site/src/routes/api/config/+page.svx
+++ b/site/src/routes/api/config/+page.svx
@@ -66,7 +66,7 @@ Here is a summary of the possible configuration values:
 - `pageQueryFilename` (optional, default: `+page.gql`): The name of the file used to define page queries.
 - `layoutQueryFilename` (optional, default: `+layout.gql`): The name of the file used to define layout queries.
 - `quietQueryErrors` (optional, default: `false`): With this enabled, errors in your query will not be thrown as exceptions. You will have to handle error state in your route components or by hand in your load (or the onError hook)
-- `static` (optional, default: `false`): A flag to treat every component as a non-route.
+- `static` (optional, default: `false`): A flag to remove the session infrastructure from your application
 
 ## Custom Scalars
 


### PR DESCRIPTION
Fixes #739 

This PR extends the existing `static` config value for the svelte plugin to prevent the session infrastructure from being generated since a `.server.js` file confuses kit when prerendering applications

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

