### PR TITLE
Disallow floating fragment loading directive

### DIFF
--- a/.changeset/chilled-planes-design.md
+++ b/.changeset/chilled-planes-design.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Disallow floating fragment spread loading

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,31 +1,31 @@
 {
-  "mode": "pre",
-  "tag": "next",
-  "initialVersions": {
-    "e2e-api": "0.0.1",
-    "e2e-kit": "0.0.1",
-    "e2e-next": "0.0.1",
-    "e2e-react-vite": "0.0.0",
-    "e2e-svelte": "0.0.1",
-    "scripts": "1.0.0",
-    "houdini": "1.1.7",
-    "houdini-plugin-svelte-global-stores": "1.1.7",
-    "houdini-react": "1.1.7",
-    "houdini-svelte": "1.1.7",
-    "site": "0.0.1"
-  },
-  "changesets": [
-    "dirty-hornets-retire",
-    "eleven-rules-cheer",
-    "gentle-coats-itch",
-    "green-camels-walk",
-    "mighty-pugs-matter",
-    "mighty-rice-trade",
-    "pink-coins-ring",
-    "pink-otters-cheer",
-    "popular-rocks-join",
-    "rude-socks-doubt",
-    "serious-pumas-explode",
-    "twenty-months-cover"
-  ]
+	"mode": "exit",
+	"tag": "next",
+	"initialVersions": {
+		"e2e-api": "0.0.1",
+		"e2e-kit": "0.0.1",
+		"e2e-next": "0.0.1",
+		"e2e-react-vite": "0.0.0",
+		"e2e-svelte": "0.0.1",
+		"scripts": "1.0.0",
+		"houdini": "1.1.7",
+		"houdini-plugin-svelte-global-stores": "1.1.7",
+		"houdini-react": "1.1.7",
+		"houdini-svelte": "1.1.7",
+		"site": "0.0.1"
+	},
+	"changesets": [
+		"dirty-hornets-retire",
+		"eleven-rules-cheer",
+		"gentle-coats-itch",
+		"green-camels-walk",
+		"mighty-pugs-matter",
+		"mighty-rice-trade",
+		"pink-coins-ring",
+		"pink-otters-cheer",
+		"popular-rocks-join",
+		"rude-socks-doubt",
+		"serious-pumas-explode",
+		"twenty-months-cover"
+	]
 }

--- a/packages/houdini/src/codegen/validators/typeCheck.test.ts
+++ b/packages/houdini/src/codegen/validators/typeCheck.test.ts
@@ -1114,6 +1114,31 @@ const table: Row[] = [
 		],
 	},
 	{
+		title: '@loading floating on fragment spread',
+		pass: false,
+		documents: [
+			`
+			fragment UserInfo on User {
+				id
+			}
+			`,
+			`
+			query A {
+				entity  {
+					...UserInfo @loading
+				}
+			}
+			`,
+			`
+			query B {
+				entity  {
+					...UserInfo @loading
+				}
+			}
+			`,
+		],
+	},
+	{
 		title: '@loading must fall on inline fragment',
 		pass: false,
 		documents: [

--- a/packages/houdini/src/codegen/validators/typeCheck.ts
+++ b/packages/houdini/src/codegen/validators/typeCheck.ts
@@ -1181,7 +1181,7 @@ function validateLoadingDirective(config: Config) {
 				if (!parentLoading && !global) {
 					ctx.reportError(
 						new graphql.GraphQLError(
-							`@${config.loadingDirective} can only be applied on a field at the root of a document or on one whose parent also has @${config.loadingDirective}`
+							`@${config.loadingDirective} can only be applied on a field or fragment spread at the root of a document or on one whose parent also has @${config.loadingDirective}`
 						)
 					)
 				}
@@ -1213,7 +1213,7 @@ function validateLoadingDirective(config: Config) {
 				if (!parentLoading && !global) {
 					ctx.reportError(
 						new graphql.GraphQLError(
-							`@${config.loadingDirective} can only be applied on a field at the root of a document or on one whose parent also has @${config.loadingDirective}`
+							`@${config.loadingDirective} can only be applied on a field or fragment spread at the root of a document or on one whose parent also has @${config.loadingDirective}`
 						)
 					)
 				}


### PR DESCRIPTION
This PR adds a check in the document validation to ensure that `@loading` isn't applied on a floating fragment spread