### PR TITLE
Fix typo in the documentation

### DIFF
--- a/site/src/routes/guides/pagination/+page.svx
+++ b/site/src/routes/guides/pagination/+page.svx
@@ -80,7 +80,7 @@ info can be looked up with the `pageInfo` field of store's value:
 </script>
 
 {#if $userInfo.pageInfo.hasNextPage}
-	<button on:click=={userInfo.loadNextPage}>
+	<button on:click={userInfo.loadNextPage}>
 		load more
 	</button>
 {/if}

--- a/site/src/routes/guides/uploading-files/+page.svx
+++ b/site/src/routes/guides/uploading-files/+page.svx
@@ -26,7 +26,7 @@ element and pass it to the mutation:
 
     const UploadFile = graphql(`
         mutation UploadFile($file: File!) {
-            uploadImage(file: File)
+            uploadImage(file: $file)
         }
     `)
 </script>


### PR DESCRIPTION
Before
```svelte
{#if $userInfo.pageInfo.hasNextPage}
    <button on:click=={userInfo.loadNextPage}>
        load more
    </button>
{/if}
```

After:
```svelte
{#if $userInfo.pageInfo.hasNextPage}
    <button on:click={userInfo.loadNextPage}>
        load more
    </button>
{/if}
```

Fixes typo

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [] If applicable, add a test that would fail without this fix
- [] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [] Includes a changeset if your fix affects the user with `pnpm changeset`

