### PR TITLE
Subscriptions reuse existing client

### DIFF
--- a/.changeset/itchy-geckos-prove.md
+++ b/.changeset/itchy-geckos-prove.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix bug causing multiple websocket clients to be created

--- a/packages/houdini-svelte/src/runtime/stores/base.ts
+++ b/packages/houdini-svelte/src/runtime/stores/base.ts
@@ -1,4 +1,4 @@
-import { DocumentStore, ObserveParams } from '$houdini/runtime/client'
+import { DocumentStore, type ObserveParams } from '$houdini/runtime/client'
 import type { GraphQLObject, DocumentArtifact, QueryResult } from '$houdini/runtime/lib/types'
 import { get } from 'svelte/store'
 import type { Readable } from 'svelte/store'

--- a/packages/houdini-svelte/src/runtime/stores/base.ts
+++ b/packages/houdini-svelte/src/runtime/stores/base.ts
@@ -1,22 +1,41 @@
-import type { DocumentStore, ObserveParams } from '$houdini/runtime/client'
-import type { GraphQLObject, DocumentArtifact } from '$houdini/runtime/lib/types'
+import { DocumentStore, ObserveParams } from '$houdini/runtime/client'
+import type { GraphQLObject, DocumentArtifact, QueryResult } from '$houdini/runtime/lib/types'
+import { get } from 'svelte/store'
+import type { Readable } from 'svelte/store'
 
-import { getClient } from '../client'
+import { isBrowser } from '../adapter'
+import { getClient, initClient } from '../client'
 
 export class BaseStore<
 	_Data extends GraphQLObject,
 	_Input extends {},
 	_Artifact extends DocumentArtifact = DocumentArtifact
 > {
-	// the underlying artifact
+	// the underlying data
 	#params: ObserveParams<_Data, _Artifact>
-
-	constructor(params: ObserveParams<_Data, _Artifact>) {
-		this.#params = params
-	}
-
 	get artifact() {
 		return this.#params.artifact
+	}
+	get name() {
+		return this.artifact.name
+	}
+
+	// loading the client is an asynchronous process so we need something for users to subscribe
+	// to while we load the client. this means we need 2 different document stores, one that
+	// the user subscribes to and one that we actually get results from.
+	#store: DocumentStore<_Data, _Input>
+	#unsubscribe: (() => void) | null = null
+
+	constructor(params: ObserveParams<_Data, _Artifact>) {
+		// we pass null here so that the store is a zombie - we will never
+		// send a request until the client has loaded
+		this.#store = new DocumentStore({
+			artifact: params.artifact,
+			client: null,
+			fetching: params.fetching,
+		})
+
+		this.#params = params
 	}
 
 	#observer: DocumentStore<_Data, _Input> | null = null
@@ -28,5 +47,75 @@ export class BaseStore<
 		this.#observer = getClient().observe<_Data, _Input>(this.#params)
 
 		return this.#observer
+	}
+
+	subscribe(...args: Parameters<Readable<QueryResult<_Data, _Input>>['subscribe']>) {
+		const bubbleUp = this.#store.subscribe(...args)
+
+		// make sure that the store is always listening to the cache (on the browser)
+		if (isBrowser && (this.#subscriberCount === 0 || !this.#unsubscribe)) {
+			// make sure the query is listening
+			this.setup()
+		}
+
+		// we have a new subscriber
+		this.#subscriberCount = (this.#subscriberCount ?? 0) + 1
+
+		// Handle unsubscribe
+		return () => {
+			// we lost a subscriber
+			this.#subscriberCount--
+
+			// don't clear the store state on the server (breaks SSR)
+			// or when there is still an active subscriber
+			if (this.#subscriberCount <= 0) {
+				// unsubscribe from the actual document store
+				this.#unsubscribe?.()
+				this.#unsubscribe = null
+
+				// unsubscribe from the local store
+				bubbleUp()
+			}
+		}
+	}
+
+	// in order to clear the store's value when unmounting, we need to track how many concurrent subscribers
+	// we have. when this number is 0, we need to clear the store
+	#subscriberCount = 0
+
+	//
+	// ** WARNING: THERE IS UNTESTED BEHAVIOR HERE **
+	//
+	// it's tricky to set up the e2e tests to create a component
+	// that is isolated from any fetches so i'm just leaving this big
+	// ugly comment for future us. If we modify this block, we have to
+	// make sure that this scenario works: https://github.com/HoudiniGraphql/houdini/pull/871#issuecomment-1416808842
+	setup(init: boolean = true) {
+		// if we have to initialize the client, do so
+		let initPromise: Promise<any> = Promise.resolve()
+		try {
+			getClient()
+		} catch {
+			initPromise = initClient()
+		}
+
+		initPromise.then(() => {
+			// if we've already setup, don't do anything
+			if (this.#unsubscribe) {
+				return
+			}
+
+			this.#unsubscribe = this.observer.subscribe((value) => {
+				this.#store.set(value)
+			})
+
+			// only initialize when told to
+			if (init) {
+				return this.observer.send({
+					setup: true,
+					variables: get(this.observer).variables,
+				})
+			}
+		})
 	}
 }

--- a/packages/houdini-svelte/src/runtime/stores/mutation.ts
+++ b/packages/houdini-svelte/src/runtime/stores/mutation.ts
@@ -1,4 +1,3 @@
-import type { DocumentStore } from '$houdini/runtime/client'
 import type { MutationArtifact, GraphQLObject, QueryResult } from '$houdini/runtime/lib/types'
 import type { RequestEvent } from '@sveltejs/kit'
 
@@ -44,11 +43,6 @@ export class MutationStore<
 				...mutationConfig,
 			},
 		})
-	}
-
-	subscribe(...args: Parameters<DocumentStore<_Data, _Input>['subscribe']>) {
-		// use it's value
-		return this.observer.subscribe(...args)
 	}
 }
 

--- a/packages/houdini-svelte/src/runtime/stores/subscription.ts
+++ b/packages/houdini-svelte/src/runtime/stores/subscription.ts
@@ -1,4 +1,3 @@
-import type { DocumentStore } from '$houdini/runtime/client'
 import type { SubscriptionArtifact } from '$houdini/runtime/lib/types'
 import { CompiledSubscriptionKind } from '$houdini/runtime/lib/types'
 import type { GraphQLObject } from 'houdini'
@@ -16,10 +15,6 @@ export class SubscriptionStore<_Data extends GraphQLObject, _Input extends {}> e
 
 	constructor({ artifact }: { artifact: SubscriptionArtifact }) {
 		super({ artifact })
-	}
-
-	subscribe(...args: Parameters<DocumentStore<_Data, _Input>['subscribe']>) {
-		return this.observer?.subscribe(...args)
 	}
 
 	async listen(variables?: _Input, args?: { metadata: App.Metadata }) {


### PR DESCRIPTION
Fixes #932 

This PR fixes a bug in the subscription plugin that would cause the subscription factory to be called multiple times if there were simultaneous subscriptions. 

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

