### PR TITLE
Include explicit `types` export conditions in package.json `exports`

### DIFF
--- a/.changeset/rude-socks-doubt.md
+++ b/.changeset/rude-socks-doubt.md
@@ -2,7 +2,6 @@
 'houdini-plugin-svelte-global-stores': patch
 'houdini-svelte': patch
 'houdini-react': patch
-'scripts': patch
 'houdini': patch
 ---
 

--- a/.changeset/rude-socks-doubt.md
+++ b/.changeset/rude-socks-doubt.md
@@ -1,0 +1,9 @@
+---
+'houdini-plugin-svelte-global-stores': patch
+'houdini-svelte': patch
+'houdini-react': patch
+'scripts': patch
+'houdini': patch
+---
+
+Include explicit types export conditions in package.json exports

--- a/packages/_scripts/build.js
+++ b/packages/_scripts/build.js
@@ -1,9 +1,9 @@
 import esbuild from 'esbuild'
 import { replace } from 'esbuild-plugin-replace'
-import fs from 'fs/promises'
 import glob from 'glob'
-import path from 'path'
-import { promisify } from 'util'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { promisify } from 'node:util'
 
 // the relevant directories
 const build_dir = path.join(process.cwd(), 'build')
@@ -38,6 +38,7 @@ export default async function ({ plugin }) {
 			// when there's a plugin directory, that is the main entry point
 			package_json.main = './build/plugin-cjs/index.js'
 			package_json.exports['.'] = {
+				types: './build/plugin/index.d.ts',
 				import: './build/plugin-esm/index.js',
 				require: './build/plugin-cjs/index.js',
 			}
@@ -49,6 +50,7 @@ export default async function ({ plugin }) {
 			// when there's a plugin directory, that is the main entry point
 			package_json.main = `./build/${dirname}-cjs/index.js`
 			package_json.exports[`.`] = {
+				types: `./build/${dirname}/index.d.ts`,
 				import: `./build/${dirname}-esm/index.js`,
 				require: `./build/${dirname}-cjs/index.js`,
 			}
@@ -68,6 +70,7 @@ export default async function ({ plugin }) {
 		else {
 			await build({ package_json, source: dir, plugin })
 			package_json.exports['./' + dirname] = {
+				types: `./build/${dirname}/index.d.ts`,
 				import: `./build/${dirname}-esm/index.js`,
 				require: `./build/${dirname}-cjs/index.js`,
 			}

--- a/packages/houdini-plugin-svelte-global-stores/package.json
+++ b/packages/houdini-plugin-svelte-global-stores/package.json
@@ -39,10 +39,12 @@
     "exports": {
         "./package.json": "./package.json",
         ".": {
+            "types": "./build/plugin/index.d.ts",
             "import": "./build/plugin-esm/index.js",
             "require": "./build/plugin-cjs/index.js"
         },
         "./test": {
+            "types": "./build/test/index.d.ts",
             "import": "./build/test-esm/index.js",
             "require": "./build/test-cjs/index.js"
         }

--- a/packages/houdini-react/package.json
+++ b/packages/houdini-react/package.json
@@ -44,10 +44,12 @@
     "exports": {
         "./package.json": "./package.json",
         "./next": {
+            "types": "./build/next/index.d.ts",
             "import": "./build/next-esm/index.js",
             "require": "./build/next-cjs/index.js"
         },
         ".": {
+            "types": "./build/plugin/index.d.ts",
             "import": "./build/plugin-esm/index.js",
             "require": "./build/plugin-cjs/index.js"
         }

--- a/packages/houdini-svelte/package.json
+++ b/packages/houdini-svelte/package.json
@@ -45,14 +45,17 @@
     "exports": {
         "./package.json": "./package.json",
         ".": {
+            "types": "./build/plugin/index.d.ts",
             "import": "./build/plugin-esm/index.js",
             "require": "./build/plugin-cjs/index.js"
         },
         "./preprocess": {
+            "types": "./build/preprocess/index.d.ts",
             "import": "./build/preprocess-esm/index.js",
             "require": "./build/preprocess-cjs/index.js"
         },
         "./test": {
+            "types": "./build/test/index.d.ts",
             "import": "./build/test-esm/index.js",
             "require": "./build/test-cjs/index.js"
         }

--- a/packages/houdini/package.json
+++ b/packages/houdini/package.json
@@ -62,18 +62,22 @@
     "exports": {
         "./package.json": "./package.json",
         "./codegen": {
+            "types": "./build/codegen/index.d.ts",
             "import": "./build/codegen-esm/index.js",
             "require": "./build/codegen-cjs/index.js"
         },
         ".": {
+            "types": "./build/lib/index.d.ts",
             "import": "./build/lib-esm/index.js",
             "require": "./build/lib-cjs/index.js"
         },
         "./test": {
+            "types": "./build/test/index.d.ts",
             "import": "./build/test-esm/index.js",
             "require": "./build/test-cjs/index.js"
         },
         "./vite": {
+            "types": "./build/vite/index.d.ts",
             "import": "./build/vite-esm/index.js",
             "require": "./build/vite-cjs/index.js"
         }


### PR DESCRIPTION
Fixes #1046

Include explicit `types` export conditions in
package.json `exports`.  The d.ts files are located elsewhere so can't relay on default value which is the same as the import, except with a `d.ts` extension.

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [ ] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [ ] Includes a changeset if your fix affects the user with `pnpm changeset`

