### PR TITLE
Send `operationName` along with the `query` and `variables` by default

### DIFF
--- a/.changeset/twenty-months-cover.md
+++ b/.changeset/twenty-months-cover.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Send `operationName` along with the `query` and `variables` by default.

--- a/packages/houdini/src/runtime/client/plugins/fetch.ts
+++ b/packages/houdini/src/runtime/client/plugins/fetch.ts
@@ -16,6 +16,7 @@ export const fetch = (target?: RequestHandler | string): ClientPlugin => {
 
 				// build up the params object
 				const fetchParams: FetchParams = {
+					name: ctx.artifact.name,
 					text: ctx.text,
 					hash: ctx.hash,
 					variables: marshalVariables(ctx),
@@ -73,11 +74,11 @@ const defaultFetch = (
 		)
 	}
 
-	return async ({ fetch, text, variables }) => {
+	return async ({ fetch, name, text, variables }) => {
 		// regular fetch (Server & Client)
 		const result = await fetch(url, {
 			method: 'POST',
-			body: JSON.stringify({ query: text, variables }),
+			body: JSON.stringify({ operationName: name, query: text, variables }),
 			...params,
 			headers: {
 				Accept: 'application/graphql+json, application/json',
@@ -115,6 +116,7 @@ export type RequestHandler<_Data = any> = (
 ) => Promise<RequestPayload<_Data>>
 
 export type FetchParams = {
+	name: string
 	text: string
 	hash: string
 	variables: { [key: string]: any }

--- a/packages/houdini/src/runtime/client/plugins/subscription.ts
+++ b/packages/houdini/src/runtime/client/plugins/subscription.ts
@@ -57,6 +57,7 @@ export function subscription(factory: SubscriptionHandler) {
 				// start listening for the new subscription
 				clearSubscription = client.subscribe(
 					{
+						operationName: ctx.artifact.name,
 						query: ctx.artifact.raw,
 						variables: marshalVariables(ctx),
 					},
@@ -101,7 +102,7 @@ export type SubscriptionHandler = (ctx: ClientPluginContext) => SubscriptionClie
 
 export type SubscriptionClient = {
 	subscribe: (
-		payload: { query: string; variables?: {} },
+		payload: { operationName: string; query: string; variables?: {} },
 		handlers: {
 			next: (payload: { data?: {} | null; errors?: readonly { message: string }[] }) => void
 			error: (data: {}) => void


### PR DESCRIPTION
Rationale: #832

This PR changes the default behavior of `fetch` built-in plugin to include `operationName` in the fetch payload along with the `query` and `variables`.

This PR also changes the signature of `subscription` built-in plugin to pass `operationName` to user-provided subscription function so the user can easily interacts with it in their implementation.
Several popular implementations such as `graphql-ws` and `graphql-sse` do already utilize `operationName` argument if it is passed into their `subscribe` function. So in the most cases if we pass `operationName` to `subscribe` function it would be automatically included in the corresponding payload, which is also good for interoperability.

This also makes Houdini aligned with other popular graphql client implementations such as Apollo, Relay, Urql. All of them are sending `operationName` to the server by default, and it can not be disabled by user as it is a de facto standard to include it and have no benefit to disable it except for saving few network bytes. (although it is a not a hard requirement [according to the spec](https://graphql.org/learn/serving-over-http/#post-request), if the `query` contains only single operation.)

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

