### PR TITLE
Fragment null parent typedefs

### DIFF
--- a/.changeset/bright-suns-listen.md
+++ b/.changeset/bright-suns-listen.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix fragment type definitions when parent is not-null

--- a/e2e/sveltekit/src/routes/pagination/fragment/backwards-cursor/+page.svelte
+++ b/e2e/sveltekit/src/routes/pagination/fragment/backwards-cursor/+page.svelte
@@ -10,7 +10,7 @@
   `);
 
   $: fragmentResult = paginatedFragment(
-    $queryResult.data?.user ?? null,
+    $queryResult.data!.user,
     graphql(`
       fragment BackwardsCursorFragment on User {
         friendsConnection(last: 2) @paginate {
@@ -26,7 +26,7 @@
 </script>
 
 <div id="result">
-  {$fragmentResult.data?.friendsConnection.edges.map(({ node }) => node?.name).join(', ')}
+  {$fragmentResult.data.friendsConnection.edges.map(({ node }) => node?.name).join(', ')}
 </div>
 
 <div id="pageInfo">

--- a/e2e/sveltekit/src/routes/pagination/fragment/backwards-cursor/+page.svelte
+++ b/e2e/sveltekit/src/routes/pagination/fragment/backwards-cursor/+page.svelte
@@ -10,6 +10,7 @@
   `);
 
   $: fragmentResult = paginatedFragment(
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     $queryResult.data!.user,
     graphql(`
       fragment BackwardsCursorFragment on User {

--- a/e2e/sveltekit/src/routes/pagination/fragment/backwards-cursor/+page.svelte
+++ b/e2e/sveltekit/src/routes/pagination/fragment/backwards-cursor/+page.svelte
@@ -26,11 +26,11 @@
 </script>
 
 <div id="result">
-  {$fragmentResult?.data?.friendsConnection.edges.map(({ node }) => node?.name).join(', ')}
+  {$fragmentResult.data?.friendsConnection.edges.map(({ node }) => node?.name).join(', ')}
 </div>
 
 <div id="pageInfo">
-  {JSON.stringify($fragmentResult?.pageInfo)}
+  {JSON.stringify($fragmentResult.pageInfo)}
 </div>
 
 <button id="previous" on:click={() => fragmentResult?.loadPreviousPage()}>previous</button>

--- a/e2e/sveltekit/src/routes/pagination/fragment/bidirectional-cursor/+page.svelte
+++ b/e2e/sveltekit/src/routes/pagination/fragment/bidirectional-cursor/+page.svelte
@@ -11,7 +11,7 @@
 
   $: fragmentResult = paginatedFragment(
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    $queryResult.data?.user ?? null,
+    $queryResult.data!.user,
     graphql(`
       fragment BidirectionalCursorFragment on User {
         usersConnection(after: "YXJyYXljb25uZWN0aW9uOjE=", first: 2) @paginate {
@@ -27,7 +27,7 @@
 </script>
 
 <div id="result">
-  {$fragmentResult?.data?.usersConnection.edges.map(({ node }) => node?.name).join(', ')}
+  {$fragmentResult.data.usersConnection.edges.map(({ node }) => node?.name).join(', ')}
 </div>
 
 <div id="pageInfo">

--- a/e2e/sveltekit/src/routes/pagination/fragment/bidirectional-cursor/+page.svelte
+++ b/e2e/sveltekit/src/routes/pagination/fragment/bidirectional-cursor/+page.svelte
@@ -11,7 +11,7 @@
 
   $: fragmentResult = paginatedFragment(
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    $queryResult.data!.user!,
+    $queryResult.data?.user ?? null,
     graphql(`
       fragment BidirectionalCursorFragment on User {
         usersConnection(after: "YXJyYXljb25uZWN0aW9uOjE=", first: 2) @paginate {
@@ -27,7 +27,7 @@
 </script>
 
 <div id="result">
-  {$fragmentResult.data?.usersConnection.edges.map(({ node }) => node?.name).join(', ')}
+  {$fragmentResult?.data?.usersConnection.edges.map(({ node }) => node?.name).join(', ')}
 </div>
 
 <div id="pageInfo">

--- a/e2e/sveltekit/src/routes/pagination/fragment/forward-cursor/+page.svelte
+++ b/e2e/sveltekit/src/routes/pagination/fragment/forward-cursor/+page.svelte
@@ -10,6 +10,7 @@
   `);
 
   $: fragmentResult = paginatedFragment(
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     $queryResult.data!.user,
     graphql(`
       fragment ForwardsCursorFragment on User {

--- a/e2e/sveltekit/src/routes/pagination/fragment/forward-cursor/+page.svelte
+++ b/e2e/sveltekit/src/routes/pagination/fragment/forward-cursor/+page.svelte
@@ -10,7 +10,7 @@
   `);
 
   $: fragmentResult = paginatedFragment(
-    $queryResult.data?.user ?? null,
+    $queryResult.data!.user,
     graphql(`
       fragment ForwardsCursorFragment on User {
         friendsConnection(first: 2) @paginate {
@@ -26,11 +26,11 @@
 </script>
 
 <div id="result">
-  {$fragmentResult?.data?.friendsConnection.edges.map(({ node }) => node?.name).join(', ')}
+  {$fragmentResult.data.friendsConnection.edges.map(({ node }) => node?.name).join(', ')}
 </div>
 
 <div id="pageInfo">
-  {JSON.stringify($fragmentResult?.pageInfo)}
+  {JSON.stringify($fragmentResult.pageInfo)}
 </div>
 
 <button id="next" on:click={() => fragmentResult?.loadNextPage()}>next</button>

--- a/e2e/sveltekit/src/routes/pagination/fragment/offset/+page.svelte
+++ b/e2e/sveltekit/src/routes/pagination/fragment/offset/+page.svelte
@@ -10,7 +10,7 @@
   `);
 
   $: fragmentResult = paginatedFragment(
-    $queryResult.data?.user ?? null,
+    $queryResult.data!.user,
     graphql(`
       fragment OffsetFragment on User {
         friendsList(limit: 2) @paginate {
@@ -22,7 +22,7 @@
 </script>
 
 <div id="result">
-  {$fragmentResult?.data?.friendsList.map((node) => node?.name).join(', ')}
+  {$fragmentResult.data.friendsList.map((node) => node?.name).join(', ')}
 </div>
 
 <button id="next" on:click={() => fragmentResult?.loadNextPage()}>next</button>

--- a/e2e/sveltekit/src/routes/pagination/fragment/offset/+page.svelte
+++ b/e2e/sveltekit/src/routes/pagination/fragment/offset/+page.svelte
@@ -10,6 +10,7 @@
   `);
 
   $: fragmentResult = paginatedFragment(
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     $queryResult.data!.user,
     graphql(`
       fragment OffsetFragment on User {

--- a/e2e/sveltekit/src/routes/plugin/fragment/update/+page.svelte
+++ b/e2e/sveltekit/src/routes/plugin/fragment/update/+page.svelte
@@ -11,17 +11,17 @@
     }
   `);
 
-  $: user = fragment<UserFragmentTestFragment>(
-    $userInfo.data?.node ?? null,
-    graphql`
+  $: user = fragment(
+    $userInfo.data!.node!,
+    graphql(`
       fragment UserFragmentTestFragment on User {
         name
       }
-    `
+    `)
   );
 </script>
 
-<div id="result">{$user?.name}</div>
+<div id="result">{$user.name}</div>
 
 <button id="refetch" on:click={() => userInfo.fetch({ variables: { id: 'preprocess-fragment:2' } })}
   >refetch</button

--- a/e2e/sveltekit/src/routes/plugin/fragment/update/+page.svelte
+++ b/e2e/sveltekit/src/routes/plugin/fragment/update/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { fragment, graphql, type UserFragmentTestFragment } from '$houdini';
+  import { fragment, graphql } from '$houdini';
 
   $: userInfo = graphql(`
     query FragmentUpdateTestQuery($id: ID!) @load {

--- a/e2e/sveltekit/src/routes/plugin/fragment/update/+page.svelte
+++ b/e2e/sveltekit/src/routes/plugin/fragment/update/+page.svelte
@@ -12,6 +12,7 @@
   `);
 
   $: user = fragment(
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     $userInfo.data!.node!,
     graphql(`
       fragment UserFragmentTestFragment on User {

--- a/packages/houdini-plugin-svelte-global-stores/src/test/index.ts
+++ b/packages/houdini-plugin-svelte-global-stores/src/test/index.ts
@@ -36,7 +36,7 @@ export async function pipeline_test(
 	const config = await test_config(extra_config)
 
 	// the first thing to do is to create the list of collected documents
-	const docs: Document[] = documents.map(mockCollectedDoc)
+	const docs: Document[] = documents.map((doc) => mockCollectedDoc(doc))
 
 	// apply the transforms
 	await runPipeline(config, docs)

--- a/packages/houdini-svelte/src/plugin/codegen/fragmentTypedefs/fragmentTypedefs.test.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/fragmentTypedefs/fragmentTypedefs.test.ts
@@ -157,7 +157,7 @@ test('generates types for paginated fragments', async function () {
 	expect(parsedQuery).toMatchInlineSnapshot(`
 		import { TestFragment$input, TestFragment$data } from "../../artifacts/TestFragment";
 		import { TestFragmentStore } from "../stores/TestFragment";
-		import type { OffsetFragmentStoreInstance } from "./types";
+		import type { CursorFragmentStoreInstance } from "./types";
 		import { Fragment } from "$houdini/runtime/lib/types";
 		import { Readable } from "svelte/store";
 		import { FragmentStore } from "./stores";
@@ -170,7 +170,7 @@ test('generates types for paginated fragments', async function () {
 		        };
 		    },
 		    document: TestFragmentStore
-		): OffsetFragmentStoreInstance<TestFragment$data>;
+		): CursorFragmentStoreInstance<TestFragment$data>;
 
 		export function fragment(
 		    initialValue: {
@@ -179,7 +179,7 @@ test('generates types for paginated fragments', async function () {
 		        };
 		    } | null,
 		    document: TestFragmentStore
-		): OffsetFragmentStoreInstance<TestFragment$data | null, TestFragment$input>;
+		): CursorFragmentStoreInstance<TestFragment$data | null, TestFragment$input>;
 
 		export declare function fragment<_Fragment extends Fragment<any>>(ref: _Fragment, fragment: FragmentStore<_Fragment["shape"]>): Readable<NonNullable<_Fragment["shape"]>> & {
 		    data: Readable<_Fragment>;
@@ -196,7 +196,7 @@ test('generates types for paginated fragments', async function () {
 		        };
 		    },
 		    document: TestFragmentStore
-		): OffsetFragmentStoreInstance<TestFragment$data>;
+		): CursorFragmentStoreInstance<TestFragment$data>;
 
 		export function paginatedFragment(
 		    initialValue: {
@@ -205,7 +205,7 @@ test('generates types for paginated fragments', async function () {
 		        };
 		    } | null,
 		    document: TestFragmentStore
-		): OffsetFragmentStoreInstance<TestFragment$data | null, TestFragment$input>;
+		): CursorFragmentStoreInstance<TestFragment$data | null, TestFragment$input>;
 
 		export declare function paginatedFragment<_Fragment extends Fragment<any>>(
 		    initialValue: _Fragment | null,

--- a/packages/houdini-svelte/src/plugin/codegen/fragmentTypedefs/fragmentTypedefs.test.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/fragmentTypedefs/fragmentTypedefs.test.ts
@@ -47,7 +47,7 @@ test('generates types for fragments', async function () {
 
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		import { TestFragment$input, TestFragment$data } from "../../artifacts/TestFragment";
+		import { TestFragment$input, TestFragment$data } from "../../../artifacts/TestFragment";
 		import { TestFragmentStore } from "../stores/TestFragment";
 		import type { FragmentStoreInstance } from "./types";
 		import { Fragment } from "$houdini/runtime/lib/types";
@@ -155,7 +155,7 @@ test('generates types for paginated fragments', async function () {
 
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		import { TestFragment$input, TestFragment$data } from "../../artifacts/TestFragment";
+		import { TestFragment$input, TestFragment$data } from "../../../artifacts/TestFragment";
 		import { TestFragmentStore } from "../stores/TestFragment";
 		import type { CursorFragmentStoreInstance } from "./types";
 		import { Fragment } from "$houdini/runtime/lib/types";
@@ -170,7 +170,7 @@ test('generates types for paginated fragments', async function () {
 		        };
 		    },
 		    document: TestFragmentStore
-		): CursorFragmentStoreInstance<TestFragment$data>;
+		): CursorFragmentStoreInstance<TestFragment$data, TestFragment$input>;
 
 		export function fragment(
 		    initialValue: {
@@ -196,7 +196,7 @@ test('generates types for paginated fragments', async function () {
 		        };
 		    },
 		    document: TestFragmentStore
-		): CursorFragmentStoreInstance<TestFragment$data>;
+		): CursorFragmentStoreInstance<TestFragment$data, TestFragment$input>;
 
 		export function paginatedFragment(
 		    initialValue: {

--- a/packages/houdini-svelte/src/plugin/codegen/fragmentTypedefs/fragmentTypedefs.test.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/fragmentTypedefs/fragmentTypedefs.test.ts
@@ -47,7 +47,7 @@ test('generates types for fragments', async function () {
 
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
-		import { TestFragment$data } from "../../artifacts/TestFragment";
+		import { TestFragment$input, TestFragment$data } from "../../artifacts/TestFragment";
 		import { TestFragmentStore } from "../stores/TestFragment";
 		import type { FragmentStoreInstance } from "./types";
 		import { Fragment } from "$houdini/runtime/lib/types";
@@ -80,6 +80,132 @@ test('generates types for fragments', async function () {
 		export declare function fragment<_Fragment extends Fragment<any>>(ref: _Fragment | null, fragment: FragmentStore<_Fragment["shape"]>): Readable<NonNullable<_Fragment["shape"]> | null> & {
 		    data: Readable<_Fragment | null>;
 		};
+
+		export declare function paginatedFragment<_Fragment extends Fragment<any>>(
+		    initialValue: _Fragment | null,
+		    document: FragmentStore<_Fragment["shape"]>
+		): FragmentStorePaginated<_Fragment["shape"], {}>;
+
+		export declare function paginatedFragment<_Fragment extends Fragment<any>>(initialValue: _Fragment, document: FragmentStore<_Fragment["shape"]>): FragmentStorePaginated<_Fragment["shape"], {}>;
+	`)
+})
+
+test('generates types for paginated fragments', async function () {
+	// create the mock filesystem
+	await fs.mock({
+		[path.join(config.pluginDirectory('houdini-svelte'), 'runtime', 'fragments.d.ts')]: `
+			import { Fragment } from '$houdini/runtime/lib/types';
+			import { Readable } from 'svelte/store';
+			import { FragmentStore } from './stores';
+			import type { FragmentStorePaginated } from './stores/pagination/fragment';
+
+			export declare function fragment<_Fragment extends Fragment<any>>(ref: _Fragment, fragment: FragmentStore<_Fragment['shape']>): Readable<NonNullable<_Fragment['shape']>> & {
+				data: Readable<_Fragment>;
+			};
+			export declare function fragment<_Fragment extends Fragment<any>>(ref: _Fragment | null, fragment: FragmentStore<_Fragment['shape']>): Readable<NonNullable<_Fragment['shape']> | null> & {
+				data: Readable<_Fragment | null>;
+			};
+			export declare function paginatedFragment<_Fragment extends Fragment<any>>(initialValue: _Fragment | null, document: FragmentStore<_Fragment['shape']>): FragmentStorePaginated<_Fragment['shape'], {}>;
+			export declare function paginatedFragment<_Fragment extends Fragment<any>>(initialValue: _Fragment, document: FragmentStore<_Fragment['shape']>): FragmentStorePaginated<_Fragment['shape'], {}>;
+		`,
+	})
+
+	// execute the generator
+	await generate({
+		config,
+		documents: [
+			mockCollectedDoc(
+				`
+				fragment TestFragment on Query { 
+					friendsByCursor(first:10) @paginate { 
+						edges { 
+							node { 
+								id  
+							}
+						}
+					}
+				} 
+			`,
+				{
+					refetch: {
+						method: 'cursor',
+						direction: 'forward',
+						embedded: true,
+						path: ['friendsByCursor', 'edges', 'node'],
+						paginated: true,
+						pageSize: 10,
+						targetType: 'User',
+					},
+				}
+			),
+		],
+		framework: 'kit',
+		pluginRoot,
+	})
+
+	// load the contents of the file
+	const queryContents = await fs.readFile(
+		path.join(config.pluginRuntimeDirectory('houdini-svelte'), 'fragments.d.ts')
+	)
+
+	expect(queryContents).toBeTruthy()
+
+	//the parser doesn't work right but the type imports are correct.
+	const parsedQuery = (await parseJS(queryContents!))?.script
+
+	// verify contents
+	expect(parsedQuery).toMatchInlineSnapshot(`
+		import { TestFragment$input, TestFragment$data } from "../../artifacts/TestFragment";
+		import { TestFragmentStore } from "../stores/TestFragment";
+		import type { OffsetFragmentStoreInstance } from "./types";
+		import { Fragment } from "$houdini/runtime/lib/types";
+		import { Readable } from "svelte/store";
+		import { FragmentStore } from "./stores";
+		import type { FragmentStorePaginated } from "./stores/pagination/fragment";
+
+		export function fragment(
+		    initialValue: {
+		        $fragments: {
+		            TestFragment: true;
+		        };
+		    },
+		    document: TestFragmentStore
+		): OffsetFragmentStoreInstance<TestFragment$data>;
+
+		export function fragment(
+		    initialValue: {
+		        $fragments: {
+		            TestFragment: true;
+		        };
+		    } | null,
+		    document: TestFragmentStore
+		): OffsetFragmentStoreInstance<TestFragment$data | null, TestFragment$input>;
+
+		export declare function fragment<_Fragment extends Fragment<any>>(ref: _Fragment, fragment: FragmentStore<_Fragment["shape"]>): Readable<NonNullable<_Fragment["shape"]>> & {
+		    data: Readable<_Fragment>;
+		};
+
+		export declare function fragment<_Fragment extends Fragment<any>>(ref: _Fragment | null, fragment: FragmentStore<_Fragment["shape"]>): Readable<NonNullable<_Fragment["shape"]> | null> & {
+		    data: Readable<_Fragment | null>;
+		};
+
+		export function paginatedFragment(
+		    initialValue: {
+		        $fragments: {
+		            TestFragment: true;
+		        };
+		    },
+		    document: TestFragmentStore
+		): OffsetFragmentStoreInstance<TestFragment$data>;
+
+		export function paginatedFragment(
+		    initialValue: {
+		        $fragments: {
+		            TestFragment: true;
+		        };
+		    } | null,
+		    document: TestFragmentStore
+		): OffsetFragmentStoreInstance<TestFragment$data | null, TestFragment$input>;
 
 		export declare function paginatedFragment<_Fragment extends Fragment<any>>(
 		    initialValue: _Fragment | null,

--- a/packages/houdini-svelte/src/plugin/codegen/fragmentTypedefs/fragmentTypedefs.test.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/fragmentTypedefs/fragmentTypedefs.test.ts
@@ -47,7 +47,9 @@ test('generates types for fragments', async function () {
 
 	// verify contents
 	expect(parsedQuery).toMatchInlineSnapshot(`
+		import { TestFragment$data } from "../../artifacts/TestFragment";
 		import { TestFragmentStore } from "../stores/TestFragment";
+		import type { FragmentStoreInstance } from "./types";
 		import { Fragment } from "$houdini/runtime/lib/types";
 		import { Readable } from "svelte/store";
 		import { FragmentStore } from "./stores";
@@ -60,7 +62,7 @@ test('generates types for fragments', async function () {
 		        };
 		    },
 		    document: TestFragmentStore
-		): ReturnType<TestFragmentStore["get"]>;
+		): FragmentStoreInstance<TestFragment$data>;
 
 		export function fragment(
 		    initialValue: {
@@ -69,7 +71,7 @@ test('generates types for fragments', async function () {
 		        };
 		    } | null,
 		    document: TestFragmentStore
-		): ReturnType<TestFragmentStore["get"]> | null;
+		): FragmentStoreInstance<TestFragment$data | null>;
 
 		export declare function fragment<_Fragment extends Fragment<any>>(ref: _Fragment, fragment: FragmentStore<_Fragment["shape"]>): Readable<NonNullable<_Fragment["shape"]>> & {
 		    data: Readable<_Fragment>;

--- a/packages/houdini-svelte/src/plugin/codegen/fragmentTypedefs/index.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/fragmentTypedefs/index.ts
@@ -107,16 +107,13 @@ export default async function fragmentTypedefs(input: PluginGenerateInput) {
 					AST.tsTypeReference(AST.identifier(store))
 				)
 
-				// the return value
-				const return_value = AST.tsTypeReference(
-					AST.identifier('ReturnType'),
-					AST.tsTypeParameterInstantiation([
-						AST.tsIndexedAccessType(
-							AST.tsTypeReference(AST.identifier(store)),
-							AST.tsLiteralType(AST.stringLiteral('get'))
-						),
-					])
-				)
+				ensureImports({
+					config: input.config,
+					body: contents!.script.body!,
+					sourceModule: './types',
+					import: ['FragmentStoreInstance'],
+					importKind: 'type',
+				})
 
 				// make sure the store is imported
 				ensureImports({
@@ -125,6 +122,30 @@ export default async function fragmentTypedefs(input: PluginGenerateInput) {
 					sourceModule: import_path,
 					import: [store],
 				})
+				const shapeID = `${doc.name}$data`
+				ensureImports({
+					config: input.config,
+					body: contents!.script.body!,
+					sourceModule: '../../artifacts/' + doc.name,
+					import: [shapeID],
+				})
+
+				// the return value for no null input
+				const return_value = AST.tsTypeReference(
+					AST.identifier('FragmentStoreInstance'),
+					AST.tsTypeParameterInstantiation([AST.tsTypeReference(AST.identifier(shapeID))])
+				)
+
+				// the return value if there is a null input
+				const null_return_value = AST.tsTypeReference(
+					AST.identifier('FragmentStoreInstance'),
+					AST.tsTypeParameterInstantiation([
+						AST.tsUnionType([
+							AST.tsTypeReference(AST.identifier(shapeID)),
+							AST.tsNullKeyword(),
+						]),
+					])
+				)
 
 				// if the user passes the string, return the correct store
 				return [
@@ -139,9 +160,7 @@ export default async function fragmentTypedefs(input: PluginGenerateInput) {
 						AST.tsDeclareFunction(
 							AST.identifier(which),
 							[initial_value_or_null_input, document_input],
-							AST.tsTypeAnnotation(
-								AST.tsUnionType([return_value, AST.tsNullKeyword()])
-							)
+							AST.tsTypeAnnotation(null_return_value)
 						)
 					),
 				]

--- a/packages/houdini-svelte/src/plugin/codegen/fragmentTypedefs/index.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/fragmentTypedefs/index.ts
@@ -138,16 +138,11 @@ export default async function fragmentTypedefs(input: PluginGenerateInput) {
 				ensureImports({
 					config: input.config,
 					body: contents!.script.body!,
-					sourceModule: '../../artifacts/' + doc.name,
+					sourceModule: '../../../artifacts/' + doc.name,
 					import: [inputID, shapeID],
 				})
 
-				const typeParams: TSTypeKind[] = [
-					AST.tsUnionType([
-						AST.tsTypeReference(AST.identifier(shapeID)),
-						AST.tsNullKeyword(),
-					]),
-				]
+				const typeParams: TSTypeKind[] = []
 				if (doc.refetch?.paginated) {
 					typeParams.push(AST.tsTypeReference(AST.identifier(inputID)))
 				}
@@ -155,13 +150,22 @@ export default async function fragmentTypedefs(input: PluginGenerateInput) {
 				// the return value for no null input
 				const return_value = AST.tsTypeReference(
 					AST.identifier(store_type),
-					AST.tsTypeParameterInstantiation([AST.tsTypeReference(AST.identifier(shapeID))])
+					AST.tsTypeParameterInstantiation([
+						AST.tsTypeReference(AST.identifier(shapeID)),
+						...typeParams,
+					])
 				)
 
 				// the return value if there is a null input
 				const null_return_value = AST.tsTypeReference(
 					AST.identifier(store_type),
-					AST.tsTypeParameterInstantiation(typeParams)
+					AST.tsTypeParameterInstantiation([
+						AST.tsUnionType([
+							AST.tsTypeReference(AST.identifier(shapeID)),
+							AST.tsNullKeyword(),
+						]),
+						...typeParams,
+					])
 				)
 
 				// if the user passes the string, return the correct store

--- a/packages/houdini-svelte/src/runtime/stores/fragment.ts
+++ b/packages/houdini-svelte/src/runtime/stores/fragment.ts
@@ -22,13 +22,7 @@ export class FragmentStore<_Data extends GraphQLObject, _Input = {}> {
 		this.name = storeName
 	}
 
-	get(initialValue: _Data): FragmentStoreInstance<_Data> | FragmentStoreInstance<_Data>
-	get(
-		initialValue: _Data | null
-	): FragmentStoreInstance<_Data> | FragmentStoreInstance<_Data | null>
-	get(
-		initialValue: _Data | null
-	): FragmentStoreInstance<_Data> | FragmentStoreInstance<_Data | null> {
+	get(initialValue: _Data): FragmentStoreInstance<_Data> | FragmentStoreInstance<_Data> {
 		// at the moment a fragment store doesn't really do anything
 		// but we're going to keep it wrapped in a store so we can eventually
 		// optimize the updates

--- a/packages/houdini-svelte/src/runtime/stores/fragment.ts
+++ b/packages/houdini-svelte/src/runtime/stores/fragment.ts
@@ -22,18 +22,29 @@ export class FragmentStore<_Data extends GraphQLObject, _Input = {}> {
 		this.name = storeName
 	}
 
-	get(initialValue: _Data | null) {
+	get(initialValue: _Data): FragmentStoreInstance<_Data> | FragmentStoreInstance<_Data>
+	get(
+		initialValue: _Data | null
+	): FragmentStoreInstance<_Data> | FragmentStoreInstance<_Data | null>
+	get(
+		initialValue: _Data | null
+	): FragmentStoreInstance<_Data> | FragmentStoreInstance<_Data | null> {
 		// at the moment a fragment store doesn't really do anything
 		// but we're going to keep it wrapped in a store so we can eventually
 		// optimize the updates
-		let store = writable(initialValue) as Writable<_Data | null>
+		let store = writable(initialValue) as Writable<_Data>
 
 		return {
 			kind: CompiledFragmentKind,
-			subscribe: (...args: Parameters<Readable<_Data | null>['subscribe']>) => {
+			subscribe: (...args: Parameters<Readable<_Data>['subscribe']>) => {
 				return store.subscribe(...args)
 			},
-			update: (val: _Data | null) => store?.set(val),
+			update: (val: _Data) => store?.set(val),
 		}
 	}
+}
+
+export type FragmentStoreInstance<_Data> = Readable<_Data> & {
+	kind: typeof CompiledFragmentKind
+	update: Writable<_Data>['set']
 }

--- a/packages/houdini-svelte/src/runtime/stores/fragment.ts
+++ b/packages/houdini-svelte/src/runtime/stores/fragment.ts
@@ -7,6 +7,8 @@ import { CompiledFragmentKind } from '$houdini/runtime/lib/types'
 import { writable } from 'svelte/store'
 import type { Readable, Writable } from 'svelte/store'
 
+import type { FragmentStoreInstance } from '../types'
+
 // a fragment store exists in multiple places in a given application so we
 // can't just return a store directly, the user has to load the version of the
 // fragment store for the object the store has been mixed into
@@ -22,23 +24,18 @@ export class FragmentStore<_Data extends GraphQLObject, _Input = {}> {
 		this.name = storeName
 	}
 
-	get(initialValue: _Data): FragmentStoreInstance<_Data> | FragmentStoreInstance<_Data> {
+	get(initialValue: _Data | null): FragmentStoreInstance<_Data | null> {
 		// at the moment a fragment store doesn't really do anything
 		// but we're going to keep it wrapped in a store so we can eventually
 		// optimize the updates
-		let store = writable(initialValue) as Writable<_Data>
+		let store = writable(initialValue) as Writable<_Data | null>
 
 		return {
 			kind: CompiledFragmentKind,
-			subscribe: (...args: Parameters<Readable<_Data>['subscribe']>) => {
+			subscribe: (...args: Parameters<Readable<_Data | null>['subscribe']>) => {
 				return store.subscribe(...args)
 			},
-			update: (val: _Data) => store?.set(val),
+			update: (val: _Data | null) => store?.set(val),
 		}
 	}
-}
-
-export type FragmentStoreInstance<_Data> = Readable<_Data> & {
-	kind: typeof CompiledFragmentKind
-	update: Writable<_Data>['set']
 }

--- a/packages/houdini-svelte/src/runtime/stores/pagination/cursor.ts
+++ b/packages/houdini-svelte/src/runtime/stores/pagination/cursor.ts
@@ -8,7 +8,7 @@ import type { GraphQLObject, QueryArtifact, QueryResult } from '$houdini/runtime
 import { get, writable } from 'svelte/store'
 
 import { getSession } from '../../session'
-import { CursorHandlers } from '../../types'
+import type { CursorHandlers } from '../../types'
 import type { QueryStoreFetchParams } from '../query'
 import { fetchParams } from '../query'
 import type { FetchFn } from './fetch'
@@ -224,7 +224,7 @@ If you think this is an error, please open an issue on GitHub`)
 					)
 				) {
 					console.warn(`⚠️ Encountered a fetch() in the middle of the connection.
-Make sure to pass a cursor value by hand that includes the current set (ie the entry before startCursor)					
+Make sure to pass a cursor value by hand that includes the current set (ie the entry before startCursor)
 `)
 					return observer.state
 				}

--- a/packages/houdini-svelte/src/runtime/stores/pagination/cursor.ts
+++ b/packages/houdini-svelte/src/runtime/stores/pagination/cursor.ts
@@ -5,10 +5,10 @@ import { getCurrentConfig } from '$houdini/runtime/lib/config'
 import { siteURL } from '$houdini/runtime/lib/constants'
 import { deepEquals } from '$houdini/runtime/lib/deepEquals'
 import type { GraphQLObject, QueryArtifact, QueryResult } from '$houdini/runtime/lib/types'
-import type { Writable } from 'svelte/store'
 import { get, writable } from 'svelte/store'
 
 import { getSession } from '../../session'
+import { CursorHandlers } from '../../types'
 import type { QueryStoreFetchParams } from '../query'
 import { fetchParams } from '../query'
 import type { FetchFn } from './fetch'
@@ -261,23 +261,4 @@ Make sure to pass a cursor value by hand that includes the current set (ie the e
 			return result
 		},
 	}
-}
-
-export type CursorHandlers<_Data extends GraphQLObject, _Input> = {
-	loadNextPage: (args?: {
-		first?: number
-		after?: string
-		fetch?: typeof globalThis.fetch
-		metadata: {}
-	}) => Promise<void>
-	loadPreviousPage: (args?: {
-		last?: number
-		before?: string
-		fetch?: typeof globalThis.fetch
-		metadata?: {}
-	}) => Promise<void>
-	pageInfo: Writable<PageInfo>
-	fetch(
-		args?: QueryStoreFetchParams<_Data, _Input> | undefined
-	): Promise<QueryResult<_Data, _Input>>
 }

--- a/packages/houdini-svelte/src/runtime/stores/pagination/fragment.ts
+++ b/packages/houdini-svelte/src/runtime/stores/pagination/fragment.ts
@@ -12,8 +12,8 @@ import type { Readable, Subscriber } from 'svelte/store'
 import { derived, get } from 'svelte/store'
 
 import { getClient, initClient } from '../../client'
+import type { CursorHandlers, OffsetFragmentStoreInstance } from '../../types'
 import type { StoreConfig } from '../query'
-import type { CursorHandlers } from './cursor'
 import { cursorHandlers } from './cursor'
 import { offsetHandlers } from './offset'
 import { extractPageInfo, type PageInfo } from './pageInfo'
@@ -158,7 +158,7 @@ export class FragmentStoreOffset<
 	_Data extends GraphQLObject,
 	_Input extends Record<string, any>
 > extends BasePaginatedFragmentStore<_Data, _Input> {
-	get(initialValue: _Data | null) {
+	get(initialValue: _Data | null): OffsetFragmentStoreInstance<_Data, _Input> {
 		const observer = getClient().observe<_Data, _Input>({
 			artifact: this.paginationArtifact,
 			initialValue,

--- a/packages/houdini-svelte/src/runtime/stores/pagination/fragment.ts
+++ b/packages/houdini-svelte/src/runtime/stores/pagination/fragment.ts
@@ -195,7 +195,8 @@ export class FragmentStoreOffset<
 		// add the offset handlers
 		return {
 			kind: CompiledFragmentKind,
-			data: derived(observer, ($value) => $value.data),
+			data: derived(observer, ($value) => $value.data!),
+			// @ts-ignore
 			subscribe: observer.subscribe.bind(observer),
 			fetch: handlers.fetch,
 			loadNextPage: handlers.loadNextPage,

--- a/packages/houdini-svelte/src/runtime/stores/pagination/offset.ts
+++ b/packages/houdini-svelte/src/runtime/stores/pagination/offset.ts
@@ -106,13 +106,3 @@ export function offsetHandlers<_Data extends GraphQLObject, _Input extends {}>({
 		},
 	}
 }
-
-export type OffsetHandlers<_Data extends GraphQLObject, _Input, _ReturnType> = {
-	loadNextPage: (args?: {
-		limit?: number
-		offset?: number
-		metadata?: {}
-		fetch?: typeof globalThis.fetch
-	}) => Promise<void>
-	fetch(args?: QueryStoreFetchParams<_Data, _Input> | undefined): Promise<_ReturnType>
-}

--- a/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
+++ b/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
@@ -3,7 +3,7 @@ import type { Subscriber } from 'svelte/store'
 import { derived } from 'svelte/store'
 
 import { getClient, initClient } from '../../client'
-import { CursorHandlers, OffsetHandlers } from '../../types'
+import type { CursorHandlers, OffsetHandlers } from '../../types'
 import type {
 	ClientFetchParams,
 	LoadEventFetchParams,

--- a/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
+++ b/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
@@ -3,6 +3,7 @@ import type { Subscriber } from 'svelte/store'
 import { derived } from 'svelte/store'
 
 import { getClient, initClient } from '../../client'
+import { CursorHandlers, OffsetHandlers } from '../../types'
 import type {
 	ClientFetchParams,
 	LoadEventFetchParams,
@@ -11,9 +12,8 @@ import type {
 	StoreConfig,
 } from '../query'
 import { QueryStore } from '../query'
-import type { CursorHandlers } from './cursor'
+import type {} from './cursor'
 import { cursorHandlers } from './cursor'
-import type { OffsetHandlers } from './offset'
 import { offsetHandlers } from './offset'
 import { extractPageInfo, type PageInfo } from './pageInfo'
 
@@ -108,11 +108,7 @@ export class QueryStoreOffset<_Data extends GraphQLObject, _Input extends {}> ex
 	// all paginated stores need to have a flag to distinguish from other query stores
 	paginated = true
 
-	async loadNextPage(
-		args?: Parameters<
-			OffsetHandlers<_Data, _Input, QueryResult<_Data, _Input>>['loadNextPage']
-		>[0]
-	) {
+	async loadNextPage(args?: Parameters<OffsetHandlers<_Data, _Input>['loadNextPage']>[0]) {
 		return this.#handlers.loadNextPage.call(this, args)
 	}
 
@@ -124,8 +120,8 @@ export class QueryStoreOffset<_Data extends GraphQLObject, _Input extends {}> ex
 		return this.#handlers.fetch.call(this, args)
 	}
 
-	#_handlers: OffsetHandlers<_Data, _Input, QueryResult<_Data, _Input>> | null = null
-	get #handlers(): OffsetHandlers<_Data, _Input, QueryResult<_Data, _Input>> {
+	#_handlers: OffsetHandlers<_Data, _Input> | null = null
+	get #handlers(): OffsetHandlers<_Data, _Input> {
 		if (this.#_handlers) {
 			return this.#_handlers
 		}

--- a/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
+++ b/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
@@ -12,7 +12,6 @@ import type {
 	StoreConfig,
 } from '../query'
 import { QueryStore } from '../query'
-import type {} from './cursor'
 import { cursorHandlers } from './cursor'
 import { offsetHandlers } from './offset'
 import { extractPageInfo, type PageInfo } from './pageInfo'

--- a/packages/houdini-svelte/src/runtime/types.ts
+++ b/packages/houdini-svelte/src/runtime/types.ts
@@ -1,5 +1,6 @@
-import type { FetchQueryResult } from '$houdini/runtime/lib/types'
+import type { FetchQueryResult, CompiledFragmentKind } from '$houdini/runtime/lib/types'
 import type { LoadEvent } from '@sveltejs/kit'
+import type { Readable, Writable } from 'svelte/store'
 
 export type QueryInputs<_Data> = FetchQueryResult<_Data> & { variables: { [key: string]: any } }
 
@@ -37,4 +38,9 @@ export type KitLoadResponse = {
 	props?: Record<string, any>
 	context?: Record<string, any>
 	maxage?: number
+}
+
+export type FragmentStoreInstance<_Data> = Readable<_Data> & {
+	kind: typeof CompiledFragmentKind
+	update: Writable<_Data>['set']
 }

--- a/packages/houdini-svelte/src/runtime/types.ts
+++ b/packages/houdini-svelte/src/runtime/types.ts
@@ -53,17 +53,19 @@ export type FragmentStoreInstance<_Data> = Readable<_Data> & {
 	update: Writable<_Data>['set']
 }
 
+type Reshape<_Data, _Input> = Omit<QueryResult<_Data, _Input>, 'data'> & { data: _Data }
+
 export type CursorFragmentStoreInstance<_Data extends GraphQLObject, _Input> = {
 	kind: typeof CompiledFragmentKind
 	data: Readable<_Data>
-	subscribe: Readable<QueryResult<_Data, _Input>>['subscribe']
+	subscribe: Readable<Reshape<_Data, _Input> & { pageInfo: PageInfo }>['subscribe']
 	fetching: Readable<boolean>
 } & CursorHandlers<_Data, _Input>
 
 export type OffsetFragmentStoreInstance<_Data extends GraphQLObject, _Input> = {
 	kind: typeof CompiledFragmentKind
-	data: Readable<_Data | null>
-	subscribe: Readable<QueryResult<_Data, _Input>>['subscribe']
+	data: Readable<_Data>
+	subscribe: Readable<Reshape<_Data, _Input>>['subscribe']
 	fetching: Readable<boolean>
 } & OffsetHandlers<_Data, _Input>
 

--- a/packages/houdini-svelte/src/runtime/types.ts
+++ b/packages/houdini-svelte/src/runtime/types.ts
@@ -7,8 +7,8 @@ import type {
 import type { LoadEvent } from '@sveltejs/kit'
 import type { Readable, Writable } from 'svelte/store'
 
-import { QueryStoreFetchParams } from './stores'
-import { PageInfo } from './stores/pagination/pageInfo'
+import type { QueryStoreFetchParams } from './stores'
+import type { PageInfo } from './stores/pagination/pageInfo'
 
 export type QueryInputs<_Data> = FetchQueryResult<_Data> & { variables: { [key: string]: any } }
 

--- a/packages/houdini-svelte/src/runtime/types.ts
+++ b/packages/houdini-svelte/src/runtime/types.ts
@@ -1,6 +1,14 @@
-import type { FetchQueryResult, CompiledFragmentKind } from '$houdini/runtime/lib/types'
+import type {
+	FetchQueryResult,
+	CompiledFragmentKind,
+	QueryResult,
+	GraphQLObject,
+} from '$houdini/runtime/lib/types'
 import type { LoadEvent } from '@sveltejs/kit'
 import type { Readable, Writable } from 'svelte/store'
+
+import { QueryStoreFetchParams } from './stores'
+import { PageInfo } from './stores/pagination/pageInfo'
 
 export type QueryInputs<_Data> = FetchQueryResult<_Data> & { variables: { [key: string]: any } }
 
@@ -43,4 +51,49 @@ export type KitLoadResponse = {
 export type FragmentStoreInstance<_Data> = Readable<_Data> & {
 	kind: typeof CompiledFragmentKind
 	update: Writable<_Data>['set']
+}
+
+export type CursorFragmentStoreInstance<_Data extends GraphQLObject, _Input> = {
+	kind: typeof CompiledFragmentKind
+	data: Readable<_Data>
+	subscribe: Readable<QueryResult<_Data, _Input>>['subscribe']
+	fetching: Readable<boolean>
+} & CursorHandlers<_Data, _Input>
+
+export type OffsetFragmentStoreInstance<_Data extends GraphQLObject, _Input> = {
+	kind: typeof CompiledFragmentKind
+	data: Readable<_Data | null>
+	subscribe: Readable<QueryResult<_Data, _Input>>['subscribe']
+	fetching: Readable<boolean>
+} & OffsetHandlers<_Data, _Input>
+
+export type CursorHandlers<_Data extends GraphQLObject, _Input> = {
+	loadNextPage: (args?: {
+		first?: number
+		after?: string
+		fetch?: typeof globalThis.fetch
+		metadata: {}
+	}) => Promise<void>
+	loadPreviousPage: (args?: {
+		last?: number
+		before?: string
+		fetch?: typeof globalThis.fetch
+		metadata?: {}
+	}) => Promise<void>
+	pageInfo: Writable<PageInfo>
+	fetch(
+		args?: QueryStoreFetchParams<_Data, _Input> | undefined
+	): Promise<QueryResult<_Data, _Input>>
+}
+
+export type OffsetHandlers<_Data extends GraphQLObject, _Input> = {
+	loadNextPage: (args?: {
+		limit?: number
+		offset?: number
+		metadata?: {}
+		fetch?: typeof globalThis.fetch
+	}) => Promise<void>
+	fetch(
+		args?: QueryStoreFetchParams<_Data, _Input> | undefined
+	): Promise<QueryResult<_Data, _Input>>
 }

--- a/packages/houdini-svelte/src/test/index.ts
+++ b/packages/houdini-svelte/src/test/index.ts
@@ -47,7 +47,7 @@ export async function pipeline_test(
 	const config = await test_config(extra_config)
 
 	// the first thing to do is to create the list of collected documents
-	const docs: Document[] = documents.map(mockCollectedDoc)
+	const docs: Document[] = documents.map((doc) => mockCollectedDoc(doc))
 
 	// apply the transforms
 	await runPipeline(config, docs)

--- a/packages/houdini/src/test/index.ts
+++ b/packages/houdini/src/test/index.ts
@@ -269,7 +269,7 @@ export function pipelineTest(
 ) {
 	return async () => {
 		// the first thing to do is to create the list of collected documents
-		const docs: Document[] = documents.map(mockCollectedDoc)
+		const docs: Document[] = documents.map((doc) => mockCollectedDoc(doc))
 
 		// we need to trap if we didn't fail
 		let error: Error[] = []
@@ -301,7 +301,7 @@ export function pipelineTest(
 	}
 }
 
-export function mockCollectedDoc(query: string): Document {
+export function mockCollectedDoc(query: string, data?: Partial<Document>): Document {
 	const parsed = graphql.parse(query)
 
 	// look at the first definition in the pile for the name
@@ -344,6 +344,7 @@ export function mockCollectedDoc(query: string): Document {
 		generateStore: true,
 		originalString: query,
 		artifact: null,
+		...data,
 	}
 }
 


### PR DESCRIPTION
This PR fixes the type definitions for the `fragment` function so that if the parent is not allowed to be null, `data` will also be non-null.

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

