### PR TITLE
Handle `null` in `watchSchema.interval` properly

### DIFF
--- a/.changeset/tender-ducks-cough.md
+++ b/.changeset/tender-ducks-cough.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix passing `null` over `watchSchema.interval` in the configuration does not work as expected

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -129,7 +129,7 @@ export class Config {
 		this.logLevel = ((logLevel as LogLevels) || LogLevel.Summary).toLowerCase() as LogLevels
 		this.defaultFragmentMasking = defaultFragmentMasking
 		this.routesDir = path.join(this.projectRoot, 'src', 'routes')
-		this.schemaPollInterval = watchSchema?.interval ?? 2000
+		this.schemaPollInterval = watchSchema?.interval === undefined ? 2000 : watchSchema.interval
 		this.schemaPollHeaders = watchSchema?.headers ?? {}
 		this.rootDir = path.join(this.projectRoot, '$houdini')
 		this.#fragmentVariableMaps = {}


### PR DESCRIPTION
Since JS [nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) treats `null` as `nullish` value, passing over `null` in `watchSchema.interval` forcefully makes the value to `2000`, not `null`.

Houdini handles `2000`, `0`, and `null` differently in its `watchSchema.interval` config, but this bug prevents users from using `null` as its value to dictate the behavior to never pull the schema on any circumstances.

This patch fixes that behavior.

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

