### PR TITLE
add missing jsx preset to parseJS

### DIFF
--- a/packages/houdini/src/lib/parse.ts
+++ b/packages/houdini/src/lib/parse.ts
@@ -11,7 +11,7 @@ export type ParsedFile = Maybe<{ script: Script; start: number; end: number }>
 // overload definitions
 export async function parseJS(str: string, config?: Partial<ParserOptions>): Promise<Script> {
 	const defaultConfig: ParserOptions = {
-		plugins: ['typescript', 'importAssertions'],
+		plugins: ['typescript', 'importAssertions', 'jsx'],
 		sourceType: 'module',
 	}
 	// @ts-ignore: babel doesn't perfectly match recast's types (the comments don't line up)


### PR DESCRIPTION
Fixes #TICKET

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [ ] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [ ] Includes a changeset if your fix affects the user with `pnpm changeset`

