### PR TITLE
fix dangling inline fragments when flattening fragments with unions

### DIFF
--- a/.changeset/green-walls-battle.md
+++ b/.changeset/green-walls-battle.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix syntax error when generating artifacts for queries that contain fragments with direct inline fragment children

--- a/packages/houdini/src/codegen/generators/artifacts/selection.test.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/selection.test.ts
@@ -1,0 +1,89 @@
+import * as graphql from 'graphql'
+import { test, expect } from 'vitest'
+
+import { mockCollectedDoc, testConfig } from '../../../test'
+import { flattenSelections } from '../../utils'
+import selection from './selection'
+
+test('fragments of unions inject correctly', function () {
+	const document = graphql.parse(`
+        query { 
+            entities {
+                ...EntityInfo
+            }
+        }
+
+        fragment EntityInfo on Entity { 
+            ... on User { 
+                firstName
+            }
+            ... on Cat { 
+                name
+            }
+        }
+    `)
+
+	const config = testConfig()
+	const fragmentDefinitions = {
+		EntityInfo: document.definitions.find(
+			(def): def is graphql.FragmentDefinitionNode => def.kind === 'FragmentDefinition'
+		)!,
+	}
+
+	const flat = flattenSelections({
+		config,
+		filepath: '',
+		selections: document.definitions.find(
+			(def): def is graphql.OperationDefinitionNode => def.kind === 'OperationDefinition'
+		)!.selectionSet.selections,
+		fragmentDefinitions,
+		ignoreMaskDisable: true,
+		applyFragments: true,
+	})
+
+	const artifactSelection = selection({
+		config,
+		filepath: '',
+		rootType: 'Query',
+		operations: {},
+		selections: flat,
+		includeFragments: false,
+		document: mockCollectedDoc(`
+        query Query { 
+            entities {
+                ...EntityInfo
+            }
+        }`),
+	})
+
+	expect(artifactSelection).toMatchInlineSnapshot(`
+		{
+		    "fields": {
+		        "entities": {
+		            "type": "Entity",
+		            "keyRaw": "entities",
+		            "selection": {
+		                "abstractFields": {
+		                    "fields": {
+		                        "User": {
+		                            "firstName": {
+		                                "type": "String",
+		                                "keyRaw": "firstName"
+		                            }
+		                        },
+		                        "Cat": {
+		                            "name": {
+		                                "type": "String",
+		                                "keyRaw": "name"
+		                            }
+		                        }
+		                    },
+		                    "typeMap": {}
+		                }
+		            },
+		            "abstract": true
+		        }
+		    }
+		}
+	`)
+})


### PR DESCRIPTION
Fixes #819 

This PR fixes a bug during artifact generation when computing the selection of a query that contained a reference whose immediate children were inline fragments (ie for a union or interface).

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

