### PR TITLE
Add client check for subscription listen function

### DIFF
--- a/.changeset/new-cars-drive.md
+++ b/.changeset/new-cars-drive.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': minor
+---
+
+Disable subscriptions `listen` function on SSR

--- a/packages/houdini-svelte/src/runtime/stores/subscription.ts
+++ b/packages/houdini-svelte/src/runtime/stores/subscription.ts
@@ -7,6 +7,7 @@ import { CompiledSubscriptionKind } from '$houdini/runtime/lib/types'
 import type { GraphQLObject } from 'houdini'
 import { derived, writable, type Subscriber, type Writable } from 'svelte/store'
 
+import { isBrowser } from '../adapter'
 import { initClient } from '../client'
 import { getSession } from '../session'
 import { BaseStore } from './base'
@@ -24,6 +25,9 @@ export class SubscriptionStore<
 	}
 
 	async listen(variables?: _Input, args?: { metadata: App.Metadata }) {
+		if (!isBrowser) {
+			return
+		}
 		this.fetchingStore.set(true)
 		await initClient()
 		this.observer.send({


### PR DESCRIPTION
This PR is supposed to fix a bug with a redundant request from SSR while `onMount` is not specified while using `listen`

fixes #1091

After this fix it will behave like described here https://houdinigraphql.com/api/subscription, I.e. `will start listening onMount (browser only)`

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

