### PR TITLE
Hide documentation search box key combo on mobile phones

### DIFF
--- a/site/src/components/search/SearchInput.svelte
+++ b/site/src/components/search/SearchInput.svelte
@@ -18,7 +18,7 @@
 		<Icon name="search" strokeWidth="3px" />
 		<span>Search</span>
 	</div>
-	<span class="column" aria-hidden="true">
+	<span class="column" id="search-keycombo" aria-hidden="true">
 		{modifier} + K
 	</span>
 </button>
@@ -46,6 +46,12 @@
 			flex-grow: 1;
 		}
 	}
+
+    @media (max-width: 480px) {
+        #search-keycombo {
+            display: none;
+        }
+    }
 
 	span {
 		margin-left: 10px;


### PR DESCRIPTION
This PR hides the keyboard combo indicator on the search box on mobile phones, so that the search box looks a bit nicer. Phones (usually) don't have a keyboard attached, so it was useless information anyways.
I know it's a small edit, but it was something I noticed and was annoying me a tiny bit 🙂 

| before | after |
|---|---|
| ![image](https://user-images.githubusercontent.com/10342829/219071819-9f74218a-29b2-4ec1-9545-d662ef446cf0.png) | ![image](https://user-images.githubusercontent.com/10342829/219071890-a89d5692-2274-4c97-b5ff-504b1623daab.png) |

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [ ] Includes a changeset if your fix affects the user with `pnpm changeset`

