### PR TITLE
Allow fragment arguments to get marshaled properly

### DIFF
--- a/.changeset/strange-adults-rush.md
+++ b/.changeset/strange-adults-rush.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Make sure fragment arguments get marshaled properly

--- a/packages/houdini/src/runtime/client/documentStore.ts
+++ b/packages/houdini/src/runtime/client/documentStore.ts
@@ -446,7 +446,7 @@ class ClientPluginContextWrapper {
 		// - or if there are no values to begin with
 		const firstInit = !ctx.stuff.inputs || !ctx.stuff.inputs.init
 		const hasChanged = Object.keys(changed).length > 0 || firstInit
-		if (artifact.kind !== ArtifactKind.Fragment && hasChanged) {
+		if (hasChanged) {
 			// only marshal the changed variables so we don't double marshal
 			const newVariables = {
 				...ctx.stuff.inputs?.marshaled,


### PR DESCRIPTION
This PR fixes a bug I was having, where list operations on a list inside of a fragment with arguments caused the fragment's store data to be set to null.

Apparently the fragment's arguments never got marshaled, so in the fragment store the variables was an empty object, and thus the lists in the fragment never got added to the cache's `lists` collection.

@AlecAivazis I was not entirely sure how to write a proper test case for this, some help with writing one would be appreciated :)

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

