### PR TITLE
Fragment argument validation

### DIFF
--- a/.changeset/gold-spies-fry.md
+++ b/.changeset/gold-spies-fry.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix parsing logic for fragment argument types

--- a/.changeset/seven-turkeys-sleep.md
+++ b/.changeset/seven-turkeys-sleep.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Improved type validation for fragment arguments

--- a/packages/houdini/src/codegen/generators/typescript/typescript.test.ts
+++ b/packages/houdini/src/codegen/generators/typescript/typescript.test.ts
@@ -147,6 +147,43 @@ describe('typescript', function () {
 			})
 		).toMatchInlineSnapshot(`
 			export type TestFragment$input = {
+			    name?: string | null | undefined;
+			};
+
+			export type TestFragment = {
+			    readonly "shape"?: TestFragment$data;
+			    readonly "$fragments": {
+			        "TestFragment": true;
+			    };
+			};
+
+			export type TestFragment$data = {
+			    readonly user: {
+			        readonly age: number | null;
+			    } | null;
+			};
+		`)
+	})
+
+	test('fragment types with required variables', async function () {
+		// the document to test
+		const doc = mockCollectedDoc(
+			`fragment TestFragment on Query @arguments(name:{ type: "ID!" }) { user(id: $name) { age } }`
+		)
+
+		// execute the generator
+		await runPipeline(config, [doc])
+
+		// look up the files in the artifact directory
+		const fileContents = await fs.readFile(config.artifactTypePath(doc.document))
+
+		// make sure they match what we expect
+		expect(
+			recast.parse(fileContents!, {
+				parser: typeScriptParser,
+			})
+		).toMatchInlineSnapshot(`
+			export type TestFragment$input = {
 			    name: string;
 			};
 

--- a/packages/houdini/src/codegen/transforms/fragmentVariables.test.ts
+++ b/packages/houdini/src/codegen/transforms/fragmentVariables.test.ts
@@ -1,5 +1,5 @@
 import type { ProgramKind } from 'ast-types/lib/gen/kinds'
-import * as graphql from 'graphql'
+import type * as graphql from 'graphql'
 import * as recast from 'recast'
 import * as typeScriptParser from 'recast/parsers/typescript'
 import { test, expect, describe } from 'vitest'

--- a/packages/houdini/src/codegen/transforms/fragmentVariables.test.ts
+++ b/packages/houdini/src/codegen/transforms/fragmentVariables.test.ts
@@ -1,11 +1,13 @@
 import type { ProgramKind } from 'ast-types/lib/gen/kinds'
+import * as graphql from 'graphql'
 import * as recast from 'recast'
 import * as typeScriptParser from 'recast/parsers/typescript'
-import { test, expect } from 'vitest'
+import { test, expect, describe } from 'vitest'
 
 import { runPipeline } from '../../codegen'
 import { fs, path } from '../../lib'
 import { testConfig, mockCollectedDoc } from '../../test'
+import { parseArgumentTypeString } from './fragmentVariables'
 
 test('pass argument values to generated fragments', async function () {
 	const docs = [
@@ -634,15 +636,16 @@ test('list arguments', async function () {
 		export default {
 		    "name": "AllUsers",
 		    "kind": "HoudiniQuery",
-		    "hash": "774e85c1a749388df97ed5768006535072408ceea2a7bba3c835553e2d65e5bd",
+		    "hash": "f67cc1c3f5ad8a2d241316a5a1e163616f79db7d2396d7a76750a34038b48fef",
 
 		    "raw": \`query AllUsers {
-		  ...QueryFragment
+		  ...QueryFragment_4AWlIw
 		}
 
-		fragment QueryFragment on Query {
-		  users(boolValue: true, stringValue: "Hello") {
+		fragment QueryFragment_4AWlIw on Query {
+		  nodes(ids: ["1"]) {
 		    id
+		    __typename
 		  }
 		}
 		\`,
@@ -651,18 +654,25 @@ test('list arguments', async function () {
 
 		    "selection": {
 		        "fields": {
-		            "users": {
-		                "type": "User",
-		                "keyRaw": "users(boolValue: true, stringValue: \\"Hello\\")",
+		            "nodes": {
+		                "type": "Node",
+		                "keyRaw": "nodes(ids: [\\"1\\"])",
 
 		                "selection": {
 		                    "fields": {
 		                        "id": {
 		                            "type": "ID",
 		                            "keyRaw": "id"
+		                        },
+
+		                        "__typename": {
+		                            "type": "String",
+		                            "keyRaw": "__typename"
 		                        }
 		                    }
-		                }
+		                },
+
+		                "abstract": true
 		            }
 		        }
 		    },
@@ -672,7 +682,7 @@ test('list arguments', async function () {
 		    "partial": false
 		};
 
-		"HoudiniHash=774e85c1a749388df97ed5768006535072408ceea2a7bba3c835553e2d65e5bd";
+		"HoudiniHash=f67cc1c3f5ad8a2d241316a5a1e163616f79db7d2396d7a76750a34038b48fef";
 	`)
 })
 
@@ -742,4 +752,95 @@ test('persists fragment variables in artifact', async function () {
 
 		"HoudiniHash=6c327bb344ded7bcdfa0cb250d5139bb8e18d5618335b4e621a06576cb10a67f";
 	`)
+})
+
+describe('parse argument type string', function () {
+	const table: {
+		title: string
+		input: string
+		expected: graphql.TypeNode
+	}[] = [
+		{
+			title: 'named types',
+			input: 'String',
+			expected: {
+				kind: 'NamedType',
+				name: {
+					kind: 'Name',
+					value: 'String',
+				},
+			},
+		},
+		{
+			title: 'non-null type',
+			input: 'String!',
+			expected: {
+				kind: 'NonNullType',
+				type: {
+					kind: 'NamedType',
+					name: {
+						kind: 'Name',
+						value: 'String',
+					},
+				},
+			},
+		},
+		{
+			title: 'list',
+			input: '[String]',
+			expected: {
+				kind: 'ListType',
+				type: {
+					kind: 'NamedType',
+					name: {
+						kind: 'Name',
+						value: 'String',
+					},
+				},
+			},
+		},
+		{
+			title: 'non-null list',
+			input: '[String]!',
+			expected: {
+				kind: 'NonNullType',
+				type: {
+					kind: 'ListType',
+					type: {
+						kind: 'NamedType',
+						name: {
+							kind: 'Name',
+							value: 'String',
+						},
+					},
+				},
+			},
+		},
+		{
+			title: 'non-null list of non-null named typesnon-null list of non-null named types',
+			input: '[String!]!',
+			expected: {
+				kind: 'NonNullType',
+				type: {
+					kind: 'ListType',
+					type: {
+						kind: 'NonNullType',
+						type: {
+							kind: 'NamedType',
+							name: {
+								kind: 'Name',
+								value: 'String',
+							},
+						},
+					},
+				},
+			},
+		},
+	]
+
+	for (const row of table) {
+		test(row.title, function () {
+			expect(parseArgumentTypeString(row.input)).toEqual(row.expected)
+		})
+	}
 })

--- a/packages/houdini/src/codegen/transforms/fragmentVariables.ts
+++ b/packages/houdini/src/codegen/transforms/fragmentVariables.ts
@@ -272,7 +272,7 @@ export function withArguments(
 
 export type FragmentArgument = {
 	name: string
-	type: string
+	type: graphql.TypeNode
 	required: boolean
 	defaultValue: graphql.ValueNode | null
 }
@@ -431,22 +431,9 @@ export function fragmentArgumentsDefinitions(
 
 	// we have a list of the arguments
 	return args.map<graphql.VariableDefinitionNode>((arg) => {
-		const innerType: graphql.NamedTypeNode = {
-			kind: 'NamedType',
-			name: {
-				kind: 'Name',
-				value: arg.type,
-			},
-		}
-
 		return {
 			kind: 'VariableDefinition',
-			type: arg.required
-				? innerType
-				: {
-						kind: 'NonNullType',
-						type: innerType,
-				  },
+			type: arg.type,
 			variable: {
 				kind: 'Variable',
 				name: {

--- a/packages/houdini/src/codegen/transforms/fragmentVariables.ts
+++ b/packages/houdini/src/codegen/transforms/fragmentVariables.ts
@@ -310,16 +310,14 @@ export function fragmentArguments(
 				}
 
 				let type = parseArgumentTypeString(typeArg.value)
-				let name = arg.name.value
-				let required = type.kind === 'NonNullType'
 				let defaultValue =
 					arg.value.fields?.find((arg) => arg.name.value === 'default')?.value || null
 
 				return [
 					{
-						name,
+						name: arg.name.value,
 						type,
-						required,
+						required: type.kind === 'NonNullType',
 						defaultValue,
 					},
 				]

--- a/packages/houdini/src/codegen/transforms/fragmentVariables.ts
+++ b/packages/houdini/src/codegen/transforms/fragmentVariables.ts
@@ -329,8 +329,6 @@ export function fragmentArguments(
 // them into the corresponding graphql AST
 export function parseArgumentTypeString(input: string): graphql.TypeNode {
 	// because of the structure of the string, we can start at the end of the input
-	// thanks chat gpt! it was struggling to pull off the actual implementation
-	// this was helpful insight
 
 	// if we are dealing with a non-null
 	if (input[input.length - 1] === '!') {

--- a/packages/houdini/src/codegen/validators/typeCheck.test.ts
+++ b/packages/houdini/src/codegen/validators/typeCheck.test.ts
@@ -1,4 +1,4 @@
-import * as graphql from 'graphql'
+import type * as graphql from 'graphql'
 import { test, expect, describe } from 'vitest'
 
 import type { Config } from '../../lib'

--- a/packages/houdini/src/codegen/validators/typeCheck.test.ts
+++ b/packages/houdini/src/codegen/validators/typeCheck.test.ts
@@ -679,7 +679,7 @@ const table: Row[] = [
 		documents: [
 			`
 			fragment Fragment on Query @arguments(
-				ids: { type: [String] }
+				ids: { type: "[String]" }
 			) {
 				nodes(ids: $ids) {
 					id

--- a/packages/houdini/src/codegen/validators/typeCheck.ts
+++ b/packages/houdini/src/codegen/validators/typeCheck.ts
@@ -779,6 +779,11 @@ export function valueIsType(
 	if (value.kind === 'FloatValue') {
 		return targetType.kind === 'NamedType' && targetType.name.value === 'Float'
 	}
+	if (value.kind === 'ObjectValue' && targetType.kind === 'NamedType') {
+		// if we are passing an object value as a type we have to trust it as a valid
+		// value for a scalar
+		return true
+	}
 	if (value.kind === 'EnumValue' && targetType.kind === 'NamedType') {
 		// we need to look up the target type in the schema and see if the enum matches
 		const enumType = config.schema.getType(targetType.name.value)

--- a/packages/houdini/src/codegen/validators/typeCheck.ts
+++ b/packages/houdini/src/codegen/validators/typeCheck.ts
@@ -712,32 +712,21 @@ function validateFragmentArguments(
 				// every argument corresponds to one defined in the fragment
 				else {
 					// zip together the provided argument with the one in the fragment definition
-					const zipped: [graphql.ArgumentNode, string][] = appliedArgumentNames.map(
-						(name) => [
+					const zipped: [graphql.ArgumentNode, graphql.TypeNode][] =
+						appliedArgumentNames.map((name) => [
 							appliedArguments[name],
 							fragmentArguments[fragmentName].find((arg) => arg.name === name)!.type,
-						]
-					)
+						])
 
 					for (const [applied, target] of zipped) {
-						// TODO: validate these types
-						// if the applied value is a variable, list, or object don't validate it
-						if (
-							applied.value.kind === graphql.Kind.VARIABLE ||
-							applied.value.kind === graphql.Kind.LIST ||
-							applied.value.kind === graphql.Kind.OBJECT
-						) {
-							continue
-						}
-
-						// the applied value isn't a variable
-						const appliedType = applied.value.kind.substring(
-							0,
-							applied.value.kind.length - 'Value'.length
-						)
-
 						// if the two don't match up, its not a valid argument type
-						if (appliedType !== target) {
+						if (!valueIsType(config, applied.value, target)) {
+							// the applied value isn't a variable
+							const appliedType = applied.value.kind.substring(
+								0,
+								applied.value.kind.length - 'Value'.length
+							)
+
 							ctx.reportError(
 								new graphql.GraphQLError(
 									`Invalid argument type. Expected ${target}, found ${appliedType}`
@@ -749,6 +738,67 @@ function validateFragmentArguments(
 			},
 		}
 	}
+}
+
+// returns true if two type nodes are equal
+export function valueIsType(
+	config: Config,
+	value: graphql.ValueNode,
+	targetType: graphql.TypeNode
+): boolean {
+	// if we were passed null then we can answer the question
+	if (value.kind === 'NullValue') {
+		// the value is correct if the targe type is not non-null
+		return targetType.kind !== 'NonNullType'
+	}
+
+	// we know we aren't passing a null value
+
+	// let's shed a non-null
+	if (targetType.kind === 'NonNullType') {
+		targetType = targetType.type
+	}
+
+	// process list values
+	if (value.kind === 'ListValue') {
+		// if the target type is not a list we're done
+		if (targetType.kind !== 'ListType') {
+			return false
+		}
+		const listType = targetType.type
+
+		// if we weren't expecting a list value, we're done
+		return value.values.every((value) => valueIsType(config, value, listType))
+	}
+
+	// we have scalar values so we need to make sure that the type match
+	if (value.kind === 'BooleanValue') {
+		return targetType.kind === 'NamedType' && targetType.name.value === 'Boolean'
+	}
+	if (value.kind === 'StringValue') {
+		return targetType.kind === 'NamedType' && targetType.name.value === 'String'
+	}
+	if (value.kind === 'IntValue') {
+		return targetType.kind === 'NamedType' && targetType.name.value === 'Int'
+	}
+	if (value.kind === 'FloatValue') {
+		return targetType.kind === 'NamedType' && targetType.name.value === 'Float'
+	}
+	if (value.kind === 'EnumValue' && targetType.kind === 'NamedType') {
+		// we need to look up the target type in the schema and see if the enum matches
+		const enumType = config.schema.getType(targetType.name.value)
+
+		// if the targe type isn't an enum, then we have a problem
+		if (!graphql.isEnumType(enumType)) {
+			return false
+		}
+
+		// its a valid value if its a possible value of the enum
+		return enumType.getValues().some((enumValue) => enumValue.value === value.value)
+	}
+
+	// if we got this far we dont recognize the situation so skip it
+	return false
 }
 
 function paginateArgs(config: Config, filepath: string) {

--- a/packages/houdini/src/test/index.ts
+++ b/packages/houdini/src/test/index.ts
@@ -71,6 +71,7 @@ export function testConfigFile({ plugins, ...config }: Partial<ConfigFile> = {})
 				entitiesByCursor(first: Int, after: String, last: Int, before: String): EntityConnection!
 				node(id: ID!): Node
 				customIdList: [CustomIdType]!
+				nodes(ids: [ID!]!): [Node!]!
 			}
 
 			type PageInfo {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
             graphql: 15.8.0
             graphql-relay: 0.10.0_graphql@15.8.0
             graphql-ws: 5.11.2_graphql@15.8.0
-            graphql-yoga: 3.4.0_l5ldqtd2ymgrkm4qlxjuv5xwgy
+            graphql-yoga: 3.4.0_graphql@15.8.0
             ws: 8.11.0
 
     e2e/next:
@@ -7428,7 +7428,7 @@ packages:
             graphql: 15.8.0
         dev: false
 
-    /graphql-yoga/3.4.0_l5ldqtd2ymgrkm4qlxjuv5xwgy:
+    /graphql-yoga/3.4.0_graphql@15.8.0:
         resolution:
             {
                 integrity: sha512-Cjx60mmpoK1qL/sLdM285VdAOQyJBKLuC6oMZrfO8QleneNtu0nDOM6Efv5m0IrRYSONEMtIYA7eNr0u/cCBfg==,
@@ -7443,13 +7443,13 @@ packages:
             '@graphql-tools/schema': 9.0.12_graphql@15.8.0
             '@graphql-tools/utils': 9.1.3_graphql@15.8.0
             '@graphql-yoga/subscription': 3.1.0
+            '@types/node': 18.11.15
             '@whatwg-node/fetch': 0.6.2
             '@whatwg-node/server': 0.5.8_@types+node@18.11.15
             dset: 3.1.2
             graphql: 15.8.0
             tslib: 2.4.1
         transitivePeerDependencies:
-            - '@types/node'
             - encoding
         dev: false
 


### PR DESCRIPTION
fixes #920, fixes #120 

This PR fixes an issue in the logic that parses the `type` string when defining fragment arguments. Along the way, I also improved the argument validation logic so that you can't pass `[1]` when a fragment argument is defined as `String`.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

