### PR TITLE
Load with satisfies expression

### DIFF
--- a/.changeset/brown-jobs-admire.md
+++ b/.changeset/brown-jobs-admire.md
@@ -1,0 +1,6 @@
+---
+'houdini-svelte': patch
+'houdini': patch
+---
+
+Fix erorr when using satisfies expression with load functions

--- a/packages/houdini-svelte/src/plugin/transforms/kit/load.test.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/kit/load.test.ts
@@ -1357,3 +1357,34 @@ test('onError hook', async function () {
 		}
 	`)
 })
+
+test('existing loads with parens', async function () {
+	const route = await route_test({
+		script: `
+			import type { LayoutServerLoad } from "./$types";
+
+			export const load = (() => ({ test: "Hello" })) satisfies LayoutServerLoad;
+			`,
+		component: `
+				<script>
+					const result = graphql\`
+						query TestQuery1 {
+							viewer {
+								id
+							}
+						}
+					\`
+				</script>
+			`,
+	})
+
+	// make sure we added the right stuff
+	expect(route.script).toMatchInlineSnapshot(`
+		import _TestQuery1Artifact from "$houdini/artifacts/TestQuery1";
+		import type { LayoutServerLoad } from "./$types";
+
+		export const load = (() => ({
+		    test: "Hello"
+		})) satisfies LayoutServerLoad;
+	`)
+})

--- a/packages/houdini-svelte/src/plugin/transforms/kit/session.test.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/kit/session.test.ts
@@ -117,6 +117,33 @@ test('modifies existing load +layout.server.js - no return', async function () {
 	`)
 })
 
+test('modifies existing load +layout.server.js - satisfies operator', async function () {
+	const result = await test_transform_js(
+		'src/routes/+layout.server.js',
+		`
+			import type { LayoutServerLoad } from "./$types";
+
+			export const load = (() => ({ test: "Hello" })) satisfies LayoutServerLoad;
+		`
+	)
+
+	expect(result).toMatchInlineSnapshot(`
+		import { buildSessionObject } from "$houdini/plugins/houdini-svelte/runtime/session";
+		import type { LayoutServerLoad } from "./$types";
+
+		export const load = (event => {
+		    const __houdini__vite__plugin__return__value__ = ({
+		        test: "Hello"
+		    });
+
+		    return {
+		        ...buildSessionObject(event),
+		        ...__houdini__vite__plugin__return__value__
+		    };
+		}) satisfies LayoutServerLoad;
+	`)
+})
+
 test('modifies existing load +layout.server.js - rest params', async function () {
 	const result = await test_transform_js(
 		'src/routes/+layout.server.js',

--- a/packages/houdini/src/vite/ast.ts
+++ b/packages/houdini/src/vite/ast.ts
@@ -26,7 +26,9 @@ export function find_exported_fn(
 	body: Statement[],
 	name: string
 ): FunctionDeclaration | FunctionExpression | ArrowFunctionExpression | null {
+	console.log(body)
 	for (const statement of body) {
+		console.log(statement)
 		if (statement.type !== 'ExportNamedDeclaration') {
 			continue
 		}
@@ -44,7 +46,6 @@ export function find_exported_fn(
 		// we also need to find exported variables that are functions or arrow functions
 		else if (exportDeclaration.declaration?.type === 'VariableDeclaration') {
 			const value = exportDeclaration.declaration as VariableDeclaration
-
 			// make sure that the declared value has a matching name
 			if (
 				value.declarations.length !== 1 ||
@@ -57,12 +58,19 @@ export function find_exported_fn(
 
 			// we only care about this exported thing if it's a function or arrow function
 			const declaration = value.declarations[0]
+			// grab the initialized value
+			let { init } = declaration
+			if (!init) {
+				continue
+			}
 
-			if (
-				declaration.init?.type === 'FunctionExpression' ||
-				declaration.init?.type === 'ArrowFunctionExpression'
-			) {
-				return declaration.init
+			// if the value is a satisfies expression, we need to use the actual expression
+			if (init.type === 'TSSatisfiesExpression') {
+				init = init.expression
+			}
+
+			if (init.type === 'FunctionExpression' || init.type === 'ArrowFunctionExpression') {
+				return init
 			}
 		}
 		// it wasn't something we care about, move along


### PR DESCRIPTION
Fixes #792 

This PR fixes a bug when using the `satisfies` keyword with load functions

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

