### PR TITLE
Pass ctx to the throwOnError error handler

### DIFF
--- a/.changeset/blue-toes-carry.md
+++ b/.changeset/blue-toes-carry.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Pass ctx to error handler in throwOnError

--- a/e2e/sveltekit/src/client.ts
+++ b/e2e/sveltekit/src/client.ts
@@ -31,7 +31,8 @@ export default new HoudiniClient({
   },
   throwOnError: {
     operations: ['all'],
-    error: (errors) => error(500, errors.map((error) => error.message).join('. ') + '.')
+    error: (errors, ctx) =>
+      error(500, `(${ctx.artifact.name}): ` + errors.map((error) => error.message).join('. ') + '.')
   },
   plugins: [logMetadata]
 });

--- a/e2e/sveltekit/src/client.ts
+++ b/e2e/sveltekit/src/client.ts
@@ -31,8 +31,7 @@ export default new HoudiniClient({
   },
   throwOnError: {
     operations: ['all'],
-    error: (errors, ctx) =>
-      error(500, `(${ctx.artifact.name}): ` + errors.map((error) => error.message).join('. ') + '.')
+    error: (errors) => error(500, errors.map((error) => error.message).join('. ') + '.')
   },
   plugins: [logMetadata]
 });

--- a/packages/houdini/src/runtime/client/plugins/throwOnError.ts
+++ b/packages/houdini/src/runtime/client/plugins/throwOnError.ts
@@ -1,10 +1,13 @@
 import type { QueryResult, ArtifactKinds } from '../../lib'
 import { ArtifactKind } from '../../lib'
-import type { ClientPlugin } from '../documentStore'
+import type { ClientPlugin, ClientPluginContext } from '../documentStore'
 
 export type ThrowOnErrorParams = {
 	operations: ('all' | 'query' | 'mutation' | 'subscription')[]
-	error?: (errors: NonNullable<QueryResult<any, any>['errors']>) => unknown
+	error?: (
+		errors: NonNullable<QueryResult<any, any>['errors']>,
+		ctx: ClientPluginContext
+	) => unknown
 }
 
 export const throwOnError =
@@ -25,7 +28,7 @@ export const throwOnError =
 			async end(ctx, { value, resolve }) {
 				// if we are supposed to throw and there are errors
 				if (value.errors && value.errors.length > 0 && throwOnKind(ctx.artifact.kind)) {
-					const result = await (error ?? defaultErrorFn)(value.errors)
+					const result = await (error ?? defaultErrorFn)(value.errors, ctx)
 					throw result
 				}
 

--- a/site/src/routes/api/client/+page.svx
+++ b/site/src/routes/api/client/+page.svx
@@ -92,7 +92,8 @@ export default new HoudiniClient({
         // query, mutation, subscription, and all
         operations: ['all'],
         // the function to call
-        error: (errors) => error(500,
+        error: (errors, ctx) => error(500,
+            `(${ctx.artifact.name}): ` +
             errors.map((err) => err.message).join('. ') + '.'
         )
     }

--- a/site/src/routes/api/client/+page.svx
+++ b/site/src/routes/api/client/+page.svx
@@ -64,7 +64,7 @@ type FetchParamsInput = {
 
 type ThrowOnErrorParams = {
 	operations: ('all' | 'query' | 'mutation' | 'subscription')[]
-	error?: (errors: GraphqlError[]) => unknown
+	error?: (errors: GraphqlError[], ctx: ClientPluginContext) => unknown
 }
 
 type GraphqlError = {


### PR DESCRIPTION
As discussed in Discord ([link to conversation](https://discord.com/channels/1024421016405016718/1077532514928820225)), passing the `ctx` to throwOnError in the client would be useful when trying to figure out which query exactly it is that is giving the error.

~~I've gone ahead and implemented a demo of this in the e2e project, but it should still work if you don't need to use the ctx.~~ It was messing up the e2e tests, so I have reverted this.

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

