### PR TITLE
Add ids to the generated selection of inline fragments

### DIFF
--- a/.changeset/fast-islands-nail.md
+++ b/.changeset/fast-islands-nail.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Add id to the generated selections of inline fragments

--- a/packages/houdini/src/codegen/generators/artifacts/artifacts.test.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/artifacts.test.ts
@@ -532,6 +532,7 @@ test('paginate over unions', async function () {
 		      node {
 		        ... on User {
 		          firstName
+		          id
 		        }
 		        __typename
 		      }
@@ -587,6 +588,11 @@ test('paginate over unions', async function () {
 		                                                        "firstName": {
 		                                                            "type": "String",
 		                                                            "keyRaw": "firstName"
+		                                                        },
+
+		                                                        "id": {
+		                                                            "type": "ID",
+		                                                            "keyRaw": "id"
 		                                                        },
 
 		                                                        "__typename": {
@@ -719,6 +725,7 @@ test('overlapping query and fragment nested selection', async function () {
 		  friends {
 		    ... on User {
 		      firstName
+		      id
 		    }
 		    ...A
 		    __typename
@@ -750,6 +757,11 @@ test('overlapping query and fragment nested selection', async function () {
 		                                "firstName": {
 		                                    "type": "String",
 		                                    "keyRaw": "firstName"
+		                                },
+
+		                                "id": {
+		                                    "type": "ID",
+		                                    "keyRaw": "id"
 		                                },
 
 		                                "friends": {
@@ -853,6 +865,7 @@ test('selections with interfaces', async function () {
 		    }
 		    ... on Ghost {
 		      name
+		      aka
 		    }
 		    __typename
 		  }
@@ -905,6 +918,11 @@ test('selections with interfaces', async function () {
 		                                "name": {
 		                                    "type": "String",
 		                                    "keyRaw": "name"
+		                                },
+
+		                                "aka": {
+		                                    "type": "String",
+		                                    "keyRaw": "aka"
 		                                },
 
 		                                "__typename": {
@@ -980,6 +998,7 @@ test('selections with unions', async function () {
 		    }
 		    ... on Ghost {
 		      name
+		      aka
 		    }
 		    __typename
 		  }
@@ -1032,6 +1051,11 @@ test('selections with unions', async function () {
 		                                "name": {
 		                                    "type": "String",
 		                                    "keyRaw": "name"
+		                                },
+
+		                                "aka": {
+		                                    "type": "String",
+		                                    "keyRaw": "aka"
 		                                },
 
 		                                "__typename": {
@@ -1109,6 +1133,7 @@ test('selections with overlapping unions', async function () {
 		    }
 		    ... on Ghost {
 		      name
+		      aka
 		    }
 		    __typename
 		  }
@@ -1166,6 +1191,11 @@ test('selections with overlapping unions', async function () {
 		                                "name": {
 		                                    "type": "String",
 		                                    "keyRaw": "name"
+		                                },
+
+		                                "aka": {
+		                                    "type": "String",
+		                                    "keyRaw": "aka"
 		                                },
 
 		                                "__typename": {
@@ -1247,10 +1277,12 @@ test('selections with unions of abstract types', async function () {
 		          firstName
 		          id
 		        }
+		        id
 		      }
 		    }
 		    ... on Ghost {
 		      name
+		      aka
 		    }
 		    __typename
 		  }
@@ -1315,6 +1347,11 @@ test('selections with unions of abstract types', async function () {
 		                                "name": {
 		                                    "type": "String",
 		                                    "keyRaw": "name"
+		                                },
+
+		                                "aka": {
+		                                    "type": "String",
+		                                    "keyRaw": "aka"
 		                                },
 
 		                                "__typename": {
@@ -1396,6 +1433,7 @@ test('selections with concrete types matching multiple abstract types', async fu
 		    }
 		    ... on Ghost {
 		      aka
+		      name
 		    }
 		    __typename
 		  }
@@ -1429,6 +1467,11 @@ test('selections with concrete types matching multiple abstract types', async fu
 		                                "aka": {
 		                                    "type": "String",
 		                                    "keyRaw": "aka"
+		                                },
+
+		                                "name": {
+		                                    "type": "String",
+		                                    "keyRaw": "name"
 		                                },
 
 		                                "cats": {
@@ -4190,6 +4233,7 @@ test('nested recursive fragments', async function () {
 		    ...NodeDetails
 		    ... on User {
 		      ...UserThings
+		      id
 		    }
 		    __typename
 		  }
@@ -4318,6 +4362,7 @@ test('leave @include and @skip alone', async function () {
 		    ...NodeDetails @include(if: true)
 		    ... on User {
 		      ...UserThings
+		      id
 		    }
 		    __typename
 		  }

--- a/packages/houdini/src/codegen/transforms/addID.test.ts
+++ b/packages/houdini/src/codegen/transforms/addID.test.ts
@@ -91,3 +91,35 @@ test('adds custom id fields to selection sets of objects with them', async funct
 
 	`)
 })
+
+test('adds id fields to inline fragments', async function () {
+	const docs = [
+		mockCollectedDoc(
+			`
+				query Friends {
+					entities {
+						... on User { 
+							name
+						}
+					}
+				}
+			`
+		),
+	]
+
+	// run the pipeline
+	const config = testConfig()
+	await runPipeline(config, docs)
+
+	expect(docs[0].document).toMatchInlineSnapshot(`
+		query Friends {
+		  entities {
+		    ... on User {
+		      name
+		      id
+		    }
+		    __typename
+		  }
+		}
+	`)
+})

--- a/packages/houdini/src/codegen/transforms/addID.ts
+++ b/packages/houdini/src/codegen/transforms/addID.ts
@@ -27,57 +27,83 @@ export default async function addID(config: Config, documents: Document[]): Prom
 				// look up the field in the parent
 				const fieldType = unwrapType(config, field.type).type
 
-				// if there is no selection set, don't worry about it
-				if (node.selectionSet?.selections.length > 0) {
-					// if the type does not have an id field ignore it
-					if (!graphql.isObjectType(fieldType) && !graphql.isInterfaceType(fieldType)) {
-						return
-					}
-
-					// look up the key fields for a given type
-					const keyFields = config.keyFieldsForType(fieldType.name)
-
-					// if there is no id field of the type
-					if (keyFields.find((key) => !fieldType.getFields()[key])) {
-						return
-					}
-
-					// add the id fields for the given type
-					const selections = [...node.selectionSet.selections]
-
-					for (const keyField of keyFields) {
-						// if there is already a selection for id, ignore it
-						if (
-							node.selectionSet.selections.find(
-								(selection) =>
-									selection.kind === 'Field' &&
-									!selection.alias &&
-									selection.name.value === keyField
-							)
-						) {
-							continue
-						}
-
-						// add a selection for the field to the selection set
-						selections.push({
-							kind: graphql.Kind.FIELD,
-							name: {
-								kind: graphql.Kind.NAME,
-								value: keyField,
-							},
-						})
-					}
-
-					// add the __typename selection to the field's selection set
-					return {
-						...node,
-						selectionSet: {
-							...node.selectionSet,
-							selections,
-						},
-					}
+				// add the appropriate fields to the selection
+				return addKeysToSelection(config, node, fieldType)
+			},
+			InlineFragment(node) {
+				// if there is no selection, move on
+				if (!node.selectionSet || !node.typeCondition) {
+					return
 				}
+
+				// we know the type from the type condition
+				const fragmentType = config.schema.getType(node.typeCondition.name.value)
+				if (!fragmentType) {
+					return
+				}
+
+				// add the appropriate fields to the selection
+				return addKeysToSelection(config, node, fragmentType)
 			},
 		})
+	}
+}
+
+function addKeysToSelection(
+	config: Config,
+	node: graphql.FieldNode | graphql.InlineFragmentNode,
+	fieldType: graphql.GraphQLNamedType
+) {
+	// if there is no selection set, don't worry about it
+	if (!node.selectionSet || node.selectionSet.selections.length == 0) {
+		return
+	}
+
+	// if the type does not have an id field ignore it
+	if (!graphql.isObjectType(fieldType) && !graphql.isInterfaceType(fieldType)) {
+		return
+	}
+
+	// look up the key fields for a given type
+	const keyFields = config.keyFieldsForType(fieldType.name)
+
+	// if there is no id field of the type
+	if (keyFields.find((key) => !fieldType.getFields()[key])) {
+		return
+	}
+
+	// add the id fields for the given type
+	const selections = [...node.selectionSet.selections]
+
+	for (const keyField of keyFields) {
+		// if there is already a selection for id, ignore it
+		if (
+			node.selectionSet.selections.find(
+				(selection) =>
+					selection.kind === 'Field' &&
+					!selection.alias &&
+					selection.name.value === keyField
+			)
+		) {
+			continue
+		}
+
+		// add a selection for the field to the selection set
+		selections.push({
+			kind: graphql.Kind.FIELD,
+			name: {
+				kind: graphql.Kind.NAME,
+				value: keyField,
+			},
+		})
+	}
+
+	// add the __typename selection to the field's selection set
+	return {
+		...node,
+		selectionSet: {
+			...node.selectionSet,
+			selections,
+		},
 	}
 }

--- a/packages/houdini/src/codegen/transforms/typename.test.ts
+++ b/packages/houdini/src/codegen/transforms/typename.test.ts
@@ -33,11 +33,11 @@ test('adds __typename on interface selection sets under query', async function (
 		    }
 		    ... on Ghost {
 		      name
+		      aka
 		    }
 		    __typename
 		  }
 		}
-
 	`)
 })
 
@@ -116,10 +116,10 @@ test('adds __typename on unions', async function () {
 		    }
 		    ... on Ghost {
 		      name
+		      aka
 		    }
 		    __typename
 		  }
 		}
-
 	`)
 })


### PR DESCRIPTION
This PR fixes a bug with the codegen's logic for adding key fields to a selection. The logic was previously only considering fields but unions that don't have fields themselves are made up of inline fragments which also need their keys added. Luckily, multiple fields showing up isn't a problem so we can be kind of lazy about this and just always add it.

