### PR TITLE
Enum as const pojo

### DIFF
--- a/.changeset/fresh-penguins-deliver.md
+++ b/.changeset/fresh-penguins-deliver.md
@@ -1,0 +1,5 @@
+---
+'houdini': major
+---
+
+Renamed subscriptionsPlugin to subscription

--- a/.changeset/honest-cheetahs-cheer.md
+++ b/.changeset/honest-cheetahs-cheer.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Enums are generated as a constant object instead of a typescript enum

--- a/packages/houdini/src/codegen/generators/definitions/enums.test.ts
+++ b/packages/houdini/src/codegen/generators/definitions/enums.test.ts
@@ -4,9 +4,8 @@ import * as typeScriptParser from 'recast/parsers/typescript'
 import { test, expect } from 'vitest'
 
 import { runPipeline } from '../..'
-import type { Document } from '../../../lib'
 import { fs, path } from '../../../lib'
-import { mockCollectedDoc, testConfig } from '../../../test'
+import { testConfig } from '../../../test'
 
 // the config to use in tests
 const config = testConfig()

--- a/packages/houdini/src/codegen/generators/definitions/enums.test.ts
+++ b/packages/houdini/src/codegen/generators/definitions/enums.test.ts
@@ -11,12 +11,6 @@ import { mockCollectedDoc, testConfig } from '../../../test'
 // the config to use in tests
 const config = testConfig()
 
-// the documents to test
-const docs: Document[] = [
-	mockCollectedDoc(`query TestQuery { version }`),
-	mockCollectedDoc(`fragment TestFragment on User { firstName }`),
-]
-
 test('generates runtime definitions for each enum', async function () {
 	// execute the generator
 	await runPipeline(config, [])
@@ -29,15 +23,15 @@ test('generates runtime definitions for each enum', async function () {
 	}).program
 
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		export declare enum TestEnum1 {
-		    Value1 = "Value1",
-		    Value2 = "Value2"
-		}
+		export const TestEnum1 = {
+		    Value1: "Value1",
+		    Value2: "Value2"
+		} as const
 		 
-		export declare enum TestEnum2 {
-		    Value3 = "Value3",
-		    Value2 = "Value2"
-		}
+		export const TestEnum2 = {
+		    Value3: "Value3",
+		    Value2: "Value2"
+		} as const
 	`)
 
 	// load the contents of the type definitions file

--- a/packages/houdini/src/codegen/generators/definitions/enums.ts
+++ b/packages/houdini/src/codegen/generators/definitions/enums.ts
@@ -47,9 +47,9 @@ export default async function definitionsGenerator(config: Config) {
 		.sort((a, b) => a.name.value.localeCompare(b.name.value))
 		.map(
 			(definition) => `
-export declare enum ${definition.name.value} {
-${definition.values?.map((value) => `    ${value.name.value} = "${value.name.value}"`).join(',\n')}
-}
+export const ${definition.name.value} = {
+${definition.values?.map((value) => `    ${value.name.value}: "${value.name.value}"`).join(',\n')}
+} as const
  `
 		)
 		.join('')

--- a/packages/houdini/src/codegen/generators/typescript/addReferencedInputTypes.ts
+++ b/packages/houdini/src/codegen/generators/typescript/addReferencedInputTypes.ts
@@ -51,6 +51,7 @@ export function addReferencedInputTypes(
 			sourceModule: '$houdini/graphql/enums',
 			importKind: 'type',
 		})
+
 		return
 	}
 
@@ -66,7 +67,7 @@ export function addReferencedInputTypes(
 		members.push(
 			AST.tsPropertySignature(
 				AST.identifier(field.name),
-				AST.tsTypeAnnotation(tsTypeReference(config, missingScalars, field)),
+				AST.tsTypeAnnotation(tsTypeReference(config, missingScalars, field, body)),
 				graphql.isNullableType(field.type)
 			)
 		)

--- a/packages/houdini/src/codegen/generators/typescript/documentTypes.ts
+++ b/packages/houdini/src/codegen/generators/typescript/documentTypes.ts
@@ -289,7 +289,7 @@ async function generateOperationTypeDefs(
 								return AST.tsPropertySignature(
 									AST.identifier(definition.variable.name.value),
 									AST.tsTypeAnnotation(
-										tsTypeReference(config, missingScalars, definition)
+										tsTypeReference(config, missingScalars, definition, body)
 									),
 									definition.type.kind !== 'NonNullType'
 								)
@@ -379,7 +379,12 @@ async function generateFragmentTypeDefs(
 									return AST.tsPropertySignature(
 										AST.identifier(definition.variable.name.value),
 										AST.tsTypeAnnotation(
-											tsTypeReference(config, missingScalars, definition)
+											tsTypeReference(
+												config,
+												missingScalars,
+												definition,
+												body
+											)
 										),
 										definition.type.kind !== 'NonNullType'
 									)

--- a/packages/houdini/src/codegen/generators/typescript/imperativeTypeDef.test.ts
+++ b/packages/houdini/src/codegen/generators/typescript/imperativeTypeDef.test.ts
@@ -156,6 +156,7 @@ test('generates type definitions for the imperative API', async function () {
 		import type { Record } from "./public/record";
 		import { TestQueryNoArgs$result, TestQueryNoArgs$input } from "../artifacts/TestQueryNoArgs";
 		import { TestQuery$result, TestQuery$input } from "../artifacts/TestQuery";
+		import type { ValueOf } from "$houdini/runtime/lib/types";
 		import type { MyEnum } from "$houdini/graphql/enums";
 		import { UserInfoWithArguments$input } from "../artifacts/UserInfoWithArguments";
 		import { UserInfoWithArguments$data } from "../artifacts/UserInfoWithArguments";
@@ -174,7 +175,7 @@ test('generates type definitions for the imperative API', async function () {
 		    listRequired: (string)[];
 		    nullList?: (string | null | undefined)[] | null | undefined;
 		    recursive?: UserFilter | null | undefined;
-		    enum?: MyEnum | null | undefined;
+		    enum?: ValueOf<typeof MyEnum> | null | undefined;
 		};
 
 		export declare type CacheTypeDef = {
@@ -188,7 +189,7 @@ test('generates type definitions for the imperative API', async function () {
 		                        id?: string | null | undefined;
 		                        filter?: UserFilter | null | undefined;
 		                        filterList?: (UserFilter)[] | null | undefined;
-		                        enumArg?: MyEnum | null | undefined;
+		                        enumArg?: ValueOf<typeof MyEnum> | null | undefined;
 		                    };
 		                };
 		                users: {

--- a/packages/houdini/src/codegen/generators/typescript/imperativeTypeDef.ts
+++ b/packages/houdini/src/codegen/generators/typescript/imperativeTypeDef.ts
@@ -52,7 +52,7 @@ export default async function imperativeCacheTypef(config: Config, docs: Documen
 			),
 			AST.tsPropertySignature(
 				AST.identifier('lists'),
-				AST.tsTypeAnnotation(listDefinitions(config, docs))
+				AST.tsTypeAnnotation(listDefinitions(config, body, docs))
 			),
 			AST.tsPropertySignature(
 				AST.identifier('queries'),
@@ -222,7 +222,7 @@ function typeDefinitions(
 										const prop = AST.tsPropertySignature(
 											AST.identifier(arg.name),
 											AST.tsTypeAnnotation(
-												tsTypeReference(config, new Set(), arg)
+												tsTypeReference(config, new Set(), arg, body)
 											)
 										)
 
@@ -281,6 +281,7 @@ function typeDefinitions(
 
 function listDefinitions(
 	config: Config,
+	body: StatementKind[],
 	docs: Document[]
 ): recast.types.namedTypes.TSTypeLiteral | recast.types.namedTypes.TSNeverKeyword {
 	// we need to look at every document for a list definition
@@ -364,7 +365,8 @@ function listDefinitions(
 																tsTypeReference(
 																	config,
 																	new Set(),
-																	arg
+																	arg,
+																	body
 																)
 															)
 														)

--- a/packages/houdini/src/codegen/generators/typescript/inlineType.ts
+++ b/packages/houdini/src/codegen/generators/typescript/inlineType.ts
@@ -45,6 +45,15 @@ export function inlineType({
 	}
 	// we could have encountered an enum
 	else if (graphql.isEnumType(type)) {
+		const [valueOf] = ensureImports({
+			config,
+			// @ts-ignore
+			body,
+			importKind: 'type',
+			import: ['ValueOf'],
+			sourceModule: '$houdini/runtime/lib/types',
+		})
+
 		// have we seen the enum before
 		if (!visitedTypes.has(type.name)) {
 			ensureImports({
@@ -59,7 +68,10 @@ export function inlineType({
 			visitedTypes.add(type.name)
 		}
 
-		result = AST.tsTypeReference(AST.identifier(type.name))
+		result = AST.tsTypeReference(
+			AST.identifier(valueOf),
+			AST.tsTypeParameterInstantiation([AST.tsTypeReference(AST.identifier(type.name))])
+		)
 	}
 	// if we are looking at something with a selection set
 	else if (selections) {

--- a/packages/houdini/src/codegen/generators/typescript/inlineType.ts
+++ b/packages/houdini/src/codegen/generators/typescript/inlineType.ts
@@ -70,7 +70,7 @@ export function inlineType({
 
 		result = AST.tsTypeReference(
 			AST.identifier('ValueOf'),
-			AST.tsTypeParameterInstantiation([AST.tsTypeReference(AST.identifier(type.name))])
+			AST.tsTypeParameterInstantiation([AST.tsTypeQuery(AST.identifier(type.name))])
 		)
 	}
 	// if we are looking at something with a selection set

--- a/packages/houdini/src/codegen/generators/typescript/inlineType.ts
+++ b/packages/houdini/src/codegen/generators/typescript/inlineType.ts
@@ -4,6 +4,7 @@ import * as recast from 'recast'
 
 import type { Config } from '../../../lib'
 import { ensureImports, HoudiniError, TypeWrapper, unwrapType } from '../../../lib'
+import { enumReference } from './typeReference'
 import { nullableField, readonlyProperty, scalarPropertyValue } from './types'
 
 const AST = recast.types.builders
@@ -68,10 +69,7 @@ export function inlineType({
 			visitedTypes.add(type.name)
 		}
 
-		result = AST.tsTypeReference(
-			AST.identifier('ValueOf'),
-			AST.tsTypeParameterInstantiation([AST.tsTypeQuery(AST.identifier(type.name))])
-		)
+		result = enumReference(config, body, type.name)
 	}
 	// if we are looking at something with a selection set
 	else if (selections) {

--- a/packages/houdini/src/codegen/generators/typescript/inlineType.ts
+++ b/packages/houdini/src/codegen/generators/typescript/inlineType.ts
@@ -45,7 +45,7 @@ export function inlineType({
 	}
 	// we could have encountered an enum
 	else if (graphql.isEnumType(type)) {
-		const [valueOf] = ensureImports({
+		ensureImports({
 			config,
 			// @ts-ignore
 			body,
@@ -69,7 +69,7 @@ export function inlineType({
 		}
 
 		result = AST.tsTypeReference(
-			AST.identifier(valueOf),
+			AST.identifier('ValueOf'),
 			AST.tsTypeParameterInstantiation([AST.tsTypeReference(AST.identifier(type.name))])
 		)
 	}

--- a/packages/houdini/src/codegen/generators/typescript/typeReference.ts
+++ b/packages/houdini/src/codegen/generators/typescript/typeReference.ts
@@ -3,7 +3,7 @@ import * as graphql from 'graphql'
 import * as recast from 'recast'
 
 import { ensureImports, TypeWrapper, unwrapType } from '../../../lib'
-import { Config } from '../../../lib'
+import type { Config } from '../../../lib'
 import { nullableField, scalarPropertyValue } from './types'
 
 const AST = recast.types.builders

--- a/packages/houdini/src/codegen/generators/typescript/typeReference.ts
+++ b/packages/houdini/src/codegen/generators/typescript/typeReference.ts
@@ -2,8 +2,8 @@ import type { StatementKind, TSTypeKind } from 'ast-types/lib/gen/kinds'
 import * as graphql from 'graphql'
 import * as recast from 'recast'
 
-import { Config, ensureImports } from '../../../lib'
-import { TypeWrapper, unwrapType } from '../../../lib'
+import { ensureImports, TypeWrapper, unwrapType } from '../../../lib'
+import { Config } from '../../../lib'
 import { nullableField, scalarPropertyValue } from './types'
 
 const AST = recast.types.builders

--- a/packages/houdini/src/codegen/generators/typescript/typeReference.ts
+++ b/packages/houdini/src/codegen/generators/typescript/typeReference.ts
@@ -31,18 +31,7 @@ export function tsTypeReference(
 	}
 	//  enums need to be passed to ValueOf
 	else if (graphql.isEnumType(type)) {
-		// if we looking at an enum we need ValueOf<enum>
-		ensureImports({
-			config,
-			body,
-			import: ['ValueOf'],
-			importKind: 'type',
-			sourceModule: '$houdini/runtime/lib/types',
-		})
-		result = AST.tsTypeReference(
-			AST.identifier('ValueOf'),
-			AST.tsTypeParameterInstantiation([AST.tsTypeQuery(AST.identifier(type.name))])
-		)
+		result = enumReference(config, body, type.name)
 	}
 	// we're looking at an object
 	else {
@@ -63,4 +52,19 @@ export function tsTypeReference(
 	}
 
 	return result
+}
+
+export function enumReference(config: Config, body: StatementKind[], name: string) {
+	// if we looking at an enum we need ValueOf<enum>
+	ensureImports({
+		config,
+		body,
+		import: ['ValueOf'],
+		importKind: 'type',
+		sourceModule: '$houdini/runtime/lib/types',
+	})
+	return AST.tsTypeReference(
+		AST.identifier('ValueOf'),
+		AST.tsTypeParameterInstantiation([AST.tsTypeQuery(AST.identifier(name))])
+	)
 }

--- a/packages/houdini/src/codegen/generators/typescript/typeReference.ts
+++ b/packages/houdini/src/codegen/generators/typescript/typeReference.ts
@@ -41,7 +41,7 @@ export function tsTypeReference(
 		})
 		result = AST.tsTypeReference(
 			AST.identifier('ValueOf'),
-			AST.tsTypeParameterInstantiation([AST.tsTypeReference(AST.identifier(type.name))])
+			AST.tsTypeParameterInstantiation([AST.tsTypeQuery(AST.identifier(type.name))])
 		)
 	}
 	// we're looking at an object

--- a/packages/houdini/src/codegen/generators/typescript/types.ts
+++ b/packages/houdini/src/codegen/generators/typescript/types.ts
@@ -68,14 +68,3 @@ export function scalarPropertyValue(
 		}
 	}
 }
-
-export function enumDeclaration(type: graphql.GraphQLEnumType) {
-	return AST.tsEnumDeclaration(
-		AST.identifier(type.name),
-		type
-			.getValues()
-			.map((value) =>
-				AST.tsEnumMember(AST.identifier(value.name), AST.stringLiteral(value.name))
-			)
-	)
-}

--- a/packages/houdini/src/codegen/generators/typescript/typescript.test.ts
+++ b/packages/houdini/src/codegen/generators/typescript/typescript.test.ts
@@ -123,7 +123,7 @@ describe('typescript', function () {
 			export type TestFragment$data = {
 			    readonly firstName: string;
 			    readonly nickname: string | null;
-			    readonly enumValue: ValueOf<MyEnum> | null;
+			    readonly enumValue: ValueOf<typeof MyEnum> | null;
 			};
 		`)
 	})
@@ -369,7 +369,7 @@ describe('typescript', function () {
 
 			export type MyQuery$input = {
 			    id: string;
-			    enum?: ValueOf<MyEnum> | null | undefined;
+			    enum?: ValueOf<typeof MyEnum> | null | undefined;
 			};
 		`)
 	})
@@ -481,7 +481,7 @@ describe('typescript', function () {
 			    listRequired: (string)[];
 			    nullList?: (string | null | undefined)[] | null | undefined;
 			    recursive?: UserFilter | null | undefined;
-			    enum?: ValueOf<MyEnum> | null | undefined;
+			    enum?: ValueOf<typeof MyEnum> | null | undefined;
 			};
 
 			export type MyMutation$input = {
@@ -605,7 +605,7 @@ describe('typescript', function () {
 			    listRequired: (string)[];
 			    nullList?: (string | null | undefined)[] | null | undefined;
 			    recursive?: UserFilter | null | undefined;
-			    enum?: ValueOf<MyEnum> | null | undefined;
+			    enum?: ValueOf<typeof MyEnum> | null | undefined;
 			};
 
 			export type MyQuery$input = {
@@ -1200,7 +1200,7 @@ describe('typescript', function () {
 			    listRequired: (string)[];
 			    nullList?: (string | null | undefined)[] | null | undefined;
 			    recursive?: UserFilter | null | undefined;
-			    enum?: ValueOf<MyEnum> | null | undefined;
+			    enum?: ValueOf<typeof MyEnum> | null | undefined;
 			};
 
 			export type MyMutation$input = {

--- a/packages/houdini/src/codegen/generators/typescript/typescript.test.ts
+++ b/packages/houdini/src/codegen/generators/typescript/typescript.test.ts
@@ -111,6 +111,7 @@ describe('typescript', function () {
 			})
 		).toMatchInlineSnapshot(`
 			import { MyEnum } from "$houdini/graphql/enums";
+			import type { ValueOf } from "$houdini/runtime/lib/types";
 
 			export type TestFragment = {
 			    readonly "shape"?: TestFragment$data;
@@ -122,7 +123,7 @@ describe('typescript', function () {
 			export type TestFragment$data = {
 			    readonly firstName: string;
 			    readonly nickname: string | null;
-			    readonly enumValue: MyEnum | null;
+			    readonly enumValue: ValueOf<MyEnum> | null;
 			};
 		`)
 	})
@@ -352,6 +353,7 @@ describe('typescript', function () {
 				parser: typeScriptParser,
 			})
 		).toMatchInlineSnapshot(`
+			import type { ValueOf } from "$houdini/runtime/lib/types";
 			import type { MyEnum } from "$houdini/graphql/enums";
 
 			export type MyQuery = {
@@ -367,7 +369,7 @@ describe('typescript', function () {
 
 			export type MyQuery$input = {
 			    id: string;
-			    enum?: MyEnum | null | undefined;
+			    enum?: ValueOf<MyEnum> | null | undefined;
 			};
 		`)
 	})
@@ -452,6 +454,7 @@ describe('typescript', function () {
 				parser: typeScriptParser,
 			})
 		).toMatchInlineSnapshot(`
+			import type { ValueOf } from "$houdini/runtime/lib/types";
 			import type { MyEnum } from "$houdini/graphql/enums";
 
 			export type MyMutation = {
@@ -478,7 +481,7 @@ describe('typescript', function () {
 			    listRequired: (string)[];
 			    nullList?: (string | null | undefined)[] | null | undefined;
 			    recursive?: UserFilter | null | undefined;
-			    enum?: MyEnum | null | undefined;
+			    enum?: ValueOf<MyEnum> | null | undefined;
 			};
 
 			export type MyMutation$input = {
@@ -575,6 +578,7 @@ describe('typescript', function () {
 				parser: typeScriptParser,
 			})
 		).toMatchInlineSnapshot(`
+			import type { ValueOf } from "$houdini/runtime/lib/types";
 			import type { MyEnum } from "$houdini/graphql/enums";
 
 			export type MyQuery = {
@@ -601,7 +605,7 @@ describe('typescript', function () {
 			    listRequired: (string)[];
 			    nullList?: (string | null | undefined)[] | null | undefined;
 			    recursive?: UserFilter | null | undefined;
-			    enum?: MyEnum | null | undefined;
+			    enum?: ValueOf<MyEnum> | null | undefined;
 			};
 
 			export type MyQuery$input = {
@@ -1165,6 +1169,7 @@ describe('typescript', function () {
 				parser: typeScriptParser,
 			})
 		).toMatchInlineSnapshot(`
+			import type { ValueOf } from "$houdini/runtime/lib/types";
 			import type { MyEnum } from "$houdini/graphql/enums";
 
 			export type MyMutation = {
@@ -1195,7 +1200,7 @@ describe('typescript', function () {
 			    listRequired: (string)[];
 			    nullList?: (string | null | undefined)[] | null | undefined;
 			    recursive?: UserFilter | null | undefined;
-			    enum?: MyEnum | null | undefined;
+			    enum?: ValueOf<MyEnum> | null | undefined;
 			};
 
 			export type MyMutation$input = {

--- a/packages/houdini/src/runtime/client/documentStore.ts
+++ b/packages/houdini/src/runtime/client/documentStore.ts
@@ -14,7 +14,7 @@ import type {
 	SubscriptionSpec,
 } from '../lib/types'
 import { ArtifactKind } from '../lib/types'
-import { cachePolicyPlugin } from './plugins'
+import { cachePolicy } from './plugins'
 
 // the list of states to step in what direction
 const steps = {
@@ -91,7 +91,7 @@ export class DocumentStore<
 
 		this.#plugins = pipeline ?? [
 			// cache policy needs to always come first so that it can be the first fetch_enter to fire
-			cachePolicyPlugin({
+			cachePolicy({
 				enabled: cache,
 				setFetching: (fetching: boolean) =>
 					this.update((state) => ({ ...state, fetching })),

--- a/packages/houdini/src/runtime/client/index.ts
+++ b/packages/houdini/src/runtime/client/index.ts
@@ -4,11 +4,11 @@ import type { DocumentArtifact, GraphQLObject, NestedList } from '../lib/types'
 import type { ClientPlugin, ClientHooks } from './documentStore'
 import { DocumentStore } from './documentStore'
 import {
-	fetchParamsPlugin,
-	fetchPlugin,
-	mutationPlugin,
-	queryPlugin,
-	throwOnErrorPlugin,
+	fetchParams as fetchParamsPlugin,
+	fetch as fetchPlugin,
+	mutation as mutationPlugin,
+	query as queryPlugin,
+	throwOnError as throwOnErrorPlugin,
 	type FetchParamFn,
 	type ThrowOnErrorParams,
 } from './plugins'
@@ -16,7 +16,7 @@ import pluginsFromPlugins from './plugins/injectedPlugins'
 
 // export the plugin constructors
 export { DocumentStore, type ClientPlugin } from './documentStore'
-export { fetchPlugin, mutationPlugin, queryPlugin, subscriptionPlugin } from './plugins'
+export { fetch, mutation, query, subscription } from './plugins'
 
 type ConstructorArgs = {
 	url: string

--- a/packages/houdini/src/runtime/client/plugins/cache.test.ts
+++ b/packages/houdini/src/runtime/client/plugins/cache.test.ts
@@ -8,7 +8,7 @@ import { setMockConfig } from '../../lib/config'
 import { ArtifactKind, DataSource } from '../../lib/types'
 import type { ClientPlugin } from '../documentStore'
 import { DocumentStore } from '../documentStore'
-import { cachePolicyPlugin } from './cache'
+import { cachePolicy } from './cache'
 
 /**
  * Testing the cache plugin
@@ -22,7 +22,7 @@ test('NetworkOnly', async function () {
 	const spy = vi.fn()
 
 	const store = createStore([
-		cachePolicyPlugin({
+		cachePolicy({
 			enabled: true,
 			setFetching: spy,
 			cache: new Cache(config),
@@ -71,7 +71,7 @@ test('CacheOrNetwork', async function () {
 	const spy = vi.fn()
 
 	const store = createStore([
-		cachePolicyPlugin({
+		cachePolicy({
 			enabled: true,
 			setFetching: spy,
 			cache: new Cache(config),
@@ -120,7 +120,7 @@ test('CacheOnly', async function () {
 	const spy = vi.fn()
 
 	const store = createStore([
-		cachePolicyPlugin({
+		cachePolicy({
 			enabled: true,
 			setFetching: spy,
 			cache: new Cache(config),
@@ -187,7 +187,7 @@ test('stale', async function () {
 	const cache = new Cache(config)
 
 	const store = createStore([
-		cachePolicyPlugin({
+		cachePolicy({
 			enabled: true,
 			setFetching,
 			cache,

--- a/packages/houdini/src/runtime/client/plugins/cache.ts
+++ b/packages/houdini/src/runtime/client/plugins/cache.ts
@@ -3,7 +3,7 @@ import type { Cache } from '../../cache/cache'
 import { ArtifactKind, CachePolicy, DataSource } from '../../lib/types'
 import type { ClientPlugin } from '../documentStore'
 
-export const cachePolicyPlugin =
+export const cachePolicy =
 	({
 		enabled,
 		setFetching,

--- a/packages/houdini/src/runtime/client/plugins/fetch.ts
+++ b/packages/houdini/src/runtime/client/plugins/fetch.ts
@@ -2,7 +2,7 @@ import type { RequestPayload } from '../../lib/types'
 import { DataSource } from '../../lib/types'
 import type { ClientPlugin, ClientPluginContext } from '../documentStore'
 
-export const fetchPlugin = (target?: RequestHandler | string): ClientPlugin => {
+export const fetch = (target?: RequestHandler | string): ClientPlugin => {
 	return () => {
 		return {
 			async network(ctx, { client, resolve, marshalVariables }) {

--- a/packages/houdini/src/runtime/client/plugins/fetchParams.ts
+++ b/packages/houdini/src/runtime/client/plugins/fetchParams.ts
@@ -3,7 +3,7 @@ import type { ClientPlugin, ClientPluginContext } from '../documentStore'
 
 export type FetchParamFn = (ctx: FetchParamsInput) => Required<ClientPluginContext>['fetchParams']
 
-export const fetchParamsPlugin: (fn?: FetchParamFn) => ClientPlugin =
+export const fetchParams: (fn?: FetchParamFn) => ClientPlugin =
 	(fn = () => ({})) =>
 	() => ({
 		beforeNetwork(ctx, { next, marshalVariables }) {

--- a/packages/houdini/src/runtime/client/plugins/mutation.ts
+++ b/packages/houdini/src/runtime/client/plugins/mutation.ts
@@ -4,7 +4,7 @@ import type { SubscriptionSpec } from '../../lib/types'
 import { ArtifactKind } from '../../lib/types'
 import { documentPlugin } from '../utils'
 
-export const mutationPlugin = documentPlugin(ArtifactKind.Mutation, () => {
+export const mutation = documentPlugin(ArtifactKind.Mutation, () => {
 	return {
 		async start(ctx, { next, marshalVariables }) {
 			// treat a mutation like it has an optimistic layer regardless of

--- a/packages/houdini/src/runtime/client/plugins/query.ts
+++ b/packages/houdini/src/runtime/client/plugins/query.ts
@@ -3,7 +3,7 @@ import { type SubscriptionSpec, ArtifactKind, DataSource } from '../../lib/types
 import type { ClientPlugin } from '../documentStore'
 import { documentPlugin } from '../utils'
 
-export const queryPlugin: ClientPlugin = documentPlugin(ArtifactKind.Query, function () {
+export const query: ClientPlugin = documentPlugin(ArtifactKind.Query, function () {
 	// track the bits of state we need to hold onto
 	let subscriptionSpec: SubscriptionSpec | null = null
 

--- a/packages/houdini/src/runtime/client/plugins/subscription.ts
+++ b/packages/houdini/src/runtime/client/plugins/subscription.ts
@@ -3,7 +3,7 @@ import { ArtifactKind, DataSource } from '../../lib/types'
 import type { ClientPluginContext } from '../documentStore'
 import { documentPlugin } from '../utils'
 
-export function subscriptionPlugin(factory: SubscriptionHandler) {
+export function subscription(factory: SubscriptionHandler) {
 	return documentPlugin(ArtifactKind.Subscription, () => {
 		// the unsubscribe hook for the active subscription
 		let clearSubscription: null | (() => void) = null

--- a/packages/houdini/src/runtime/client/plugins/throwOnError.ts
+++ b/packages/houdini/src/runtime/client/plugins/throwOnError.ts
@@ -7,7 +7,7 @@ export type ThrowOnErrorParams = {
 	error?: (errors: NonNullable<QueryResult<any, any>['errors']>) => unknown
 }
 
-export const throwOnErrorPlugin =
+export const throwOnError =
 	({ operations, error }: ThrowOnErrorParams): ClientPlugin =>
 	() => {
 		// build a map of artifact kinds we will throw on

--- a/packages/houdini/src/runtime/lib/types.ts
+++ b/packages/houdini/src/runtime/lib/types.ts
@@ -218,3 +218,5 @@ export type RequestPayload<GraphQLObject = any> = {
 }
 
 export type NestedList<_Result = string> = (_Result | null | NestedList<_Result>)[]
+
+export type ValueOf<Parent> = Parent[keyof Parent]

--- a/site/src/routes/api/client/+page.svx
+++ b/site/src/routes/api/client/+page.svx
@@ -141,26 +141,26 @@ of plugins is follows:
 
 ```typescript:title=
 import {
-    throwOnErrorPlugin,
-    fetchParamsPlugin,
-    queryPlugin,
-    mutationPlugins,
-    fetchPlugin
+    throwOnError,
+    fetchParams,
+    query,
+    mutations,
+    fetch
 } from '$houdini/plugins'
 
 const plugins = [
     // client-level config always works
     // these two plugins are only passed if the config value is added
-    throwOnErrorPlugin,
-    fetchParamsPlugin,
+    throwOnError,
+    fetchParams,
     // queries and mutations will always work
-    queryPlugin,
-    mutationPlugin,
+    query,
+    mutation,
     // your plugins can wrap the injected ones
-    ...specifiedPlugins,
-    ...injectedPlugins,
+    ...specified,
+    ...injected,
     // fetch will always exist as a fallback to resolve your pipeline
-    fetchPlugin
+    fetch
 ]
 ```
 

--- a/site/src/routes/api/subscription/+page.svx
+++ b/site/src/routes/api/subscription/+page.svx
@@ -52,13 +52,13 @@ client and pass it directly:
 
 ```typescript:title=src/client.ts&typescriptToggle=true
 import { createClient } from 'graphql-ws'
-import { subscriptionPlugin } from '$houdini/plugins'
+import { subscription } from '$houdini/plugins'
 
 // prettier-ignore
 export default new HoudiniClient({
   url: "...",
   plugins: [
-    subscriptionPlugin(() => new createClient({
+    subscription(() => new createClient({
       url: 'ws://api.url'
     }))
   ]
@@ -73,7 +73,7 @@ you will have to slightly modify the above block:
 ```typescript:title=src/client.ts&typescriptToggle=true
 import { SubscriptionClient } from 'subscriptions-transport-ws'
 import { browser } from '$app/environment'
-import { subscriptionPlugin } from '$houdini/plugins'
+import { subscription } from '$houdini/plugins'
 
   // prettier-ignore
 function createClient() {
@@ -97,7 +97,7 @@ function createClient() {
 export default new HoudiniClient({
   url: "...",
   plugins: [
-    subscriptionPlugin(createClient)
+    subscription(createClient)
   ]
 })
 ```
@@ -109,7 +109,7 @@ If your server supports the latest Server-Side events, you can use them to power
 ```typescript:title=src/client.ts&typescriptToggle=true
 import { SubscriptionClient } from 'subscriptions-transport-ws'
 import { browser } from '$app/environment'
-import { subscriptionPlugin } from '$houdini/plugins'
+import { subscription } from '$houdini/plugins'
 
   // prettier-ignore
 function sseSockets() {
@@ -131,7 +131,7 @@ function sseSockets() {
 export default new HoudiniClient({
   url: "...",
   plugins: [
-    subscriptionPlugin(sseSockets)
+    subscription(sseSockets)
   ]
 })
 ```
@@ -146,13 +146,13 @@ something like:
 
 ```typescript:title=src/client.ts&typescriptToggle=true
 import { createClient } from 'graphql-ws'
-import { subscriptionPlugin } from '$houdini/plugins'
+import { subscription } from '$houdini/plugins'
 
 // prettier-ignore
 export default new HoudiniClient({
   url: "...",
   plugins: [
-    subscriptionPlugin(({ session }) => new createClient({
+    subscription(({ session }) => new createClient({
       url: 'ws://api.url',
       connectionParams: () => {
         return {

--- a/site/src/routes/guides/release-notes/+page.svx
+++ b/site/src/routes/guides/release-notes/+page.svx
@@ -125,7 +125,7 @@ If your application uses subscriptions, you'll need to import the
 ```diff:title=src/client.ts
   import { createClient } from 'graphql-ws'
   import { browser } from '$app/environment'
-+ import { subscriptionPlugin } from '$houdini/plugins'
++ import { subscription } from '$houdini/plugins'
 
 -  let socketClient = browser
 -  	? new createClient({
@@ -137,7 +137,7 @@ If your application uses subscriptions, you'll need to import the
 + export default new HoudiniClient({
 +     url: '...',
 +     plugins: [
-+         subscriptionPlugin(({ session }) => createClient({
++         subscription(({ session }) => createClient({
 +             url: 'ws://api.url',
 +             connectionParams: {
 +                 headers: {


### PR DESCRIPTION
This PR changes the way enums are handled to be a generated constant object instead of a typescript enum. The generated types reference values of this object which means users can pass strings if they want or they can import `MyEnum` like usual and use the object 