### PR TITLE
fix error type in onError handler

### DIFF
--- a/.changeset/forty-pugs-exercise.md
+++ b/.changeset/forty-pugs-exercise.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix onError error type

--- a/e2e/_api/graphql.mjs
+++ b/e2e/_api/graphql.mjs
@@ -133,7 +133,7 @@ export const resolvers = {
 			}
 
 			if (!user) {
-				throw new Error('User not found')
+				throw new GraphQLYogaError('User not found', { code: 404 })
 			}
 			return user
 		},

--- a/e2e/_api/graphql.mjs
+++ b/e2e/_api/graphql.mjs
@@ -133,7 +133,7 @@ export const resolvers = {
 			}
 
 			if (!user) {
-				throw new GraphQLYogaError('User not found', { code: 404 })
+				throw new Error('User not found')
 			}
 			return user
 		},

--- a/e2e/sveltekit/src/routes/plugin/query/onError/+page.svelte
+++ b/e2e/sveltekit/src/routes/plugin/query/onError/+page.svelte
@@ -4,5 +4,5 @@
 </script>
 
 <div id="result">
-  {data.fancyMessage}
+  {data.fancyMessage},{data.errorMessage}
 </div>

--- a/e2e/sveltekit/src/routes/plugin/query/onError/+page.ts
+++ b/e2e/sveltekit/src/routes/plugin/query/onError/+page.ts
@@ -1,5 +1,7 @@
 import { graphql } from '$houdini';
 
+import type { OnErrorEvent } from './$houdini';
+
 export const _houdini_load = graphql`
   query PreprocessorOnErrorTestQuery {
     user(id: "1000", snapshot: "preprocess-on-error-test-simple") {
@@ -8,8 +10,9 @@ export const _houdini_load = graphql`
   }
 `;
 
-export const _houdini_onError = () => {
+export const _houdini_onError = (event: OnErrorEvent) => {
   return {
+    errorMessage: event.error.body.message,
     fancyMessage: 'hello'
   };
 };

--- a/e2e/sveltekit/src/routes/plugin/query/onError/spec.ts
+++ b/e2e/sveltekit/src/routes/plugin/query/onError/spec.ts
@@ -6,13 +6,13 @@ test.describe('query preprocessor', () => {
   test('onError hook', async ({ page }) => {
     await goto(page, routes.Plugin_query_onError);
 
-    await expectToBe(page, 'hello');
+    await expectToBe(page, 'hello,User not found');
   });
 
   test('onError hook blocks on client', async ({ page }) => {
     await goto(page, routes.Home);
     await clientSideNavigation(page, routes.Plugin_query_onError);
 
-    await expectToBe(page, 'hello');
+    await expectToBe(page, 'hello,User not found');
   });
 });

--- a/e2e/sveltekit/src/routes/plugin/query/onError/spec.ts
+++ b/e2e/sveltekit/src/routes/plugin/query/onError/spec.ts
@@ -6,13 +6,13 @@ test.describe('query preprocessor', () => {
   test('onError hook', async ({ page }) => {
     await goto(page, routes.Plugin_query_onError);
 
-    await expectToBe(page, 'hello,User not found');
+    await expectToBe(page, 'hello,User not found.');
   });
 
   test('onError hook blocks on client', async ({ page }) => {
     await goto(page, routes.Home);
     await clientSideNavigation(page, routes.Plugin_query_onError);
 
-    await expectToBe(page, 'hello,User not found');
+    await expectToBe(page, 'hello,User not found.');
   });
 });

--- a/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
@@ -366,7 +366,7 @@ function append_onError(onError: boolean, type: 'Layout' | 'Page', hasLoadInput:
 type OnErrorReturn = Awaited<ReturnType<typeof import('./+${type.toLowerCase()}').${houdini_on_error_fn}>>;
 export type OnErrorEvent =  { event: Kit.LoadEvent, input: ${
 				hasLoadInput ? 'LoadInput' : '{}'
-		  }, error: Error | Error[] };
+		  }, error: Kit.HttpError };
 `
 		: ''
 }

--- a/packages/houdini-svelte/src/plugin/codegen/routes/kit.test.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/kit.test.ts
@@ -491,7 +491,7 @@ test('generates types for layout onError', async function () {
 		export type OnErrorEvent = {
 		    event: Kit.LoadEvent;
 		    input: LoadInput;
-		    error: Error | Error[];
+		    error: Kit.HttpError;
 		};
 
 		export type MyPageLoad1QueryVariables = VariableFunction<LayoutParams, MyPageLoad1Query$input>;
@@ -609,7 +609,7 @@ test('generates types for page onError', async function () {
 		export type OnErrorEvent = {
 		    event: Kit.LoadEvent;
 		    input: LoadInput;
-		    error: Error | Error[];
+		    error: Kit.HttpError;
 		};
 
 		export type MyPageLoad1QueryVariables = VariableFunction<PageParams, MyPageLoad1Query$input>;


### PR DESCRIPTION
This PR fixes the generated types for the onError hook to use the `HttpError` type provided by Kit