### PR TITLE
Docs: (TYPO) id number on wrong field

### DIFF
--- a/site/src/routes/intro/reusing-parts-of-a-query/+page.svx
+++ b/site/src/routes/intro/reusing-parts-of-a-query/+page.svx
@@ -176,8 +176,8 @@ Before we add anything to our route, let's update the component defined in `src/
 Once that's done, go back to the route we've been working with and update the query to look like this:
 
 ```graphql:title=src/routes/[[id]]/+page.gql
-query Info($id: Int!) {
-    species(id: $id = 1) {
+query Info($id: Int! = 1) {
+    species(id: $id) {
         name
         flavor_text
         evolution_chain {


### PR DESCRIPTION
Copying and pasting from the docs from [Reusing Parts of a Query](https://houdinigraphql.com/intro/reusing-parts-of-a-query) will produce the error:

```
❌ Encountered error in src/routes/[[id]]/+page.gql 
Syntax Error: Expected Name, found "=".
```

On the next section, [Mutations](https://houdinigraphql.com/intro/mutations), it reverts back to:

```diff
query Info($id: Int! = 1) {
    species(id: $id) {
```

so I figured this must be a typo.



