### PR TITLE
Node interface warning update

### DIFF
--- a/.changeset/wise-cycles-add.md
+++ b/.changeset/wise-cycles-add.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+improve: node interface messages & display only on usage.

--- a/packages/houdini/src/codegen/generators/typescript/imperativeTypeDef.test.ts
+++ b/packages/houdini/src/codegen/generators/typescript/imperativeTypeDef.test.ts
@@ -255,8 +255,8 @@ test('generates type definitions for the imperative API', async function () {
 		        };
 		        Ghost: {
 		            idFields: {
-		                name: string;
 		                aka: string;
+		                name: string;
 		            };
 		            fields: {
 		                id: {

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -389,10 +389,17 @@ export class Config {
 	}
 
 	keyFieldsForType(type: string) {
+		// TODO JYC: any special reason for this? (in postegraphile, there is a node interface on query)
+		// """
+		// Exposes the root query type nested one level down. This is helpful for Relay
+		// which can only query top level fields if they are in a particular form.
+		// """
+		// query: Query!
+
 		// the only type that doesn't have a well defined ID is the root query type
-		return this.schema.getQueryType()?.name === type
-			? []
-			: keyFieldsForType(this.configFile, type)
+		return keyFieldsForType(this.configFile, type)
+		// return this.schema.getQueryType()?.name === type
+		// 	? []
 	}
 
 	computeID(type: string, data: any): string {


### PR DESCRIPTION
- Node interface message update (trying to give more info)
- Message is now not displayed if the Node interface is not used
- Message will show on usage & wrong configuration

Example of message:
![image](https://github.com/HoudiniGraphql/houdini/assets/5312607/a57d63fa-f5d6-4ac7-94ee-2c84b40be42f)


### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

