### PR TITLE
CacheAndNetwork policy and other Grafbase fixes

### DIFF
--- a/.changeset/cyan-pandas-tan.md
+++ b/.changeset/cyan-pandas-tan.md
@@ -1,5 +1,0 @@
----
-'houdini': patch
----
-
-Loosen constraints when writing values from network results

--- a/.changeset/cyan-pandas-tan.md
+++ b/.changeset/cyan-pandas-tan.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Loosen constraints when writing values from network results

--- a/.changeset/quick-yaks-walk.md
+++ b/.changeset/quick-yaks-walk.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix behavior for CacheAndNetwork policies

--- a/packages/houdini/src/runtime/cache/cache.ts
+++ b/packages/houdini/src/runtime/cache/cache.ts
@@ -286,13 +286,7 @@ class CacheInternal {
 		for (const [field, value] of Object.entries(data)) {
 			// grab the selection info we care about
 			if (!selection || !targetSelection[field]) {
-				throw new Error(
-					'Could not find field listing in selection for ' +
-						field +
-						' @ ' +
-						JSON.stringify(selection) +
-						''
-				)
+				continue
 			}
 
 			// look up the field in our schema

--- a/packages/houdini/src/runtime/client/plugins/cache.test.ts
+++ b/packages/houdini/src/runtime/client/plugins/cache.test.ts
@@ -116,6 +116,69 @@ test('CacheOrNetwork', async function () {
 	})
 })
 
+test('CacheAndNetwork', async function () {
+	const spy = vi.fn()
+
+	const store = createStore([
+		cachePolicy({
+			enabled: true,
+			setFetching: () => {},
+			cache: new Cache(config),
+		}),
+		fakeFetch({}),
+	])
+	store.subscribe(spy)
+	await store.send({ policy: CachePolicy.CacheAndNetwork })
+	await store.send({ policy: CachePolicy.CacheAndNetwork })
+
+	expect(spy).toHaveBeenNthCalledWith(2, {
+		data: {
+			viewer: {
+				id: '1',
+				firstName: 'bob',
+				__typename: 'User',
+			},
+		},
+		errors: null,
+		fetching: false,
+		variables: null,
+		source: 'network',
+		partial: false,
+		stale: false,
+	})
+
+	expect(spy).toHaveBeenNthCalledWith(3, {
+		data: {
+			viewer: {
+				id: '1',
+				firstName: 'bob',
+				__typename: 'User',
+			},
+		},
+		errors: null,
+		fetching: false,
+		variables: null,
+		source: 'cache',
+		partial: false,
+		stale: false,
+	})
+	expect(spy).toHaveBeenNthCalledWith(4, {
+		data: {
+			viewer: {
+				id: '1',
+				firstName: 'bob',
+				__typename: 'User',
+			},
+		},
+		errors: null,
+		fetching: false,
+		variables: null,
+		source: 'network',
+		partial: false,
+		stale: false,
+	})
+})
+
 test('CacheOnly', async function () {
 	const spy = vi.fn()
 

--- a/packages/houdini/src/runtime/client/plugins/cache.ts
+++ b/packages/houdini/src/runtime/client/plugins/cache.ts
@@ -71,7 +71,13 @@ export const cachePolicy =
 						}
 
 						// if we used the cache data and there's no followup necessary, we're done
-						if (useCache && !value.partial && !value.stale) {
+						if (
+							useCache &&
+							!value.partial &&
+							!value.stale &&
+							// if the policy is CacheAndNetwork then we don't want to stop here regardless
+							ctx.policy !== 'CacheAndNetwork'
+						) {
 							return
 						}
 					}


### PR DESCRIPTION
This PR contains some fixes to some issues that I encountered while putting https://github.com/grafbase/grafbase/pull/214 together. The most important one is a fix for `CacheAndNetwork` policies. 

Also, Grafbase has a "bug" in their implementation of live queries that sends more fields than the query specifically asks for. This was breaking houdini which requires that responses match the selection object. While they fix this issue, I added a small work around that makes the cache fail silently and skip over fields that it doesn't recognize.
