### PR TITLE
Query variable type

### DIFF
--- a/.changeset/fresh-cameras-press.md
+++ b/.changeset/fresh-cameras-press.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Use {} as the default/empty/unset value for Query.variables

--- a/e2e/sveltekit/src/routes/stores/mutation/spec.ts
+++ b/e2e/sveltekit/src/routes/stores/mutation/spec.ts
@@ -11,7 +11,7 @@ test.describe('Mutation Page', () => {
       data: null,
       errors: null,
       fetching: false,
-      variables: null,
+      variables: {},
       partial: false,
       stale: false,
       source: null

--- a/packages/houdini/src/runtime/client/documentStore.test.ts
+++ b/packages/houdini/src/runtime/client/documentStore.test.ts
@@ -117,7 +117,7 @@ test('middleware pipeline happy path', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: null,
+					variables: {},
 				})
 			},
 			afterNetwork(ctx, { resolve }) {
@@ -183,7 +183,7 @@ test('middleware pipeline happy path', async function () {
 		partial: false,
 		stale: false,
 		source: DataSource.Cache,
-		variables: null,
+		variables: {},
 	})
 })
 
@@ -218,7 +218,7 @@ test('terminate short-circuits pipeline', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: null,
+					variables: {},
 				})
 			},
 			end(ctx, { resolve }) {
@@ -230,7 +230,7 @@ test('terminate short-circuits pipeline', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: null,
+					variables: {},
 				})
 			},
 			network(ctx, { next }) {
@@ -288,7 +288,7 @@ test('uneven lists phases', async function () {
 				partial: false,
 				stale: false,
 				source: DataSource.Cache,
-				variables: null,
+				variables: {},
 			})
 		},
 	})
@@ -303,7 +303,7 @@ test('uneven lists phases', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: null,
+					variables: {},
 				})
 			},
 			afterNetwork(ctx, { resolve }) {
@@ -340,7 +340,7 @@ test('can call resolve multiple times to set multiple values', async function ()
 				partial: false,
 				stale: false,
 				source: DataSource.Cache,
-				variables: null,
+				variables: {},
 			})
 			sleep(100).then(() =>
 				resolve(ctx, {
@@ -350,7 +350,7 @@ test('can call resolve multiple times to set multiple values', async function ()
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: null,
+					variables: {},
 				})
 			)
 		},
@@ -374,7 +374,7 @@ test('can call resolve multiple times to set multiple values', async function ()
 		partial: false,
 		stale: false,
 		source: DataSource.Cache,
-		variables: null,
+		variables: {},
 	})
 	expect(fn).toHaveBeenNthCalledWith(2, {
 		data: { hello: 'world' },
@@ -383,7 +383,7 @@ test('can call resolve multiple times to set multiple values', async function ()
 		partial: false,
 		stale: false,
 		source: DataSource.Cache,
-		variables: null,
+		variables: {},
 	})
 	expect(fn).toHaveBeenNthCalledWith(3, {
 		fetching: true,
@@ -392,7 +392,7 @@ test('can call resolve multiple times to set multiple values', async function ()
 		data: { hello: 'another-world' },
 		errors: [],
 		source: DataSource.Cache,
-		variables: null,
+		variables: {},
 	})
 })
 
@@ -439,7 +439,7 @@ test('middlewares can set fetch params', async function () {
 				partial: false,
 				stale: false,
 				source: DataSource.Cache,
-				variables: null,
+				variables: {},
 			})
 		},
 	})
@@ -469,7 +469,7 @@ test('exit can replay a pipeline', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: null,
+					variables: {},
 				})
 			}
 		},
@@ -486,7 +486,7 @@ test('exit can replay a pipeline', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: null,
+					variables: {},
 				})
 				return
 			}
@@ -498,7 +498,7 @@ test('exit can replay a pipeline', async function () {
 				partial: false,
 				stale: false,
 				source: DataSource.Cache,
-				variables: null,
+				variables: {},
 			})
 		},
 	})
@@ -514,7 +514,7 @@ test('exit can replay a pipeline', async function () {
 		partial: false,
 		stale: false,
 		source: DataSource.Cache,
-		variables: null,
+		variables: {},
 	})
 })
 
@@ -553,7 +553,7 @@ test('plugins can update variables', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: null,
+					variables: {},
 				})
 			},
 		}
@@ -592,7 +592,7 @@ test('can detect changed variables from inputs', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: null,
+					variables: {},
 				})
 			},
 		}
@@ -653,7 +653,7 @@ test('can pass new variables in a spread', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: null,
+					variables: {},
 				})
 			},
 		}
@@ -696,7 +696,7 @@ test('can update variables and then check if they were updated', async function 
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: null,
+					variables: {},
 				})
 			},
 		}
@@ -795,7 +795,7 @@ test('can set observer state from hook', async function () {
 				partial: false,
 				stale: false,
 				source: DataSource.Network,
-				variables: null,
+				variables: {},
 			})
 		},
 	})
@@ -819,7 +819,7 @@ test('can set observer state from hook', async function () {
 		partial: false,
 		stale: false,
 		source: null,
-		variables: null,
+		variables: {},
 	})
 
 	// the third should have the final result
@@ -830,7 +830,7 @@ test('can set observer state from hook', async function () {
 		partial: false,
 		stale: false,
 		source: DataSource.Network,
-		variables: null,
+		variables: {},
 	})
 })
 
@@ -885,7 +885,7 @@ test("sending a setup message doesn't trigger the network steps", async function
 				partial: false,
 				stale: false,
 				source: DataSource.Cache,
-				variables: null,
+				variables: {},
 			})
 		},
 		afterNetwork(ctx, { resolve }) {
@@ -928,7 +928,7 @@ test('in a query, if fetching is set to false, return with false', async functio
 				partial: false,
 				stale: false,
 				source: DataSource.Cache,
-				variables: null,
+				variables: {},
 			})
 		},
 	})
@@ -951,7 +951,7 @@ test('in a query, if fetching is set to false, return with false', async functio
 		partial: false,
 		stale: false,
 		source: null,
-		variables: null,
+		variables: {},
 	})
 })
 
@@ -965,7 +965,7 @@ test('in a mutation, fetching should be false', async function () {
 				partial: false,
 				stale: false,
 				source: DataSource.Cache,
-				variables: null,
+				variables: {},
 			})
 		},
 	})
@@ -988,7 +988,7 @@ test('in a mutation, fetching should be false', async function () {
 		partial: false,
 		stale: false,
 		source: null,
-		variables: null,
+		variables: {},
 	})
 })
 
@@ -1077,7 +1077,7 @@ test('throw hooks can resolve the plugin instead', async function () {
 				partial: false,
 				stale: false,
 				source: DataSource.Cache,
-				variables: null,
+				variables: {},
 			})
 		},
 	})
@@ -1104,7 +1104,7 @@ test('throw hooks can resolve the plugin instead', async function () {
 		partial: false,
 		stale: false,
 		source: DataSource.Cache,
-		variables: null,
+		variables: {},
 	})
 
 	// make sure the spy was called in the correct order
@@ -1120,7 +1120,7 @@ test('throw hooks can replay the plugin instead', async function () {
 		partial: false,
 		stale: false,
 		source: DataSource.Cache,
-		variables: null,
+		variables: {},
 	}
 	const fn = vi.fn()
 

--- a/packages/houdini/src/runtime/client/documentStore.ts
+++ b/packages/houdini/src/runtime/client/documentStore.ts
@@ -69,7 +69,7 @@ export class DocumentStore<
 			stale: false,
 			source: null,
 			fetching,
-			variables: null,
+			variables: {},
 		}
 
 		super(initialState, () => {

--- a/packages/houdini/src/runtime/client/plugins/cache.test.ts
+++ b/packages/houdini/src/runtime/client/plugins/cache.test.ts
@@ -44,7 +44,7 @@ test('NetworkOnly', async function () {
 		},
 		errors: null,
 		fetching: false,
-		variables: null,
+		variables: {},
 		source: 'network',
 		partial: false,
 		stale: false,
@@ -60,7 +60,7 @@ test('NetworkOnly', async function () {
 		},
 		errors: null,
 		fetching: false,
-		variables: null,
+		variables: {},
 		source: 'network',
 		partial: false,
 		stale: false,
@@ -93,7 +93,7 @@ test('CacheOrNetwork', async function () {
 		},
 		errors: null,
 		fetching: false,
-		variables: null,
+		variables: {},
 		source: 'network',
 		partial: false,
 		stale: false,
@@ -154,7 +154,7 @@ test('CacheOnly', async function () {
 		},
 		errors: null,
 		fetching: false,
-		variables: null,
+		variables: {},
 		source: 'network',
 		partial: false,
 		stale: false,
@@ -213,7 +213,7 @@ test('stale', async function () {
 		partial: false,
 		source: 'network',
 		stale: false,
-		variables: null,
+		variables: {},
 	})
 
 	// intermediate returns
@@ -224,7 +224,7 @@ test('stale', async function () {
 		partial: false,
 		source: null,
 		stale: false,
-		variables: null,
+		variables: {},
 	})
 
 	//  mark stale
@@ -280,7 +280,7 @@ test('stale', async function () {
 		partial: false,
 		source: 'network',
 		stale: false,
-		variables: null,
+		variables: {},
 	})
 })
 

--- a/packages/houdini/src/runtime/client/plugins/cache.test.ts
+++ b/packages/houdini/src/runtime/client/plugins/cache.test.ts
@@ -342,7 +342,7 @@ function fakeFetch({
 		},
 		errors: null,
 		fetching: false,
-		variables: null,
+		variables: {},
 		source: DataSource.Network,
 		partial: false,
 		stale: false,

--- a/packages/houdini/src/runtime/client/plugins/cache.ts
+++ b/packages/houdini/src/runtime/client/plugins/cache.ts
@@ -47,7 +47,7 @@ export const cachePolicy =
 						if (policy === CachePolicy.CacheOnly) {
 							return resolve(ctx, {
 								fetching: false,
-								variables: ctx.variables ?? null,
+								variables: ctx.variables ?? {},
 								data: allowed ? value.data : initialValue.data,
 								errors: null,
 								source: DataSource.Cache,
@@ -61,7 +61,7 @@ export const cachePolicy =
 						if (useCache) {
 							resolve(ctx, {
 								fetching: false,
-								variables: ctx.variables ?? null,
+								variables: ctx.variables ?? {},
 								data: value.data,
 								errors: null,
 								source: DataSource.Cache,

--- a/packages/houdini/src/runtime/client/plugins/fetch.ts
+++ b/packages/houdini/src/runtime/client/plugins/fetch.ts
@@ -45,7 +45,7 @@ export const fetch = (target?: RequestHandler | string): ClientPlugin => {
 				// return the result
 				resolve(ctx, {
 					fetching: false,
-					variables: ctx.variables ?? null,
+					variables: ctx.variables ?? {},
 					data: result.data,
 					errors: !result.errors || result.errors.length === 0 ? null : result.errors,
 					partial: false,

--- a/packages/houdini/src/runtime/client/plugins/query.ts
+++ b/packages/houdini/src/runtime/client/plugins/query.ts
@@ -50,7 +50,7 @@ export const query: ClientPlugin = documentPlugin(ArtifactKind.Query, function (
 							partial: false,
 							stale: false,
 							source: DataSource.Cache,
-							variables: ctx.variables ?? null,
+							variables: ctx.variables ?? {},
 						})
 					},
 				}

--- a/packages/houdini/src/runtime/client/plugins/subscription.ts
+++ b/packages/houdini/src/runtime/client/plugins/subscription.ts
@@ -72,7 +72,7 @@ export function subscription(factory: SubscriptionHandler) {
 								partial: true,
 								stale: false,
 								source: DataSource.Network,
-								variables: ctx.variables ?? null,
+								variables: ctx.variables ?? {},
 							})
 						},
 						error(data) {
@@ -84,7 +84,7 @@ export function subscription(factory: SubscriptionHandler) {
 								data: null,
 								errors: [data as Error],
 								fetching: false,
-								variables: ctx.variables ?? null,
+								variables: ctx.variables ?? {},
 							})
 						},
 						complete() {},

--- a/packages/houdini/src/runtime/lib/types.ts
+++ b/packages/houdini/src/runtime/lib/types.ts
@@ -209,7 +209,7 @@ export type QueryResult<_Data = GraphQLObject, _Input = Record<string, any>> = {
 	partial: boolean
 	stale: boolean
 	source: DataSources | null
-	variables: _Input | null
+	variables: _Input | {}
 }
 
 export type RequestPayload<GraphQLObject = any> = {


### PR DESCRIPTION
This PR applies some feedback from @seppahbaws in order to make the `variables` key on `DocumentStores` more ergnomic. Now, the type is `_Input | {}` and the runtime uses `{}` as the default/empty value