### PR TITLE
Bug/include directive null

### DIFF
--- a/.changeset/proud-moons-rhyme.md
+++ b/.changeset/proud-moons-rhyme.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix bug with include and skip directives

--- a/e2e/_api/schema-hello.graphql
+++ b/e2e/_api/schema-hello.graphql
@@ -1,3 +1,3 @@
 extend type Query {
-	hello: String!
+	hello: String
 }

--- a/e2e/kit/src/lib/utils/routes.ts
+++ b/e2e/kit/src/lib/utils/routes.ts
@@ -42,6 +42,7 @@ export const routes = {
   Stores_Partial_Off_Child: '/stores/partial-off/child',
   Stores_Connection_Fragment: '/stores/connection-fragment',
   Stores_Pagination_query_forward_cursor: '/stores/pagination/query/forward-cursor',
+  Stores_Directives: '/stores/directives',
 
   Plugin_query_simple: '/plugin/query/simple',
   Plugin_query_variable_1: '/plugin/query/variable-1',

--- a/e2e/kit/src/routes/stores/directives/+page.gql
+++ b/e2e/kit/src/routes/stores/directives/+page.gql
@@ -1,0 +1,9 @@
+query Directives {
+  user(id: "1", snapshot: "directives") {
+    name
+  }
+  cities @include(if: false) {
+    name
+  }
+  hello @skip(if: true)
+}

--- a/e2e/kit/src/routes/stores/directives/+page.svelte
+++ b/e2e/kit/src/routes/stores/directives/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import type { PageData } from './$houdini';
+
+  export let data: PageData;
+  $: ({ Directives } = data);
+</script>
+
+<div id="result">{JSON.stringify($Directives.data)}</div>

--- a/e2e/kit/src/routes/stores/directives/spec.ts
+++ b/e2e/kit/src/routes/stores/directives/spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test';
+import { routes } from '../../../lib/utils/routes.js';
+import { expect_to_be, goto } from '../../../lib/utils/testsHelper.js';
+
+test.describe('directives', () => {
+  test('Directives get correctly applied', async ({ page }) => {
+    await goto(page, routes.Stores_Directives);
+
+    await expect_to_be(page, '{"user":{"name":"Bruce Willis","id":"directives:1"}}');
+  });
+});

--- a/packages/houdini/src/codegen/generators/artifacts/selection.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/selection.ts
@@ -173,6 +173,7 @@ function prepareSelection({
 				fieldType = getRootType(typeRef)
 				nullable = !graphql.isNonNullType(typeRef)
 			}
+
 			const typeName = fieldType.toString()
 
 			// make sure we include the attribute in the path
@@ -184,6 +185,22 @@ function prepareSelection({
 			let fieldObj: Required<SubscriptionSelection>['fields']['field'] = {
 				type: typeName,
 				keyRaw: fieldKey(config, field),
+			}
+
+			// add directive meta data
+			if (field.directives && field.directives.length > 0) {
+				fieldObj.directives = field.directives?.map((directive) => ({
+					name: directive.name.value,
+					arguments: (directive.arguments ?? []).reduce(
+						(acc, arg) => ({
+							...acc,
+							[arg.name.value]: config.serializeValueMap({ field: arg.value })![
+								'field'
+							],
+						}),
+						{}
+					),
+				}))
 			}
 
 			if (keys.includes(field.name.value)) {

--- a/packages/houdini/src/codegen/generators/artifacts/tests/artifacts.test.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/tests/artifacts.test.ts
@@ -669,6 +669,22 @@ test('paginate over unions', async function () {
 		                "type": "EntityConnection",
 		                "keyRaw": "entitiesByCursor::paginated",
 
+		                "directives": [{
+		                    "name": "paginate",
+
+		                    "arguments": {
+		                        "name": {
+		                            "kind": "StringValue",
+		                            "value": "All_Users"
+		                        },
+
+		                        "connection": {
+		                            "kind": "BooleanValue",
+		                            "value": true
+		                        }
+		                    }
+		                }],
+
 		                "list": {
 		                    "name": "All_Users",
 		                    "connection": true,
@@ -2517,6 +2533,11 @@ describe('mutation artifacts', function () {
 			                            "type": "ID",
 			                            "keyRaw": "userID",
 
+			                            "directives": [{
+			                                "name": "User_delete",
+			                                "arguments": {}
+			                            }],
+
 			                            "operations": [{
 			                                "action": "delete",
 			                                "type": "User"
@@ -2589,6 +2610,20 @@ describe('mutation artifacts', function () {
 			                        "userID": {
 			                            "type": "ID",
 			                            "keyRaw": "userID",
+
+			                            "directives": [{
+			                                "name": "User_delete",
+			                                "arguments": {}
+			                            }, {
+			                                "name": "when",
+
+			                                "arguments": {
+			                                    "stringValue": {
+			                                        "kind": "StringValue",
+			                                        "value": "foo"
+			                                    }
+			                                }
+			                            }],
 
 			                            "operations": [{
 			                                "action": "delete",
@@ -3540,6 +3575,17 @@ describe('mutation artifacts', function () {
 			                "type": "User",
 			                "keyRaw": "users(boolValue: true, floatValue: 1.2, intValue: 1, stringValue: $value)",
 
+			                "directives": [{
+			                    "name": "list",
+
+			                    "arguments": {
+			                        "name": {
+			                            "kind": "StringValue",
+			                            "value": "All_Users"
+			                        }
+			                    }
+			                }],
+
 			                "list": {
 			                    "name": "All_Users",
 			                    "connection": false,
@@ -3764,6 +3810,17 @@ describe('mutation artifacts', function () {
 			                "type": "User",
 			                "keyRaw": "users(stringValue: \\"foo\\")",
 
+			                "directives": [{
+			                    "name": "list",
+
+			                    "arguments": {
+			                        "name": {
+			                            "kind": "StringValue",
+			                            "value": "All_Users"
+			                        }
+			                    }
+			                }],
+
 			                "list": {
 			                    "name": "All_Users",
 			                    "connection": false,
@@ -3885,6 +3942,22 @@ describe('mutation artifacts', function () {
 			            "usersByCursor": {
 			                "type": "UserConnection",
 			                "keyRaw": "usersByCursor::paginated",
+
+			                "directives": [{
+			                    "name": "paginate",
+
+			                    "arguments": {
+			                        "name": {
+			                            "kind": "StringValue",
+			                            "value": "All_Users"
+			                        },
+
+			                        "connection": {
+			                            "kind": "BooleanValue",
+			                            "value": true
+			                        }
+			                    }
+			                }],
 
 			                "list": {
 			                    "name": "All_Users",
@@ -4110,6 +4183,27 @@ describe('mutation artifacts', function () {
 			                "type": "UserConnection",
 			                "keyRaw": "usersByCursor(after: $after, before: $before, first: $first, last: $last)::paginated",
 
+			                "directives": [{
+			                    "name": "paginate",
+
+			                    "arguments": {
+			                        "name": {
+			                            "kind": "StringValue",
+			                            "value": "All_Users"
+			                        },
+
+			                        "mode": {
+			                            "kind": "EnumValue",
+			                            "value": "SinglePage"
+			                        },
+
+			                        "connection": {
+			                            "kind": "BooleanValue",
+			                            "value": true
+			                        }
+			                    }
+			                }],
+
 			                "list": {
 			                    "name": "All_Users",
 			                    "connection": true,
@@ -4299,6 +4393,17 @@ describe('mutation artifacts', function () {
 			                "type": "User",
 			                "keyRaw": "users(boolValue: true, floatValue: 1.2, intValue: 1, stringValue: $value)",
 
+			                "directives": [{
+			                    "name": "list",
+
+			                    "arguments": {
+			                        "name": {
+			                            "kind": "StringValue",
+			                            "value": "All_Users"
+			                        }
+			                    }
+			                }],
+
 			                "list": {
 			                    "name": "All_Users",
 			                    "connection": false,
@@ -4411,6 +4516,17 @@ describe('mutation artifacts', function () {
 			            "users": {
 			                "type": "User",
 			                "keyRaw": "users(boolValue: true, floatValue: 1.2, intValue: 1, stringValue: $value)",
+
+			                "directives": [{
+			                    "name": "list",
+
+			                    "arguments": {
+			                        "name": {
+			                            "kind": "StringValue",
+			                            "value": "All_Users"
+			                        }
+			                    }
+			                }],
 
 			                "list": {
 			                    "name": "All_Users",
@@ -5061,7 +5177,18 @@ test('leave @include and @skip alone', async function () {
 		                        "id": {
 		                            "type": "ID",
 		                            "keyRaw": "id",
-		                            "visible": true
+		                            "visible": true,
+
+		                            "directives": [{
+		                                "name": "skip",
+
+		                                "arguments": {
+		                                    "if": {
+		                                        "kind": "BooleanValue",
+		                                        "value": true
+		                                    }
+		                                }
+		                            }]
 		                        },
 
 		                        "__typename": {
@@ -5077,7 +5204,18 @@ test('leave @include and @skip alone', async function () {
 		                                "id": {
 		                                    "type": "ID",
 		                                    "keyRaw": "id",
-		                                    "visible": true
+		                                    "visible": true,
+
+		                                    "directives": [{
+		                                        "name": "skip",
+
+		                                        "arguments": {
+		                                            "if": {
+		                                                "kind": "BooleanValue",
+		                                                "value": true
+		                                            }
+		                                        }
+		                                    }]
 		                                },
 
 		                                "__typename": {

--- a/packages/houdini/src/codegen/generators/artifacts/tests/pagination.test.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/tests/pagination.test.ts
@@ -82,6 +82,11 @@ test('pagination arguments stripped from key', async function () {
 		                "type": "UserConnection",
 		                "keyRaw": "friendsByCursor(filter: \\"hello\\")::paginated",
 
+		                "directives": [{
+		                    "name": "paginate",
+		                    "arguments": {}
+		                }],
+
 		                "selection": {
 		                    "fields": {
 		                        "edges": {
@@ -278,6 +283,17 @@ test('pagination arguments stays in key as it s a SinglePage Mode', async functi
 		                "type": "UserConnection",
 		                "keyRaw": "friendsByCursor(after: $after, before: $before, filter: \\"hello\\", first: $first, last: $last)::paginated",
 
+		                "directives": [{
+		                    "name": "paginate",
+
+		                    "arguments": {
+		                        "mode": {
+		                            "kind": "EnumValue",
+		                            "value": "SinglePage"
+		                        }
+		                    }
+		                }],
+
 		                "selection": {
 		                    "fields": {
 		                        "edges": {
@@ -447,6 +463,12 @@ test('offset based pagination marks appropriate field', async function () {
 		            "friendsByOffset": {
 		                "type": "User",
 		                "keyRaw": "friendsByOffset(filter: \\"hello\\")::paginated",
+
+		                "directives": [{
+		                    "name": "paginate",
+		                    "arguments": {}
+		                }],
+
 		                "updates": ["append"],
 
 		                "selection": {
@@ -589,6 +611,11 @@ test('cursor as scalar gets the right pagination query argument types', async fu
 		                        "friendsByCursorScalar": {
 		                            "type": "UserConnection",
 		                            "keyRaw": "friendsByCursorScalar(filter: \\"hello\\")::paginated",
+
+		                            "directives": [{
+		                                "name": "paginate",
+		                                "arguments": {}
+		                            }],
 
 		                            "selection": {
 		                                "fields": {
@@ -867,6 +894,11 @@ test("sibling aliases don't get marked", async function () {
 		            "friendsByCursor": {
 		                "type": "UserConnection",
 		                "keyRaw": "friendsByCursor(filter: \\"hello\\")::paginated",
+
+		                "directives": [{
+		                    "name": "paginate",
+		                    "arguments": {}
+		                }],
 
 		                "selection": {
 		                    "fields": {

--- a/packages/houdini/src/codegen/generators/artifacts/tests/selection.test.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/tests/selection.test.ts
@@ -120,7 +120,7 @@ test('fragments in lists', async function () {
 		export default {
 		    "name": "TestQuery",
 		    "kind": "HoudiniQuery",
-		    "hash": "6409e8b842cbd3f943db27ab1d214eec514c1c9689d5e0dc32d37e2574edec81",
+		    "hash": "6c2ec570ec75b009aae97355f5b36acae92039a0bf1750fc62fe144f0898f403",
 
 		    "raw": \`query TestQuery {
 		  usersByCursor {
@@ -159,6 +159,22 @@ test('fragments in lists', async function () {
 		            "usersByCursor": {
 		                "type": "UserConnection",
 		                "keyRaw": "usersByCursor",
+
+		                "directives": [{
+		                    "name": "list",
+
+		                    "arguments": {
+		                        "name": {
+		                            "kind": "StringValue",
+		                            "value": "All_Users"
+		                        },
+
+		                        "connection": {
+		                            "kind": "BooleanValue",
+		                            "value": true
+		                        }
+		                    }
+		                }],
 
 		                "list": {
 		                    "name": "All_Users",
@@ -265,7 +281,7 @@ test('fragments in lists', async function () {
 		    "partial": false
 		};
 
-		"HoudiniHash=6409e8b842cbd3f943db27ab1d214eec514c1c9689d5e0dc32d37e2574edec81";
+		"HoudiniHash=6c2ec570ec75b009aae97355f5b36acae92039a0bf1750fc62fe144f0898f403";
 	`)
 })
 

--- a/packages/houdini/src/codegen/generators/artifacts/tests/selection.test.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/tests/selection.test.ts
@@ -97,16 +97,16 @@ test('fragments in lists', async function () {
 		mockCollectedDoc(
 			`query TestQuery {
 				usersByCursor @list(name: "All_Users") {
-					edges { 
-						node { 
+					edges {
+						node {
 							...UserTest
 						}
-					}	
+					}
 				}
 			}`
 		),
 		mockCollectedDoc(
-			`fragment UserTest on User { 
+			`fragment UserTest on User {
 				firstName
 			}`
 		),

--- a/packages/houdini/src/codegen/transforms/paginate.test.ts
+++ b/packages/houdini/src/codegen/transforms/paginate.test.ts
@@ -513,6 +513,11 @@ test('embeds node pagination query as a separate document', async function () {
 		                                    "type": "UserConnection",
 		                                    "keyRaw": "friendsByForwardsCursor::paginated",
 
+		                                    "directives": [{
+		                                        "name": "paginate",
+		                                        "arguments": {}
+		                                    }],
+
 		                                    "selection": {
 		                                        "fields": {
 		                                            "edges": {
@@ -782,6 +787,11 @@ test('embeds custom pagination query as a separate document', async function () 
 		                        "friendsConnection": {
 		                            "type": "GhostConnection",
 		                            "keyRaw": "friendsConnection::paginated",
+
+		                            "directives": [{
+		                                "name": "paginate",
+		                                "arguments": {}
+		                            }],
 
 		                            "selection": {
 		                                "fields": {
@@ -1565,6 +1575,11 @@ test('generated query has same refetch spec', async function () {
 		                "type": "UserConnection",
 		                "keyRaw": "usersByCursor::paginated",
 
+		                "directives": [{
+		                    "name": "paginate",
+		                    "arguments": {}
+		                }],
+
 		                "selection": {
 		                    "fields": {
 		                        "edges": {
@@ -1858,6 +1873,11 @@ test('default defaultPaginateMode to SinglePage', async function () {
 		            "usersByCursor": {
 		                "type": "UserConnection",
 		                "keyRaw": "usersByCursor(after: $after, before: $before, first: $first, last: $last)::paginated",
+
+		                "directives": [{
+		                    "name": "paginate",
+		                    "arguments": {}
+		                }],
 
 		                "selection": {
 		                    "fields": {

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -672,7 +672,7 @@ export class Config {
 		fragment: string
 	}) {
 		this.#fragmentVariableMaps[hash] = {
-			args: this.#serializeValueMap(args),
+			args: this.serializeValueMap(args),
 			fragment,
 		}
 	}
@@ -686,7 +686,7 @@ export class Config {
 		)
 	}
 
-	#serializeValueMap(map: ValueMap | null): ValueMap | null {
+	serializeValueMap(map: ValueMap | null): ValueMap | null {
 		if (!map) {
 			return null
 		}
@@ -705,7 +705,7 @@ export class Config {
 					if ('values' in input) {
 						// @ts-ignore
 						result.values = input.values.map(
-							(value) => this.#serializeValueMap({ foo: value })!.foo!
+							(value) => this.serializeValueMap({ foo: value })!.foo!
 						)
 					}
 					if ('name' in input) {
@@ -717,7 +717,7 @@ export class Config {
 						// @ts-ignore
 						result.fields = input.fields.map((field) => ({
 							name: field.name,
-							value: this.#serializeValueMap({ foo: field.value })!.foo!,
+							value: this.serializeValueMap({ foo: field.value })!.foo!,
 						}))
 					}
 				}

--- a/packages/houdini/src/runtime/cache/cache.ts
+++ b/packages/houdini/src/runtime/cache/cache.ts
@@ -835,7 +835,7 @@ class CacheInternal {
 				continue
 			}
 
-			// some directives like @if and @include prevent the value from being in the
+			// some directives like @skip and @include prevent the value from being in the
 			// selection
 			const includeDirective = directives?.find((d) => {
 				return d.name === 'include'

--- a/packages/houdini/src/runtime/cache/tests/readwrite.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/readwrite.test.ts
@@ -1990,3 +1990,259 @@ test('recreates fragment references with variables', function () {
 		},
 	})
 })
+
+test('include directive - positive', function () {
+	// instantiate the cache
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				nullable: true,
+				selection: {
+					fields: {
+						id: {
+							keyRaw: 'id',
+							type: 'String',
+							visible: true,
+						},
+						firstName: {
+							keyRaw: 'firstName',
+							type: 'String',
+							visible: true,
+							directives: [
+								{
+									name: 'include',
+									arguments: {
+										if: {
+											kind: 'BooleanValue',
+											value: false,
+										},
+									},
+								},
+							],
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// write the user data without the nested value
+	cache.write({
+		selection,
+		data: {
+			viewer: {
+				id: '1',
+			},
+		},
+	})
+
+	expect(
+		cache.read({
+			selection,
+		})
+	).toEqual({
+		partial: false,
+		stale: false,
+		data: {
+			viewer: {
+				id: '1',
+			},
+		},
+	})
+})
+
+test('include directive - negative', function () {
+	// instantiate the cache
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				nullable: true,
+				selection: {
+					fields: {
+						id: {
+							keyRaw: 'id',
+							type: 'String',
+							visible: true,
+						},
+						firstName: {
+							keyRaw: 'firstName',
+							type: 'String',
+							visible: true,
+							directives: [
+								{
+									name: 'include',
+									arguments: {
+										if: {
+											kind: 'BooleanValue',
+											value: true,
+										},
+									},
+								},
+							],
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// write the user data without the nested value
+	cache.write({
+		selection,
+		data: {
+			viewer: {
+				id: '1',
+			},
+		},
+	})
+
+	expect(
+		cache.read({
+			selection,
+		})
+	).toEqual({
+		partial: true,
+		stale: false,
+		data: {
+			viewer: null,
+		},
+	})
+})
+
+test('skip directive - positive', function () {
+	// instantiate the cache
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				nullable: true,
+				selection: {
+					fields: {
+						id: {
+							keyRaw: 'id',
+							type: 'String',
+							visible: true,
+						},
+						firstName: {
+							keyRaw: 'firstName',
+							type: 'String',
+							visible: true,
+							directives: [
+								{
+									name: 'skip',
+									arguments: {
+										if: {
+											kind: 'BooleanValue',
+											value: true,
+										},
+									},
+								},
+							],
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// write the user data without the nested value
+	cache.write({
+		selection,
+		data: {
+			viewer: {
+				id: '1',
+			},
+		},
+	})
+
+	expect(
+		cache.read({
+			selection,
+		})
+	).toEqual({
+		partial: false,
+		stale: false,
+		data: {
+			viewer: {
+				id: '1',
+			},
+		},
+	})
+})
+
+test('skip directive - negative', function () {
+	// instantiate the cache
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				nullable: true,
+				selection: {
+					fields: {
+						id: {
+							keyRaw: 'id',
+							type: 'String',
+							visible: true,
+						},
+						firstName: {
+							keyRaw: 'firstName',
+							type: 'String',
+							visible: true,
+							directives: [
+								{
+									name: 'skip',
+									arguments: {
+										if: {
+											kind: 'BooleanValue',
+											value: false,
+										},
+									},
+								},
+							],
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// write the user data without the nested value
+	cache.write({
+		selection,
+		data: {
+			viewer: {
+				id: '1',
+			},
+		},
+	})
+
+	expect(
+		cache.read({
+			selection,
+		})
+	).toEqual({
+		partial: true,
+		stale: false,
+		data: {
+			viewer: null,
+		},
+	})
+})

--- a/packages/houdini/src/runtime/lib/types.ts
+++ b/packages/houdini/src/runtime/lib/types.ts
@@ -177,6 +177,7 @@ export type SubscriptionSelection = {
 				connection: boolean
 				type: string
 			}
+			directives?: { name: string; arguments: ValueMap }[]
 			updates?: string[]
 			visible?: boolean
 			filters?: Record<


### PR DESCRIPTION
Fixes #1018 

This PR fixes a bug in the cache behavior that was ignoring `include` and `skip` directives causing a `null` value to incorrectly cascade.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

