### PR TITLE
Several small fixes in intro docs

### DIFF
--- a/site/src/routes/intro/fragments/+page.svx
+++ b/site/src/routes/intro/fragments/+page.svx
@@ -79,9 +79,9 @@ Defining a fragment inside of your component looks a lot like the query from bef
 ```svelte:title=src/components/Sprite.svelte&typescriptToggle=true
 <script lang="ts">
     import { fragment, graphql } from '$houdini'
-    import type { SprintInfo } from '$houdini'
+    import type { SpriteInfo } from '$houdini'
 
-    export let species: SprintInfo
+    export let species: SpriteInfo
 
     // prettier-ignore
     $: info = fragment(species, graphql(`
@@ -144,7 +144,7 @@ It's worth mentioning explicitly that you are free to mix and match fragments ho
 
 Before we add anything to our route, let's update the component defined in `src/components/SpeciesPreview` to use the new fragment we just added to `Sprite`. You might want to give it a try without looking ahead but either way, here's what it should look like now:
 
-```svelte:title=src/components/Sprite.svelte&typescriptToggle=true
+```svelte:title=src/components/SpeciesPreview.svelte&typescriptToggle=true
 <script lang="ts">
     import { graphql, fragment } from '$houdini'
     import { Sprite, Display } from '.'

--- a/site/src/routes/intro/mutations/+page.svx
+++ b/site/src/routes/intro/mutations/+page.svx
@@ -37,7 +37,7 @@ This example defines a mutation document named `SetFavorite` that invokes the `t
 Before we explain how to use mutations in Houdini, we need a way to visualize if a species is one of our favorites. To start, add the `favorite` to the route's query. It should now look something like:
 
 ```graphql:title=src/routes/[[id]]/+page.gql
-query Info($id: Int!) {
+query Info($id: Int! = 1) {
 	species(id: $id) {
 		name
 		flavor_text
@@ -115,14 +115,16 @@ It wouldn't be possible to look up this list's new value in the payload of `togg
 Before we get too far, let's add a place in our UI to show us the list of favorites. First, open up the `+page.gql` file and add the following block:
 
 ```diff:title=src/routes/[[id]]/+page.gql
- query Info {
-     species(id: 1) {
+ query Info($id: Int! = 1) {
+     species(id: $id) {
          id
          name
          flavor_text
-         sprites {
-             front
+         favorite
+         evolution_chain {
+             ...SpeciesPreview
          }
+         ...SpriteInfo
      }
 +    favorites @list(name:"FavoriteSpecies") {
 +        ...FavoritePreview
@@ -130,14 +132,14 @@ Before we get too far, let's add a place in our UI to show us the list of favori
  }
 ```
 
-Then, open up `src/routes/[[id]]/+page.svelte`, add imports for `FavoritePreview` and `FavoriteContainer`, and some components to visualize the list:
+Then, open up `src/routes/[[id]]/+page.svelte`, add imports for `FavoritePreview` and `FavoritesContainer`, and some components to visualize the list:
 
 ```svelte:title=src/routes/[[id]]/+page.svelte&typescriptToggle=true
 <script lang="ts">
-    import { FavoritePreview, FavoriteContainer } from '$houdini'
+    import { FavoritePreview, FavoritesContainer } from '$houdini'
 </script>
 
-<!-- this should go in the root of your component -->
+<!-- this should go in the root of your component, just before the Container -->
 <FavoritesContainer>
 	{#each $favorites.data.favorites as favorite}
 		<FavoritePreview species={favorite} />

--- a/site/src/routes/intro/pagination/+page.svx
+++ b/site/src/routes/intro/pagination/+page.svx
@@ -170,10 +170,10 @@ For more information on the Connection model, check out [this blog post](https:/
 ## Paginated Queries
 
 Interacting with a paginated query is pretty similar to everything we've been doing so far.
-Just add decorate the paginated field with the `@paginate` directive. Go ahead and change the `+page.gql` file to look like this:
+Just decorate the paginated field with the `@paginate` directive. Go ahead and change the `+page.gql` file to look like this:
 
 ```graphql:title=src/routes/[[id]]/+page.gql
-query Info($id: Int!) {
+query Info($id: Int! = 1) {
     species(id: $id) {
         name
         flavor_text
@@ -247,8 +247,8 @@ In most situations houdini's automatic appending is great since it covers popula
 <div id="move-summary">
     <MoveDisplay move={$Info.data.species.moves.edges[moveIndex].node} />
     <div id="move-controls">
-        <UpButton disabled={!hasPrevMove} on:click={Info.loadPrevMove} />
-        <DownButton disabled={!hasNextMove} on:click={Info.loadNextMove} />
+        <UpButton disabled={!hasPrevMove} on:click={loadPrevMove} />
+        <DownButton disabled={!hasNextMove} on:click={loadNextMove} />
     </div>
 </div>
 ```


### PR DESCRIPTION
No ticket for this PR.

I went through the intro docs and found a couple things details that needed fixing:

* Fix typo: SprintInfo -> SpriteInfo

* Fix typo: FavoriteContainer -> FavoritesContainer

* Fix some file names in code snippets

* Add default parameter to graphql "Info" query

* Update Info query in some snippets to use fragments instead of explicit fields

* Fix snippet code: Info.loadPrevMove -> loadPrevMove

* Other small typos

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

