### PR TITLE
Mutation response

### DIFF
--- a/.changeset/cool-panthers-juggle.md
+++ b/.changeset/cool-panthers-juggle.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': major
+---
+
+MutationStore.mutate returns full payload

--- a/e2e/sveltekit/src/routes/stores/action-mutation/+page.svelte
+++ b/e2e/sveltekit/src/routes/stores/action-mutation/+page.svelte
@@ -17,5 +17,5 @@
 </form>
 
 <div id="result">
-  {form?.addUser?.name || 'No user added'}
+  {form?.data?.addUser?.name || 'No user added'}
 </div>

--- a/packages/houdini-svelte/src/runtime/stores/mutation.ts
+++ b/packages/houdini-svelte/src/runtime/stores/mutation.ts
@@ -1,5 +1,5 @@
 import type { DocumentStore } from '$houdini/runtime/client'
-import type { MutationArtifact, GraphQLObject } from '$houdini/runtime/lib/types'
+import type { MutationArtifact, GraphQLObject, QueryResult } from '$houdini/runtime/lib/types'
 import type { RequestEvent } from '@sveltejs/kit'
 
 import { initClient } from '../client'
@@ -26,7 +26,7 @@ export class MutationStore<
 			fetch?: typeof globalThis.fetch
 			event?: RequestEvent
 		} & MutationConfig<_Data, _Input, _Optimistic> = {}
-	): Promise<_Data> {
+	): Promise<QueryResult<_Data, _Input>> {
 		await initClient()
 
 		const { context } = await fetchParams(this.artifact, this.artifact.name, {
@@ -35,17 +35,15 @@ export class MutationStore<
 			event,
 		})
 
-		return (
-			await this.observer.send({
-				variables,
-				fetch: context.fetch,
-				metadata,
-				session: context.session,
-				stuff: {
-					...mutationConfig,
-				},
-			})
-		).data!
+		return await this.observer.send({
+			variables,
+			fetch: context.fetch,
+			metadata,
+			session: context.session,
+			stuff: {
+				...mutationConfig,
+			},
+		})
 	}
 
 	subscribe(...args: Parameters<DocumentStore<_Data, _Input>['subscribe']>) {

--- a/site/src/routes/guides/release-notes/+page.svx
+++ b/site/src/routes/guides/release-notes/+page.svx
@@ -206,6 +206,29 @@ need to pass a new config to your client:
 
 </DeepDive>
 
+### Mutation return value changed
+
+Because of the change in Houdini's default error handling, mutations were brought
+in line with query behavior and return the full query result with `data`, `errors`,
+etc.
+
+```diff:title=src/components/AddFriend.svelte
+<script>
+    const mutation = graphql(`
+        mutation AddFriend {
+            addFriend {
+                ...
+            }
+        }
+    `)
+
+    async function onClick() {
+-       const { addFriend } = await mutation.mutate()
++       const { data: { addFriend } } = await mutation.mutate()
+    }
+</script>
+```
+
 ### Grouped `apiUrl`, `schemaPollHeaders`, and `schemaPollInterval` together
 
 In order to clarify the difference between the `apiUrl` config value and the


### PR DESCRIPTION
This PR changes the return type of `MutationStore.mutate` to include the full result instead of just the value of `data`

cc @xmlking