### PR TITLE
mutation result can never be undefined

### DIFF
--- a/.changeset/heavy-pumas-wink.md
+++ b/.changeset/heavy-pumas-wink.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Mutation store result types can never be undefined

--- a/packages/houdini-svelte/src/plugin/codegen/stores/mutation.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/stores/mutation.ts
@@ -32,7 +32,7 @@ export class ${storeName} extends ${store_class} {
 	// the type definitions for the store
 	const typeDefs = `import type { ${_input}, ${_data}, ${_optimistic}, ${store_class} } from '$houdini'
 
-export declare class ${storeName} extends ${store_class}<${_data} | undefined, ${_input}, ${_optimistic}>{
+export declare class ${storeName} extends ${store_class}<${_data}, ${_input}, ${_optimistic}>{
 	constructor() {
 		// @ts-ignore
 		super({})


### PR DESCRIPTION
This PR fixes the mutation store to never have `undefined` as a return type (again)

