### PR TITLE
:sparkles: NEW: init with svelte files containing graphql things

### DIFF
--- a/.changeset/tasty-bags-end.md
+++ b/.changeset/tasty-bags-end.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+update init to have correct graphqlrc.yaml looking at svelte files

--- a/.graphqlrc.yaml
+++ b/.graphqlrc.yaml
@@ -6,4 +6,5 @@ projects:
             - e2e/sveltekit/$houdini/graphql/schema.graphql
         documents:
             - e2e/sveltekit/src/**/*.gql
+            - e2e/sveltekit/src/**/*.svelte
             - e2e/sveltekit/$houdini/graphql/documents.gql

--- a/packages/houdini/src/cmd/init.ts
+++ b/packages/houdini/src/cmd/init.ts
@@ -530,6 +530,7 @@ async function graphqlRCFile(targetPath: string) {
       - ./$houdini/graphql/schema.graphql
     documents:
       - '**/*.gql'
+      - '**/*.svelte'
       - ./$houdini/graphql/documents.gql
 `
 


### PR DESCRIPTION
Update the default `.graphqlrc.yaml` to check for svelte files.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] ~If applicable, add a test that would fail without this fix~
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

