### PR TITLE
Fix page.server files

### DIFF
--- a/.changeset/dull-pianos-greet.md
+++ b/.changeset/dull-pianos-greet.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix bug preventing server.js and page.gql files from coexisting

--- a/e2e/sveltekit/src/lib/utils/routes.ts
+++ b/e2e/sveltekit/src/lib/utils/routes.ts
@@ -60,6 +60,7 @@ export const routes = {
   Plugin_load_list: '/plugin/load/list',
   Plugin_load_pageQuery: '/plugin/load/pageQuery',
   Plugin_load_pageQuerySession: '/plugin/load/pageQuery-session',
+  Plugin_load_pageQuery_with_server: '/plugin/load/pageQuery-with-server',
 
   Pagination_query_forward_cursor: '/pagination/query/forward-cursor',
   Pagination_query_backwards_cursor: '/pagination/query/backwards-cursor',

--- a/e2e/sveltekit/src/routes/plugin/load/pageQuery-with-server/+page.gql
+++ b/e2e/sveltekit/src/routes/plugin/load/pageQuery-with-server/+page.gql
@@ -1,0 +1,5 @@
+query PageQueryWithServer {
+  user(id: "1", snapshot: "page-query-with-server") {
+    id
+  }
+}

--- a/e2e/sveltekit/src/routes/plugin/load/pageQuery-with-server/+page.svelte
+++ b/e2e/sveltekit/src/routes/plugin/load/pageQuery-with-server/+page.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { PageData } from './$houdini';
+  export let data: PageData;
+
+  $: ({ PageQueryWithServer } = data);
+</script>
+
+<div id="result">
+  {$PageQueryWithServer.data?.user.id}
+</div>

--- a/e2e/sveltekit/src/routes/plugin/load/pageQuery-with-server/spec.ts
+++ b/e2e/sveltekit/src/routes/plugin/load/pageQuery-with-server/spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test';
+import { routes } from '../../../../lib/utils/routes.js';
+import { expectToBe, goto } from '../../../../lib/utils/testsHelper.js';
+
+test.describe('query preprocessor', () => {
+  test('happy path query - SSR', async ({ page }) => {
+    await goto(page, routes.Plugin_load_pageQuery_with_server);
+
+    await expectToBe(page, 'page-query-with-server:1');
+  });
+});

--- a/packages/houdini-svelte/src/plugin/fsPatch.ts
+++ b/packages/houdini-svelte/src/plugin/fsPatch.ts
@@ -174,10 +174,7 @@ filesystem.readdirSync = function (
 	}
 
 	// if there is a route component but no script, add the script
-	if (
-		contains('+page.svelte', '+page.gql') &&
-		!contains('+page.js', '+page.ts', '+page.server.js', '+page.server.ts')
-	) {
+	if (contains('+page.svelte', '+page.gql') && !contains('+page.js', '+page.ts')) {
 		result.push(virtual_file('+page.js', options))
 	}
 


### PR DESCRIPTION
This PR fixes an issue raised in discord that was preventing a `+page.gql` from loading if there was a `server` file. 

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

