### PR TITLE
Add support for Yarn's PnP mode

### DIFF
--- a/.changeset/gorgeous-turtles-joke.md
+++ b/.changeset/gorgeous-turtles-joke.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Add support for Yarn's PnP mode

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -1084,7 +1084,7 @@ async function pluginPath(plugin_name: string, config_path: string): Promise<str
 
 			// this directly returns the ESM export of the corresponding module, thanks to the PnP API
 			// it will throw if the module isn't found in the project's dependencies
-			return pnp.resolveRequest(plugin_name, config_path, { conditions: ['import'] })
+			return pnp.resolveRequest(plugin_name, config_path, { conditions: new Set(['import']) })
 		}
 
 		// otherwise we have to hunt the module down relative to the current path

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -343,10 +343,28 @@ export class Config {
 	get runtimeSource() {
 		// when running in the real world, scripts are nested in a sub directory of build, in tests they aren't nested
 		// under /src so we need to figure out how far up to go to find the appropriately compiled runtime
-		const relative = houdini_mode.is_testing
-			? path.join(currentDir, '..', '..')
-			: // start here and go to parent until we find the node_modules/houdini folder
-			  findModule('houdini', path.join(path.dirname(this.filepath)))
+		let relative: string;
+		if (houdini_mode.is_testing) {
+			relative = path.join(currentDir, '..', '..')
+		} else if (process.versions.pnp) {
+			// we are in a PnP environment
+			// retrieve the PnP API (Yarn injects the `findPnpApi` into `node:module` builtin module in runtime)
+			const { findPnpApi } = require('node:module');
+
+			// this will traverse the file system to find the closest `.pnp.cjs` file and return the PnP API based on it
+			const pnp = findPnpApi(this.filepath);
+
+			// this will return the houdini package location (it will be inside the .zip file)
+			// it will throw if the module isn't found in the project's dependencies, but it should be there
+			// this will be something like `.yarn/cache/houdini-npm-bcb9b12a88-c0f1080ca8.zip/node_modules/houdini/`
+			// it is inside the .zip archive, but since Yarn dynamically patches `fs` module to add support for reading
+			// files from the .zip archives, we can just use the path as-is
+			// https://yarnpkg.com/features/pnp#packages-are-stored-inside-zip-archives-how-can-i-access-their-files
+			relative = pnp.resolveToUnqualified('houdini', this.filepath);
+		} else {
+			// start here and go to parent until we find the node_modules/houdini folder
+			relative = findModule('houdini', path.join(path.dirname(this.filepath)))
+		}
 
 		const which = this.module === 'esm' ? 'esm' : 'cjs'
 
@@ -1055,6 +1073,20 @@ export const orderedPlugins = (plugins: PluginMeta[]) => {
 
 async function pluginPath(plugin_name: string, config_path: string): Promise<string> {
 	try {
+		// check if we are in a PnP environment
+		if (process.versions.pnp) {
+			// retrieve the PnP API (Yarn injects the `findPnpApi` into `node:module` builtin module in runtime)
+			const { findPnpApi } = require('node:module');
+
+			// this will traverse the file system to find the closest `.pnp.cjs` file and return the PnP API based on it
+			// normally it will reside at the same level with `houdini.config.js` file, so it is unlikely that traversing the whole file system will happen
+			const pnp = findPnpApi(config_path);
+
+			// this directly returns the ESM export of the corresponding module, thanks to the PnP API
+			// it will throw if the module isn't found in the project's dependencies
+			return pnp.resolveRequest(plugin_name, config_path, { conditions: ['import'] });
+		}
+
 		// otherwise we have to hunt the module down relative to the current path
 		const pluginDirectory = findModule(plugin_name, config_path)
 

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -343,16 +343,16 @@ export class Config {
 	get runtimeSource() {
 		// when running in the real world, scripts are nested in a sub directory of build, in tests they aren't nested
 		// under /src so we need to figure out how far up to go to find the appropriately compiled runtime
-		let relative: string;
+		let relative: string
 		if (houdini_mode.is_testing) {
 			relative = path.join(currentDir, '..', '..')
 		} else if (process.versions.pnp) {
 			// we are in a PnP environment
 			// retrieve the PnP API (Yarn injects the `findPnpApi` into `node:module` builtin module in runtime)
-			const { findPnpApi } = require('node:module');
+			const { findPnpApi } = require('node:module')
 
 			// this will traverse the file system to find the closest `.pnp.cjs` file and return the PnP API based on it
-			const pnp = findPnpApi(this.filepath);
+			const pnp = findPnpApi(this.filepath)
 
 			// this will return the houdini package location (it will be inside the .zip file)
 			// it will throw if the module isn't found in the project's dependencies, but it should be there
@@ -360,7 +360,7 @@ export class Config {
 			// it is inside the .zip archive, but since Yarn dynamically patches `fs` module to add support for reading
 			// files from the .zip archives, we can just use the path as-is
 			// https://yarnpkg.com/features/pnp#packages-are-stored-inside-zip-archives-how-can-i-access-their-files
-			relative = pnp.resolveToUnqualified('houdini', this.filepath);
+			relative = pnp.resolveToUnqualified('houdini', this.filepath)
 		} else {
 			// start here and go to parent until we find the node_modules/houdini folder
 			relative = findModule('houdini', path.join(path.dirname(this.filepath)))
@@ -1076,15 +1076,15 @@ async function pluginPath(plugin_name: string, config_path: string): Promise<str
 		// check if we are in a PnP environment
 		if (process.versions.pnp) {
 			// retrieve the PnP API (Yarn injects the `findPnpApi` into `node:module` builtin module in runtime)
-			const { findPnpApi } = require('node:module');
+			const { findPnpApi } = require('node:module')
 
 			// this will traverse the file system to find the closest `.pnp.cjs` file and return the PnP API based on it
 			// normally it will reside at the same level with `houdini.config.js` file, so it is unlikely that traversing the whole file system will happen
-			const pnp = findPnpApi(config_path);
+			const pnp = findPnpApi(config_path)
 
 			// this directly returns the ESM export of the corresponding module, thanks to the PnP API
 			// it will throw if the module isn't found in the project's dependencies
-			return pnp.resolveRequest(plugin_name, config_path, { conditions: ['import'] });
+			return pnp.resolveRequest(plugin_name, config_path, { conditions: ['import'] })
 		}
 
 		// otherwise we have to hunt the module down relative to the current path


### PR DESCRIPTION
Fixes #1035.

Making test cases with PnP environment mocking is not viable, really.
But I can confirm that _it works on my machine_ ¯\\_(ツ)_/¯

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

