### PR TITLE
Subscription listen then unlisten

### DIFF
--- a/.changeset/old-walls-cover.md
+++ b/.changeset/old-walls-cover.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix bug when relistening on a subscription

--- a/packages/houdini/src/runtime/client/plugins/subscription.ts
+++ b/packages/houdini/src/runtime/client/plugins/subscription.ts
@@ -90,6 +90,8 @@ export function subscription(factory: SubscriptionHandler) {
 			},
 			cleanup() {
 				clearSubscription?.()
+				// clear the check so we already recreate the connection next time
+				check = null
 			},
 		}
 	})


### PR DESCRIPTION
This PR fixes an issue reporting in discord that caused subscriptions to not recreate their session if `listen` was called after `unlisten` when the `checkValue` didn't actually change.


