### PR TITLE
Only parse as JSX in react bindings

### DIFF
--- a/.changeset/old-months-draw.md
+++ b/.changeset/old-months-draw.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix bug causing svelte files to be parsed as jsx

--- a/packages/houdini-react/src/plugin/extract.ts
+++ b/packages/houdini-react/src/plugin/extract.ts
@@ -19,7 +19,7 @@ export async function extractDocuments({
 	}
 
 	// parse the content
-	const parsed = await parseJS(content, {plugins:['jsx']})
+	const parsed = await parseJS(content, { plugins: ['jsx'] })
 
 	// use the houdini utility to search for the graphql functions
 	await find_graphql(config, parsed, {

--- a/packages/houdini-react/src/plugin/extract.ts
+++ b/packages/houdini-react/src/plugin/extract.ts
@@ -19,7 +19,7 @@ export async function extractDocuments({
 	}
 
 	// parse the content
-	const parsed = await parseJS(content)
+	const parsed = await parseJS(content, {plugins:['jsx']})
 
 	// use the houdini utility to search for the graphql functions
 	await find_graphql(config, parsed, {

--- a/packages/houdini/src/lib/parse.ts
+++ b/packages/houdini/src/lib/parse.ts
@@ -11,7 +11,7 @@ export type ParsedFile = Maybe<{ script: Script; start: number; end: number }>
 // overload definitions
 export async function parseJS(str: string, config?: Partial<ParserOptions>): Promise<Script> {
 	const defaultConfig: ParserOptions = {
-		plugins: ['typescript', 'importAssertions', 'jsx'],
+		plugins: ['typescript', 'importAssertions'],
 		sourceType: 'module',
 	}
 	// @ts-ignore: babel doesn't perfectly match recast's types (the comments don't line up)


### PR DESCRIPTION
Fixes the issue found on discord [here](https://discord.com/channels/1024421016405016718/1099067986083594300)

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [ ] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [ ] Includes a changeset if your fix affects the user with `pnpm changeset`

