### PR TITLE
On schema change, revalidate documents

### DIFF
--- a/.changeset/plenty-llamas-deliver.md
+++ b/.changeset/plenty-llamas-deliver.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+on schema change, revalidate all document. No need to restart vite to pick up changes.

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -744,17 +744,20 @@ let pendingConfigPromise: Promise<Config> | null = null
 export async function getConfig({
 	configPath = DEFAULT_CONFIG_PATH,
 	noSchema,
+	forceReload,
 	...extraConfig
-}: PluginConfig & { noSchema?: boolean } = {}): Promise<Config> {
-	if (_config) {
-		return _config
-	}
+}: PluginConfig & { noSchema?: boolean; forceReload?: boolean } = {}): Promise<Config> {
+	// if we force a reload, we will bypass this part
+	if (!forceReload) {
+		if (_config) {
+			return _config
+		}
 
-	// if we have a pending promise, return the result of that
-	if (pendingConfigPromise) {
-		return await pendingConfigPromise
+		// if we have a pending promise, return the result of that
+		if (pendingConfigPromise) {
+			return await pendingConfigPromise
+		}
 	}
-
 	// there isn't a pending config so let's make one to claim
 	let resolve: (cfg: Config | PromiseLike<Config>) => void = () => {}
 	let reject = (message?: any) => {}

--- a/packages/houdini/src/vite/index.ts
+++ b/packages/houdini/src/vite/index.ts
@@ -27,11 +27,13 @@ export default function (opts?: PluginConfig): Plugin[] {
 				quiet: true,
 				async watchFile(filepath: string) {
 					// load the config file
-					const config = await getConfig(opts)
+					let config = await getConfig(opts)
 
 					// we need to watch some specific files
 					const schemaPath = path.join(path.dirname(config.filepath), config.schemaPath!)
 					if (minimatch(filepath, schemaPath)) {
+						// if it's a schema change, let's reload the config
+						config = await getConfig({ ...opts, forceReload: true })
 						return true
 					}
 


### PR DESCRIPTION
Fixes https://discord.com/channels/1024421016405016718/1068209851047616663/1068209851047616663

Reload the config on schema change.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] ~If applicable, add a test that would fail without this fix~
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

