### PR TITLE
Change spread order to get deep merge

### DIFF
--- a/packages/houdini-svelte/src/plugin/kit.ts
+++ b/packages/houdini-svelte/src/plugin/kit.ts
@@ -366,6 +366,7 @@ export function plugin_config(config: Config): Required<HoudiniSvelteConfig> {
 		layoutQueryFilename: '+layout.gql',
 		quietQueryErrors: false,
 		static: false,
+		...cfg,
 		customStores: {
 			query: '$houdini/plugins/houdini-svelte/runtime/stores.QueryStore',
 			mutation: '$houdini/plugins/houdini-svelte/runtime/stores.MutationStore',
@@ -383,7 +384,6 @@ export function plugin_config(config: Config): Required<HoudiniSvelteConfig> {
 			fragmentOffset: '$houdini/plugins/houdini-svelte/runtime/stores.FragmentStoreOffset',
 			...cfg?.customStores,
 		},
-		...cfg,
 	}
 }
 


### PR DESCRIPTION
Fixes an issue due to the wrong order in merging custom stores configuration: in case only a subset of the standard store is customized, the names of the remaining ones get lost.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [ ] Includes a changeset if your fix affects the user with `pnpm changeset`

