### PR TITLE
Fix initialization issue in paginated queries

### DIFF
--- a/.changeset/brown-icons-call.md
+++ b/.changeset/brown-icons-call.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix initialization issue in paginated queries

--- a/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
+++ b/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
@@ -74,17 +74,20 @@ export class QueryStoreCursor<_Data extends GraphQLObject, _Input extends {}> ex
 	fetch(params?: ClientFetchParams<_Data, _Input>): Promise<QueryResult<_Data, _Input>>
 	fetch(params?: QueryStoreFetchParams<_Data, _Input>): Promise<QueryResult<_Data, _Input>>
 	async fetch(args?: QueryStoreFetchParams<_Data, _Input>): Promise<QueryResult<_Data, _Input>> {
-		return (await this.#handlers()).fetch.call(this, args)
+		const handlers = await this.#handlers()
+		return await handlers.fetch.call(this, args)
 	}
 
 	async loadPreviousPage(
 		args?: Parameters<Required<CursorHandlers<_Data, _Input>>['loadPreviousPage']>[0]
 	) {
-		return (await this.#handlers()).loadPreviousPage(args)
+		const handlers = await this.#handlers()
+		return await handlers.loadPreviousPage(args)
 	}
 
 	async loadNextPage(args?: Parameters<CursorHandlers<_Data, _Input>['loadNextPage']>[0]) {
-		return (await this.#handlers()).loadNextPage(args)
+		const handlers = await this.#handlers()
+		return await handlers.loadNextPage(args)
 	}
 
 	subscribe(
@@ -111,7 +114,8 @@ export class QueryStoreOffset<_Data extends GraphQLObject, _Input extends {}> ex
 	paginated = true
 
 	async loadNextPage(args?: Parameters<OffsetHandlers<_Data, _Input>['loadNextPage']>[0]) {
-		return (await this.#handlers()).loadNextPage.call(this, args)
+		const handlers = await this.#handlers()
+		return await handlers.loadNextPage.call(this, args)
 	}
 
 	fetch(params?: RequestEventFetchParams<_Data, _Input>): Promise<QueryResult<_Data, _Input>>
@@ -119,7 +123,8 @@ export class QueryStoreOffset<_Data extends GraphQLObject, _Input extends {}> ex
 	fetch(params?: ClientFetchParams<_Data, _Input>): Promise<QueryResult<_Data, _Input>>
 	fetch(params?: QueryStoreFetchParams<_Data, _Input>): Promise<QueryResult<_Data, _Input>>
 	async fetch(args?: QueryStoreFetchParams<_Data, _Input>): Promise<QueryResult<_Data, _Input>> {
-		return (await this.#handlers()).fetch.call(this, args)
+		const handlers = await this.#handlers()
+		return await handlers.fetch.call(this, args)
 	}
 
 	#_handlers: OffsetHandlers<_Data, _Input> | null = null

--- a/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
+++ b/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
@@ -56,12 +56,10 @@ export class QueryStoreCursor<_Data extends GraphQLObject, _Input extends {}> ex
 
 				return paginationObserver.send({
 					...args,
-					variables: {
-						...args?.variables,
-					},
 					cacheParams: {
 						applyUpdates: updates,
 						disableSubscriptions: true,
+						...args?.cacheParams,
 					},
 				})
 			},

--- a/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
+++ b/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
@@ -136,7 +136,6 @@ export class QueryStoreOffset<_Data extends GraphQLObject, _Input extends {}> ex
 		await initClient()
 
 		// we're going to use a separate observer for the page loading
-		// we're going to use a separate observer for the page loading
 		const paginationObserver = getClient().observe<_Data, _Input>({
 			artifact: this.artifact,
 		})

--- a/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
+++ b/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
@@ -35,11 +35,12 @@ export class QueryStoreCursor<_Data extends GraphQLObject, _Input extends {}> ex
 
 	#_handlers: CursorHandlers<_Data, _Input> | null = null
 	async #handlers(): Promise<CursorHandlers<_Data, _Input>> {
-		await initClient()
-
 		if (this.#_handlers) {
 			return this.#_handlers
 		}
+
+		// initialize the client before we compute the handlers
+		await initClient()
 
 		// we're going to use a separate observer for the page loading
 		const paginationObserver = getClient().observe<_Data, _Input>({
@@ -110,22 +111,24 @@ export class QueryStoreOffset<_Data extends GraphQLObject, _Input extends {}> ex
 	paginated = true
 
 	async loadNextPage(args?: Parameters<OffsetHandlers<_Data, _Input>['loadNextPage']>[0]) {
-		return this.#handlers.loadNextPage.call(this, args)
+		return (await this.#handlers()).loadNextPage.call(this, args)
 	}
 
 	fetch(params?: RequestEventFetchParams<_Data, _Input>): Promise<QueryResult<_Data, _Input>>
 	fetch(params?: LoadEventFetchParams<_Data, _Input>): Promise<QueryResult<_Data, _Input>>
 	fetch(params?: ClientFetchParams<_Data, _Input>): Promise<QueryResult<_Data, _Input>>
 	fetch(params?: QueryStoreFetchParams<_Data, _Input>): Promise<QueryResult<_Data, _Input>>
-	fetch(args?: QueryStoreFetchParams<_Data, _Input>): Promise<QueryResult<_Data, _Input>> {
-		return this.#handlers.fetch.call(this, args)
+	async fetch(args?: QueryStoreFetchParams<_Data, _Input>): Promise<QueryResult<_Data, _Input>> {
+		return (await this.#handlers()).fetch.call(this, args)
 	}
 
 	#_handlers: OffsetHandlers<_Data, _Input> | null = null
-	get #handlers(): OffsetHandlers<_Data, _Input> {
+	async #handlers(): Promise<OffsetHandlers<_Data, _Input>> {
 		if (this.#_handlers) {
 			return this.#_handlers
 		}
+		// initialize the client before we compute the handlers
+		await initClient()
 
 		// we're going to use a separate observer for the page loading
 		// we're going to use a separate observer for the page loading

--- a/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
+++ b/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
@@ -39,11 +39,6 @@ export class QueryStoreCursor<_Data extends GraphQLObject, _Input extends {}> ex
 			return this.#_handlers
 		}
 
-		// we're going to use a separate observer for the page loading
-		const paginationObserver = getClient().observe<_Data, _Input>({
-			artifact: this.artifact,
-		})
-
 		this.#_handlers = cursorHandlers<_Data, _Input>({
 			artifact: this.artifact,
 			initialValue: get(this.observer).data,
@@ -53,6 +48,12 @@ export class QueryStoreCursor<_Data extends GraphQLObject, _Input extends {}> ex
 			fetch: super.fetch.bind(this),
 			fetchUpdate: async (args, updates) => {
 				await initClient()
+
+				// we're going to use a separate observer for the page loading
+				const paginationObserver = getClient().observe<_Data, _Input>({
+					artifact: this.artifact,
+				})
+
 				return paginationObserver.send({
 					...args,
 					variables: {
@@ -60,6 +61,7 @@ export class QueryStoreCursor<_Data extends GraphQLObject, _Input extends {}> ex
 					},
 					cacheParams: {
 						applyUpdates: updates,
+						disableSubscriptions: true,
 					},
 				})
 			},


### PR DESCRIPTION
This PR fixes a timing issue with paginated stores. Now, we make sure that `initClient` is called before we build the pagination handlers