### PR TITLE
Svelte: Warn if "include" config key doesn't specify js files

### DIFF
--- a/.changeset/warm-crews-drive.md
+++ b/.changeset/warm-crews-drive.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+The codegen now warns the user if they are using page/layout queries without having .js files in their `include` paths.

--- a/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
@@ -3,7 +3,7 @@ import type { Config, GenerateHookInput } from 'houdini'
 import { fs, path } from 'houdini'
 
 import type { HoudiniSvelteConfig } from '../..'
-import type { Framework } from '../../kit'
+import { Framework, plugin_config } from '../../kit'
 import { type_route_dir, stores_directory_name, store_suffix, walk_routes } from '../../kit'
 import { houdini_afterLoad_fn, houdini_before_load_fn, houdini_on_error_fn } from '../../naming'
 import { route_params } from '../../routing'
@@ -56,7 +56,7 @@ export default async function svelteKitGenerator(
 				// Include path doesn't include js
 				!config.include.some((path) => path.includes('js')) &&
 				// And the plugin isn't configured to run in static mode
-				!(config.pluginConfig('houdini-svelte') as HoudiniSvelteConfig).static
+				!plugin_config(config).static
 			) {
 				console.error(
 					`⚠️ You are using at least one page/layout query but aren't "include"ing .js files in your config. \n 

--- a/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
@@ -56,12 +56,14 @@ export default async function svelteKitGenerator(
 			}
 
 			if (
-				// User uses layout/page queries
-				(uniquePageQueries.length > 0 || uniqueLayoutQueries.length > 0) &&
 				// Include path doesn't include js
 				!config.include.some((path) => path.includes('js')) &&
-				// And the plugin isn't configured to run in static mode
-				!plugin_config(config).static
+				(
+				  // And the plugin isn't configured to run in static mode
+				  !plugin_config(config).static ||
+				  // User uses layout/page queries
+				  (uniquePageQueries.length > 0 || uniqueLayoutQueries.length > 0)
+				)
 			) {
 				console.error(
 					`⚠️ You are using at least one page/layout query but aren't "include"ing .js files in your config. \n 

--- a/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
@@ -2,6 +2,7 @@ import type { OperationDefinitionNode } from 'graphql'
 import type { Config, GenerateHookInput } from 'houdini'
 import { fs, path } from 'houdini'
 
+import type { HoudiniSvelteConfig } from '../..'
 import type { Framework } from '../../kit'
 import { type_route_dir, stores_directory_name, store_suffix, walk_routes } from '../../kit'
 import { houdini_afterLoad_fn, houdini_before_load_fn, houdini_on_error_fn } from '../../naming'
@@ -47,6 +48,20 @@ export default async function svelteKitGenerator(
 					layoutNames.push(layout.name!.value)
 					uniqueLayoutQueries.push(layout)
 				}
+			}
+
+			if (
+				// User uses layout/page queries
+				(uniquePageQueries.length > 0 || uniqueLayoutQueries.length > 0) &&
+				// Include path doesn't include js
+				!config.include.some((path) => path.includes('js')) &&
+				// And the plugin isn't configured to run in static mode
+				!(config.pluginConfig('houdini-svelte') as HoudiniSvelteConfig).static
+			) {
+				console.error(
+					`⚠️ You are using at least one page/layout query but aren't "include"ing .js files in your config. \n 
+					This will cause houdini to not pick up the generated files and prevent it from working as expected.`
+				)
 			}
 
 			// read the svelte-kit $types.d.ts file into a string

--- a/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
@@ -58,12 +58,11 @@ export default async function svelteKitGenerator(
 			if (
 				// Include path doesn't include js
 				!config.include.some((path) => path.includes('js')) &&
-				(
-				  // And the plugin isn't configured to run in static mode
-				  !plugin_config(config).static ||
-				  // User uses layout/page queries
-				  (uniquePageQueries.length > 0 || uniqueLayoutQueries.length > 0)
-				)
+				// And the plugin isn't configured to run in static mode
+				(!plugin_config(config).static ||
+					// User uses layout/page queries
+					uniquePageQueries.length > 0 ||
+					uniqueLayoutQueries.length > 0)
 			) {
 				console.error(
 					`⚠️ You are using at least one page/layout query but aren't "include"ing .js files in your config. \n 

--- a/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
@@ -2,9 +2,14 @@ import type { OperationDefinitionNode } from 'graphql'
 import type { Config, GenerateHookInput } from 'houdini'
 import { fs, path } from 'houdini'
 
-import type { HoudiniSvelteConfig } from '../..'
-import { Framework, plugin_config } from '../../kit'
-import { type_route_dir, stores_directory_name, store_suffix, walk_routes } from '../../kit'
+import type { Framework } from '../../kit'
+import {
+	type_route_dir,
+	stores_directory_name,
+	store_suffix,
+	walk_routes,
+	plugin_config,
+} from '../../kit'
 import { houdini_afterLoad_fn, houdini_before_load_fn, houdini_on_error_fn } from '../../naming'
 import { route_params } from '../../routing'
 


### PR DESCRIPTION
### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

This PR is the result of a thread @AlecAivazis and I had on discord, where all the generated code was simply *missing* / not there in the first case, which was very difficult to debug on my own.

Now, we throw a warning during the `houdini-svelte` codegen step.
