### PR TITLE
Revert null query variables

### DIFF
--- a/.changeset/rude-clocks-thank.md
+++ b/.changeset/rude-clocks-thank.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Query variables can be null again

--- a/e2e/sveltekit/src/routes/stores/mutation/spec.ts
+++ b/e2e/sveltekit/src/routes/stores/mutation/spec.ts
@@ -11,7 +11,7 @@ test.describe('Mutation Page', () => {
       data: null,
       errors: null,
       fetching: false,
-      variables: {},
+      variables: null,
       partial: false,
       stale: false,
       source: null

--- a/packages/houdini/src/runtime/client/documentStore.test.ts
+++ b/packages/houdini/src/runtime/client/documentStore.test.ts
@@ -117,7 +117,7 @@ test('middleware pipeline happy path', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: {},
+					variables: null,
 				})
 			},
 			afterNetwork(ctx, { resolve }) {
@@ -183,7 +183,7 @@ test('middleware pipeline happy path', async function () {
 		partial: false,
 		stale: false,
 		source: DataSource.Cache,
-		variables: {},
+		variables: null,
 	})
 })
 
@@ -218,7 +218,7 @@ test('terminate short-circuits pipeline', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: {},
+					variables: null,
 				})
 			},
 			end(ctx, { resolve }) {
@@ -230,7 +230,7 @@ test('terminate short-circuits pipeline', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: {},
+					variables: null,
 				})
 			},
 			network(ctx, { next }) {
@@ -288,7 +288,7 @@ test('uneven lists phases', async function () {
 				partial: false,
 				stale: false,
 				source: DataSource.Cache,
-				variables: {},
+				variables: null,
 			})
 		},
 	})
@@ -303,7 +303,7 @@ test('uneven lists phases', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: {},
+					variables: null,
 				})
 			},
 			afterNetwork(ctx, { resolve }) {
@@ -340,7 +340,7 @@ test('can call resolve multiple times to set multiple values', async function ()
 				partial: false,
 				stale: false,
 				source: DataSource.Cache,
-				variables: {},
+				variables: null,
 			})
 			sleep(100).then(() =>
 				resolve(ctx, {
@@ -350,7 +350,7 @@ test('can call resolve multiple times to set multiple values', async function ()
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: {},
+					variables: null,
 				})
 			)
 		},
@@ -374,7 +374,7 @@ test('can call resolve multiple times to set multiple values', async function ()
 		partial: false,
 		stale: false,
 		source: DataSource.Cache,
-		variables: {},
+		variables: null,
 	})
 	expect(fn).toHaveBeenNthCalledWith(2, {
 		data: { hello: 'world' },
@@ -383,7 +383,7 @@ test('can call resolve multiple times to set multiple values', async function ()
 		partial: false,
 		stale: false,
 		source: DataSource.Cache,
-		variables: {},
+		variables: null,
 	})
 	expect(fn).toHaveBeenNthCalledWith(3, {
 		fetching: true,
@@ -392,7 +392,7 @@ test('can call resolve multiple times to set multiple values', async function ()
 		data: { hello: 'another-world' },
 		errors: [],
 		source: DataSource.Cache,
-		variables: {},
+		variables: null,
 	})
 })
 
@@ -439,7 +439,7 @@ test('middlewares can set fetch params', async function () {
 				partial: false,
 				stale: false,
 				source: DataSource.Cache,
-				variables: {},
+				variables: null,
 			})
 		},
 	})
@@ -469,7 +469,7 @@ test('exit can replay a pipeline', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: {},
+					variables: null,
 				})
 			}
 		},
@@ -486,7 +486,7 @@ test('exit can replay a pipeline', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: {},
+					variables: null,
 				})
 				return
 			}
@@ -498,7 +498,7 @@ test('exit can replay a pipeline', async function () {
 				partial: false,
 				stale: false,
 				source: DataSource.Cache,
-				variables: {},
+				variables: null,
 			})
 		},
 	})
@@ -514,7 +514,7 @@ test('exit can replay a pipeline', async function () {
 		partial: false,
 		stale: false,
 		source: DataSource.Cache,
-		variables: {},
+		variables: null,
 	})
 })
 
@@ -553,7 +553,7 @@ test('plugins can update variables', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: {},
+					variables: null,
 				})
 			},
 		}
@@ -592,7 +592,7 @@ test('can detect changed variables from inputs', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: {},
+					variables: null,
 				})
 			},
 		}
@@ -653,7 +653,7 @@ test('can pass new variables in a spread', async function () {
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: {},
+					variables: null,
 				})
 			},
 		}
@@ -696,7 +696,7 @@ test('can update variables and then check if they were updated', async function 
 					partial: false,
 					stale: false,
 					source: DataSource.Cache,
-					variables: {},
+					variables: null,
 				})
 			},
 		}
@@ -795,7 +795,7 @@ test('can set observer state from hook', async function () {
 				partial: false,
 				stale: false,
 				source: DataSource.Network,
-				variables: {},
+				variables: null,
 			})
 		},
 	})
@@ -819,7 +819,7 @@ test('can set observer state from hook', async function () {
 		partial: false,
 		stale: false,
 		source: null,
-		variables: {},
+		variables: null,
 	})
 
 	// the third should have the final result
@@ -830,7 +830,7 @@ test('can set observer state from hook', async function () {
 		partial: false,
 		stale: false,
 		source: DataSource.Network,
-		variables: {},
+		variables: null,
 	})
 })
 
@@ -885,7 +885,7 @@ test("sending a setup message doesn't trigger the network steps", async function
 				partial: false,
 				stale: false,
 				source: DataSource.Cache,
-				variables: {},
+				variables: null,
 			})
 		},
 		afterNetwork(ctx, { resolve }) {
@@ -928,7 +928,7 @@ test('in a query, if fetching is set to false, return with false', async functio
 				partial: false,
 				stale: false,
 				source: DataSource.Cache,
-				variables: {},
+				variables: null,
 			})
 		},
 	})
@@ -951,7 +951,7 @@ test('in a query, if fetching is set to false, return with false', async functio
 		partial: false,
 		stale: false,
 		source: null,
-		variables: {},
+		variables: null,
 	})
 })
 
@@ -965,7 +965,7 @@ test('in a mutation, fetching should be false', async function () {
 				partial: false,
 				stale: false,
 				source: DataSource.Cache,
-				variables: {},
+				variables: null,
 			})
 		},
 	})
@@ -988,7 +988,7 @@ test('in a mutation, fetching should be false', async function () {
 		partial: false,
 		stale: false,
 		source: null,
-		variables: {},
+		variables: null,
 	})
 })
 
@@ -1077,7 +1077,7 @@ test('throw hooks can resolve the plugin instead', async function () {
 				partial: false,
 				stale: false,
 				source: DataSource.Cache,
-				variables: {},
+				variables: null,
 			})
 		},
 	})
@@ -1104,7 +1104,7 @@ test('throw hooks can resolve the plugin instead', async function () {
 		partial: false,
 		stale: false,
 		source: DataSource.Cache,
-		variables: {},
+		variables: null,
 	})
 
 	// make sure the spy was called in the correct order
@@ -1120,7 +1120,7 @@ test('throw hooks can replay the plugin instead', async function () {
 		partial: false,
 		stale: false,
 		source: DataSource.Cache,
-		variables: {},
+		variables: null,
 	}
 	const fn = vi.fn()
 

--- a/packages/houdini/src/runtime/client/documentStore.ts
+++ b/packages/houdini/src/runtime/client/documentStore.ts
@@ -69,7 +69,7 @@ export class DocumentStore<
 			stale: false,
 			source: null,
 			fetching,
-			variables: {},
+			variables: null,
 		}
 
 		super(initialState, () => {
@@ -116,7 +116,7 @@ export class DocumentStore<
 			text: this.#artifact.raw,
 			hash: this.#artifact.hash,
 			policy: policy ?? (this.#artifact as QueryArtifact).policy,
-			variables: {},
+			variables: null,
 			metadata,
 			session,
 			fetch,
@@ -135,7 +135,7 @@ export class DocumentStore<
 
 		// assign variables to take advantage of the setter on variables
 		const draft = context.draft()
-		draft.variables = variables ?? {}
+		draft.variables = variables ?? null
 		context = context.apply(draft, false)
 
 		// walk through the plugins to get the first result
@@ -413,7 +413,7 @@ class ClientPluginContextWrapper {
 				ctx.stuff = val
 			},
 			get variables() {
-				return ctx.variables ?? {}
+				return ctx.variables ?? null
 			},
 			set variables(val: Required<ClientPluginContext>['variables']) {
 				Object.assign(ctx, applyVariables(ctx, { variables: val }))
@@ -547,7 +547,7 @@ export type ClientPluginContext = {
 	artifact: DocumentArtifact
 	policy?: CachePolicies
 	fetch?: Fetch
-	variables?: Record<string, any>
+	variables?: Record<string, any> | null
 	metadata?: App.Metadata | null
 	session?: App.Session | null
 	fetchParams?: RequestInit

--- a/packages/houdini/src/runtime/client/plugins/cache.test.ts
+++ b/packages/houdini/src/runtime/client/plugins/cache.test.ts
@@ -44,7 +44,7 @@ test('NetworkOnly', async function () {
 		},
 		errors: null,
 		fetching: false,
-		variables: {},
+		variables: null,
 		source: 'network',
 		partial: false,
 		stale: false,
@@ -60,7 +60,7 @@ test('NetworkOnly', async function () {
 		},
 		errors: null,
 		fetching: false,
-		variables: {},
+		variables: null,
 		source: 'network',
 		partial: false,
 		stale: false,
@@ -93,7 +93,7 @@ test('CacheOrNetwork', async function () {
 		},
 		errors: null,
 		fetching: false,
-		variables: {},
+		variables: null,
 		source: 'network',
 		partial: false,
 		stale: false,
@@ -109,7 +109,7 @@ test('CacheOrNetwork', async function () {
 		},
 		errors: null,
 		fetching: false,
-		variables: {},
+		variables: null,
 		source: 'cache',
 		partial: false,
 		stale: false,
@@ -135,7 +135,7 @@ test('CacheOnly', async function () {
 		data: null,
 		errors: null,
 		fetching: false,
-		variables: {},
+		variables: null,
 		source: 'cache',
 		partial: false,
 		stale: false,
@@ -154,7 +154,7 @@ test('CacheOnly', async function () {
 		},
 		errors: null,
 		fetching: false,
-		variables: {},
+		variables: null,
 		source: 'network',
 		partial: false,
 		stale: false,
@@ -173,7 +173,7 @@ test('CacheOnly', async function () {
 		},
 		errors: null,
 		fetching: false,
-		variables: {},
+		variables: null,
 		source: 'cache',
 		partial: false,
 		stale: false,
@@ -213,7 +213,7 @@ test('stale', async function () {
 		partial: false,
 		source: 'network',
 		stale: false,
-		variables: {},
+		variables: null,
 	})
 
 	// intermediate returns
@@ -224,7 +224,7 @@ test('stale', async function () {
 		partial: false,
 		source: null,
 		stale: false,
-		variables: {},
+		variables: null,
 	})
 
 	//  mark stale
@@ -246,7 +246,7 @@ test('stale', async function () {
 		partial: false,
 		source: 'cache',
 		stale: true,
-		variables: {},
+		variables: null,
 	})
 
 	// intermediate returns
@@ -263,7 +263,7 @@ test('stale', async function () {
 		partial: false,
 		source: 'cache',
 		stale: true,
-		variables: {},
+		variables: null,
 	})
 
 	// Doing a real network call in the end and returning the new data & stale false
@@ -280,7 +280,7 @@ test('stale', async function () {
 		partial: false,
 		source: 'network',
 		stale: false,
-		variables: {},
+		variables: null,
 	})
 })
 
@@ -342,7 +342,7 @@ function fakeFetch({
 		},
 		errors: null,
 		fetching: false,
-		variables: {},
+		variables: null,
 		source: DataSource.Network,
 		partial: false,
 		stale: false,

--- a/packages/houdini/src/runtime/client/plugins/cache.ts
+++ b/packages/houdini/src/runtime/client/plugins/cache.ts
@@ -47,7 +47,7 @@ export const cachePolicy =
 						if (policy === CachePolicy.CacheOnly) {
 							return resolve(ctx, {
 								fetching: false,
-								variables: ctx.variables ?? {},
+								variables: ctx.variables ?? null,
 								data: allowed ? value.data : initialValue.data,
 								errors: null,
 								source: DataSource.Cache,
@@ -61,7 +61,7 @@ export const cachePolicy =
 						if (useCache) {
 							resolve(ctx, {
 								fetching: false,
-								variables: ctx.variables ?? {},
+								variables: ctx.variables ?? null,
 								data: value.data,
 								errors: null,
 								source: DataSource.Cache,

--- a/packages/houdini/src/runtime/lib/types.ts
+++ b/packages/houdini/src/runtime/lib/types.ts
@@ -209,7 +209,7 @@ export type QueryResult<_Data = GraphQLObject, _Input = Record<string, any>> = {
 	partial: boolean
 	stale: boolean
 	source: DataSources | null
-	variables: _Input | {}
+	variables: _Input | null
 }
 
 export type RequestPayload<GraphQLObject = any> = {


### PR DESCRIPTION
This PR reverts #908 and allows the `variables` key of the query store to be `null` (indicating no variables have been set)