### PR TITLE
Client plugins list of lists

### DIFF
--- a/.changeset/weak-islands-stare.md
+++ b/.changeset/weak-islands-stare.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Client plugins can return hooks, null, or list of hooks

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -1,7 +1,7 @@
-import type { SubscriptionSelection, ListWhen, SubscriptionSpec } from '../lib/types'
-import type { Cache, LinkedList } from './cache'
+import { flatten } from '../lib/flatten'
+import type { SubscriptionSelection, ListWhen, SubscriptionSpec, NestedList } from '../lib/types'
+import type { Cache } from './cache'
 import { rootID } from './cache'
-import { flattenList } from './stuff'
 
 export class ListManager {
 	rootID: string
@@ -330,7 +330,7 @@ export class List {
 				embeddedConnectionID,
 				'edges'
 			)
-			for (const edge of flattenList(edges as LinkedList) || []) {
+			for (const edge of flatten(edges as NestedList) || []) {
 				if (!edge) {
 					continue
 				}
@@ -354,7 +354,7 @@ export class List {
 
 		// if the id is not contained in the list, dont notify anyone
 		let value = this.cache._internal_unstable.storage.get(parentID, targetKey)
-			.value as LinkedList
+			.value as NestedList
 		if (!value || !value.includes(targetID)) {
 			return
 		}
@@ -455,11 +455,11 @@ export class List {
 
 		// grab the underlying value from the cache
 		let value = this.cache._internal_unstable.storage.get(this.recordID, this.key).value as
-			| LinkedList
+			| NestedList
 			| string
 
 		if (!this.connection) {
-			entries = flattenList(value as LinkedList)
+			entries = flatten(value as NestedList)
 		} else {
 			// connections need to reference the edges field for the list of entries
 			entries = this.cache._internal_unstable.storage.get(value as string, 'edges')

--- a/packages/houdini/src/runtime/cache/storage.ts
+++ b/packages/houdini/src/runtime/cache/storage.ts
@@ -1,5 +1,5 @@
+import { flatten } from '../lib/flatten'
 import type { GraphQLValue } from '../lib/types'
-import { flattenList } from './stuff'
 
 // NOTE: the current implementation of delete is slow. it should try to compare the
 // type of the id being deleted with the type contained in the linked list so that
@@ -178,7 +178,7 @@ export class InMemoryStorage {
 		}
 	}
 
-	writeLink(id: string, field: string, value: string | LinkedList) {
+	writeLink(id: string, field: string, value: string | NestedList) {
 		// write to the top most layer
 		return this.topLayer.writeLink(id, field, value)
 	}
@@ -309,10 +309,10 @@ export class Layer {
 		return this.id
 	}
 
-	writeLink(id: string, field: string, value: null | string | LinkedList): LayerID {
+	writeLink(id: string, field: string, value: null | string | NestedList): LayerID {
 		// if any of the values in this link are flagged to be deleted, undelete it
 		const valueList = Array.isArray(value) ? value : [value]
-		for (const value of flattenList(valueList)) {
+		for (const value of flatten(valueList)) {
 			if (!value) {
 				continue
 			}
@@ -510,13 +510,13 @@ export class Layer {
 	}
 }
 
-type GraphQLField = GraphQLValue | LinkedList
+type GraphQLField = GraphQLValue | NestedList
 
 type EntityMap<_Value> = { [id: string]: { [field: string]: _Value } }
 
 type EntityFieldMap = EntityMap<GraphQLField>
 
-type LinkMap = EntityMap<string | null | LinkedList>
+type LinkMap = EntityMap<string | null | NestedList>
 
 type OperationMap = {
 	[id: string]: {
@@ -526,7 +526,7 @@ type OperationMap = {
 	}
 }
 
-type LinkedList<_Result = string> = (_Result | null | LinkedList<_Result>)[]
+type NestedList<_Result = string> = (_Result | null | NestedList<_Result>)[]
 
 type InsertOperation = {
 	kind: OperationKind.insert

--- a/packages/houdini/src/runtime/cache/stuff.ts
+++ b/packages/houdini/src/runtime/cache/stuff.ts
@@ -1,26 +1,4 @@
 import type { GraphQLValue } from '../lib/types'
-import type { LinkedList } from './cache'
-
-export function flattenList<T>(source: LinkedList<T>): T[] {
-	const flat: T[] = []
-
-	// we need to flatten the list links
-	const unvisited = [source || []]
-	while (unvisited.length > 0) {
-		const target = unvisited.shift() as T[]
-
-		for (const id of target) {
-			if (Array.isArray(id)) {
-				unvisited.push(id)
-				continue
-			}
-
-			flat.push(id)
-		}
-	}
-
-	return flat
-}
 
 // given a raw key and a set of variables, generate the fully qualified key
 export function evaluateKey(key: string, variables: { [key: string]: GraphQLValue } = {}): string {

--- a/packages/houdini/src/runtime/cache/subscription.ts
+++ b/packages/houdini/src/runtime/cache/subscription.ts
@@ -1,7 +1,13 @@
+import { flatten } from '../lib/flatten'
 import { getFieldsForType } from '../lib/selection'
-import type { GraphQLValue, SubscriptionSelection, SubscriptionSpec } from '../lib/types'
-import type { Cache, LinkedList } from './cache'
-import { evaluateKey, flattenList } from './stuff'
+import type {
+	GraphQLValue,
+	SubscriptionSelection,
+	SubscriptionSpec,
+	NestedList,
+} from '../lib/types'
+import type { Cache } from './cache'
+import { evaluateKey } from './stuff'
 
 export type FieldSelection = [
 	SubscriptionSpec,
@@ -84,7 +90,7 @@ export class InMemorySubscriptions {
 				)
 				let children = !Array.isArray(linkedRecord)
 					? [linkedRecord]
-					: flattenList(linkedRecord) || []
+					: flatten(linkedRecord) || []
 
 				// add the subscriber to every child
 				for (const child of children) {
@@ -249,7 +255,7 @@ export class InMemorySubscriptions {
 					// figure out who else needs subscribers
 					const children = !Array.isArray(link)
 						? ([link] as string[])
-						: flattenList(link as string[])
+						: flatten(link as string[])
 
 					for (const linkedRecord of children) {
 						// avoid null records
@@ -314,7 +320,7 @@ export class InMemorySubscriptions {
 			// if its not a list, wrap it as one so we can dry things up
 			const links = !Array.isArray(previousValue)
 				? [previousValue as string]
-				: flattenList(previousValue as LinkedList)
+				: flatten(previousValue as NestedList)
 
 			for (const link of links) {
 				if (link !== null) {
@@ -381,7 +387,7 @@ export class InMemorySubscriptions {
 
 			// if the value is a single link , wrap it in a list. otherwise, flatten the link list
 			const nextTargets = Array.isArray(value)
-				? flattenList(value as LinkedList)
+				? flatten(value as NestedList)
 				: [value as string]
 
 			for (const id of nextTargets) {

--- a/packages/houdini/src/runtime/client/client.test.ts
+++ b/packages/houdini/src/runtime/client/client.test.ts
@@ -1,7 +1,7 @@
 import { expect, vi, test } from 'vitest'
 
 import { DataSource } from '../lib'
-import { ClientPlugin } from './documentStore'
+import type { ClientPlugin } from './documentStore'
 import { createStore } from './documentStore.test'
 
 test('createPluginHooks', async function () {

--- a/packages/houdini/src/runtime/client/client.test.ts
+++ b/packages/houdini/src/runtime/client/client.test.ts
@@ -1,0 +1,102 @@
+import { expect, vi, test } from 'vitest'
+
+import { DataSource } from '../lib'
+import { ClientPlugin } from './documentStore'
+import { createStore } from './documentStore.test'
+
+test('createPluginHooks', async function () {
+	const enter = vi.fn()
+	const create = vi.fn()
+
+	const plugins: ClientPlugin[] = [
+		() => [
+			{
+				start(ctx, { next }) {
+					enter(1)
+					next(ctx)
+				},
+			},
+		],
+		() => ({
+			start(ctx, { next }) {
+				enter(2)
+				next(ctx)
+			},
+		}),
+		() => [
+			{
+				start(ctx, { next }) {
+					enter(3)
+					next(ctx)
+				},
+			},
+			{
+				start(ctx, { next }) {
+					enter(4)
+					next(ctx)
+				},
+			},
+			() => {
+				create(1)
+				return [
+					{
+						start(ctx, { next }) {
+							enter(5)
+							next(ctx)
+						},
+					},
+					{
+						start(ctx, { next }) {
+							enter(6)
+							next(ctx)
+						},
+					},
+					() => {
+						create(2)
+						return [
+							{
+								start(ctx, { next }) {
+									enter(7)
+									next(ctx)
+								},
+							},
+							{
+								start(ctx, { resolve }) {
+									enter(8)
+									resolve(ctx, {
+										data: null,
+										errors: [],
+										fetching: false,
+										partial: false,
+										source: DataSource.Cache,
+										stale: false,
+										variables: {},
+									})
+								},
+							},
+						]
+					},
+				]
+			},
+		],
+	]
+
+	// create a document store out of the plugins
+	const store = createStore(plugins)
+
+	// go through the pipeline
+	await store.send()
+
+	// make sure the spies were call with the correct history
+	expect(enter).toHaveBeenNthCalledWith(1, 1)
+	expect(enter).toHaveBeenNthCalledWith(2, 2)
+	expect(enter).toHaveBeenNthCalledWith(3, 3)
+	expect(enter).toHaveBeenNthCalledWith(4, 4)
+	expect(enter).toHaveBeenNthCalledWith(5, 5)
+	expect(enter).toHaveBeenNthCalledWith(6, 6)
+	expect(enter).toHaveBeenNthCalledWith(7, 7)
+	expect(enter).toHaveBeenNthCalledWith(8, 8)
+
+	expect(create).toHaveBeenNthCalledWith(1, 1)
+	expect(create).toHaveBeenNthCalledWith(2, 2)
+})

--- a/packages/houdini/src/runtime/client/documentStore.test.ts
+++ b/packages/houdini/src/runtime/client/documentStore.test.ts
@@ -1,14 +1,14 @@
 import { sleep } from '@kitql/helper'
 import { test, expect, vi, beforeEach } from 'vitest'
 
-import { HoudiniClient } from '.'
+import { createPluginHooks, HoudiniClient } from '.'
 import { setMockConfig } from '../lib/config'
 import type { GraphQLObject } from '../lib/types'
 import { ArtifactKind, DataSource } from '../lib/types'
 import type { ClientPlugin } from './documentStore'
 import { DocumentStore } from './documentStore'
 
-function createStore(
+export function createStore(
 	plugins: ClientPlugin[],
 	fetching: boolean | undefined = undefined
 ): DocumentStore<GraphQLObject, Record<string, any>> {
@@ -18,7 +18,7 @@ function createStore(
 
 	return new DocumentStore({
 		client,
-		pipeline: plugins,
+		pipeline: createPluginHooks(plugins),
 		artifact: {
 			kind: ArtifactKind.Query,
 			hash: '1234',
@@ -49,7 +49,7 @@ function createStoreMutation(
 
 	return new DocumentStore({
 		client,
-		pipeline: plugins,
+		pipeline: createPluginHooks(plugins),
 		artifact: {
 			kind: ArtifactKind.Mutation,
 			hash: '1234',

--- a/packages/houdini/src/runtime/client/documentStore.ts
+++ b/packages/houdini/src/runtime/client/documentStore.ts
@@ -12,7 +12,6 @@ import type {
 	GraphQLObject,
 	QueryArtifact,
 	SubscriptionSpec,
-	NestedList,
 } from '../lib/types'
 import { ArtifactKind } from '../lib/types'
 import { cachePolicyPlugin } from './plugins'

--- a/packages/houdini/src/runtime/client/documentStore.ts
+++ b/packages/houdini/src/runtime/client/documentStore.ts
@@ -531,7 +531,7 @@ type IteratorState = {
 	}
 }
 
-export type ClientPlugin = () => ClientHooks | (ClientHooks | ClientPlugin | null)[]
+export type ClientPlugin = () => ClientHooks | null | (ClientHooks | ClientPlugin | null)[]
 
 export type ClientHooks = {
 	start?: ClientPluginEnterPhase

--- a/packages/houdini/src/runtime/client/index.ts
+++ b/packages/houdini/src/runtime/client/index.ts
@@ -106,6 +106,11 @@ export function createPluginHooks(plugins: ClientPlugin[]): ClientHooks[] {
 		// invoke the plugin
 		const result = plugin()
 
+		// ignore null results
+		if (!result) {
+			return hooks
+		}
+
 		// if we just have a single value, we're done
 		if (!Array.isArray(result)) {
 			return hooks.concat(result)

--- a/packages/houdini/src/runtime/client/index.ts
+++ b/packages/houdini/src/runtime/client/index.ts
@@ -1,9 +1,8 @@
 /// <reference path="../../../../../houdini.d.ts" />
 import { flatten } from '../lib/flatten'
 import type { DocumentArtifact, GraphQLObject, NestedList } from '../lib/types'
-import type { ClientPlugin } from './documentStore'
+import type { ClientPlugin, ClientHooks } from './documentStore'
 import { DocumentStore } from './documentStore'
-import type { ClientHooks } from './documentStore'
 import {
 	fetchParamsPlugin,
 	fetchPlugin,

--- a/packages/houdini/src/runtime/client/plugins/cache.test.ts
+++ b/packages/houdini/src/runtime/client/plugins/cache.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, expect, test, vi } from 'vitest'
 
-import { HoudiniClient } from '..'
+import { createPluginHooks, HoudiniClient } from '..'
 import { testConfigFile } from '../../../test'
 import { Cache } from '../../cache/cache'
 import { CachePolicy } from '../../lib'
@@ -294,7 +294,7 @@ export function createStore(plugins: ClientPlugin[]): DocumentStore<any, any> {
 	})
 
 	return new DocumentStore({
-		pipeline: plugins,
+		pipeline: createPluginHooks(plugins),
 		client,
 		cache: true,
 		artifact: {

--- a/packages/houdini/src/runtime/client/plugins/injectedPlugins.ts
+++ b/packages/houdini/src/runtime/client/plugins/injectedPlugins.ts
@@ -1,8 +1,9 @@
 // the actual contents of this file will be overwritten by the runtime generator
 // to include imports from plugins so that they can register middlewares as
 // part of the generation pipeline
+import type { NestedList } from '../../lib/types'
 import type { ClientPlugin } from '../documentStore'
 
-const plugins: ClientPlugin[] = []
+const plugins: NestedList<ClientPlugin> = []
 
 export default plugins

--- a/packages/houdini/src/runtime/client/utils/documentPlugins.ts
+++ b/packages/houdini/src/runtime/client/utils/documentPlugins.ts
@@ -1,7 +1,12 @@
 import type { ArtifactKind } from '../../lib/types'
-import type { ClientPlugin, ClientPluginExitPhase, ClientPluginEnterPhase } from '../documentStore'
+import type {
+	ClientPlugin,
+	ClientPluginExitPhase,
+	ClientPluginEnterPhase,
+	ClientHooks,
+} from '../documentStore'
 
-export const documentPlugin = (kind: ArtifactKind, source: ClientPlugin): ClientPlugin => {
+export const documentPlugin = (kind: ArtifactKind, source: () => ClientHooks): ClientPlugin => {
 	return () => {
 		// pull out the hooks we care about
 		const sourceHandlers = source()

--- a/packages/houdini/src/runtime/lib/flatten.test.ts
+++ b/packages/houdini/src/runtime/lib/flatten.test.ts
@@ -1,0 +1,7 @@
+import { test, expect } from 'vitest'
+
+import { flatten } from './flatten'
+
+test('flatten - happy path', function () {
+	expect(flatten([1, [2, [3, 4]], 5])).toEqual([1, 2, 3, 4, 5])
+})

--- a/packages/houdini/src/runtime/lib/flatten.ts
+++ b/packages/houdini/src/runtime/lib/flatten.ts
@@ -1,0 +1,24 @@
+import { NestedList } from './types'
+
+// flatten processes a deeply nested lists of lists
+export function flatten<T>(source?: NestedList<T>): T[] {
+	// if we dont have a list we're done
+	if (!source) {
+		return []
+	}
+
+	return source.reduce<T[]>((acc, element) => {
+		// null values get ignored
+		if (!element) {
+			return acc
+		}
+
+		// if we found an array, flatten it
+		if (Array.isArray(element)) {
+			return acc.concat(flatten(element))
+		}
+
+		// if we found an element, add it to the parent
+		return acc.concat(element)
+	}, [])
+}

--- a/packages/houdini/src/runtime/lib/flatten.ts
+++ b/packages/houdini/src/runtime/lib/flatten.ts
@@ -1,4 +1,4 @@
-import { NestedList } from './types'
+import type { NestedList } from './types'
 
 // flatten processes a deeply nested lists of lists
 export function flatten<T>(source?: NestedList<T>): T[] {

--- a/packages/houdini/src/runtime/lib/types.ts
+++ b/packages/houdini/src/runtime/lib/types.ts
@@ -216,3 +216,5 @@ export type RequestPayload<GraphQLObject = any> = {
 		  }[]
 		| null
 }
+
+export type NestedList<_Result = string> = (_Result | null | NestedList<_Result>)[]

--- a/site/src/routes/api/client-plugins/+page.svx
+++ b/site/src/routes/api/client-plugins/+page.svx
@@ -54,12 +54,50 @@ While preparing the request, plugins are iterated over in the order they are pas
 has been provided, its value is sent in reverse order through the list of plugins we've visited to potentially
 modify the response. For more information on this, please read the section on [Enter vs Exit hooks](#enter-vs-exit-hooks).
 
-## Create Your First Plugin
 
-If you are brand new to working with client plugins, we recommend creating a
-few very simple ones before getting too deep in the explanation:
+## Writing a Plugin
+
+A client plugin is defined as a function that returns an object with a fixed set of keys defining the "hooks" that you want
+to use:
+
+```javascript:title=src/plugins/custom_plugin.js
+import { plugin } from 'houdini'
+
+const sayHello: ClientPlugin = () => {
+    return {
+        start(ctx, { next }) {
+			// ...
+        }
+    }
+}
+```
+
 
 <AuthoringPluginsDive />
+
+<DeepDive title="Composing Plugins">
+
+Client plugins can be defined as a composition of many different sets of hooks.
+Your plugin can return any combination of hooks, null or lists of hooks -
+allowing you to easily toggle functionality depending on configuration values:
+
+```javascript:title=src/plugins/custom_plugin.js
+import { plugin } from 'houdini'
+import externalPlugin from 'third-party'
+
+const sayHello: ClientPlugin = () => {
+    return [
+		{
+			start(ctx, { next }) {
+				// ...
+			},
+    	},
+		externalPlugin
+	]
+}
+```
+
+</DeepDive>
 
 ## Enter vs Exit Hooks
 

--- a/site/src/routes/api/client-plugins/Authoring.svx
+++ b/site/src/routes/api/client-plugins/Authoring.svx
@@ -6,9 +6,7 @@ layout: blank
     import { DeepDive, Warning } from '~/components'
     </script>
 
-<DeepDive title="Get Started Creating Plugins">
-
-## Your First Client Plugin
+<DeepDive title="Creating Your First Plugin">
 
 Let's start off simple and create a plugin to log something every time we send a query. If you don't have
 a project to test in, you can always use the [`final` branch](https://github.com/HoudiniGraphql/intro/tree/final)


### PR DESCRIPTION
This PR makes it so that client plugins can return `(ClientHook | null | (ClientHook | null ClientPlugin)[]` allowing users to easily toggle functionality depending on configuration values:

```javascript
import { plugin } from 'houdini'
import externalPlugin from 'third-party'
import externalPlugin2 from 'third-party2'

const sayHello: ClientPlugin = ({ include }) => {
   return [
      {
         start(ctx, { next }) {
             next(ctx)
         },
      },
      externalPlugin,
      include ? externalPlugin2 :  null
   ]
}
```