### PR TITLE
fix: Duplicate virtual `+layout.js` files

### DIFF
--- a/.changeset/mighty-rice-trade.md
+++ b/.changeset/mighty-rice-trade.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix duplicate virtual `+layout.js` files

--- a/packages/houdini-svelte/src/plugin/fsPatch.ts
+++ b/packages/houdini-svelte/src/plugin/fsPatch.ts
@@ -181,12 +181,13 @@ filesystem.readdirSync = function (
 		result.push(virtual_file('+page.js', options))
 	}
 
-	// if there is a layout file but no layout.js, we need to make one
-	if (contains('+layout.svelte', '+layout.gql') && !contains('+layout.ts', '+layout.js')) {
+	const posix_filepath = path.posixify(filepath.toString())
+	
+	// there needs to always be a root load function that passes the session down
+	// also, if there is a layout file but no layout.js, we need to make one
+	if ((is_root_route(posix_filepath) || contains('+layout.svelte', '+layout.gql')) && !contains('+layout.ts', '+layout.js')) {
 		result.push(virtual_file('+layout.js', options))
 	}
-
-	const posix_filepath = path.posixify(filepath.toString())
 
 	// if we are in looking inside of src/routes and there's no +layout.svelte file
 	// we need to create one
@@ -201,11 +202,6 @@ filesystem.readdirSync = function (
 		!plugin_config(_config).static
 	) {
 		result.push(virtual_file('+layout.server.js', options))
-	}
-
-	// there needs to always be a root load function that passes the session down
-	if (is_root_route(posix_filepath) && !contains('+layout.js', '+layout.ts')) {
-		result.push(virtual_file('+layout.js', options))
 	}
 
 	// we're done modifying the results

--- a/packages/houdini-svelte/src/plugin/fsPatch.ts
+++ b/packages/houdini-svelte/src/plugin/fsPatch.ts
@@ -182,10 +182,13 @@ filesystem.readdirSync = function (
 	}
 
 	const posix_filepath = path.posixify(filepath.toString())
-	
+
 	// there needs to always be a root load function that passes the session down
 	// also, if there is a layout file but no layout.js, we need to make one
-	if ((is_root_route(posix_filepath) || contains('+layout.svelte', '+layout.gql')) && !contains('+layout.ts', '+layout.js')) {
+	if (
+		(is_root_route(posix_filepath) || contains('+layout.svelte', '+layout.gql')) &&
+		!contains('+layout.ts', '+layout.js')
+	) {
 		result.push(virtual_file('+layout.js', options))
 	}
 


### PR DESCRIPTION
Duplicate `+layout.js` files were being created in the root directory. This was an issue without side effects until sveltekit 1.15.5, which added a duplicate check. This fix allows houdini to work in sveltekit again.

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [X] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [X] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [X] Includes a changeset if your fix affects the user with `pnpm changeset`

