### PR TITLE
Add paramter to set initial fetching value

### DIFF
--- a/e2e/kit/src/lib/utils/routes.ts
+++ b/e2e/kit/src/lib/utils/routes.ts
@@ -4,8 +4,10 @@ export const routes = {
 
   // edge cases
   nested_routes: '/nested-routes',
+  fetching_page_gql: '/fetching/page_gql',
   fetching_with_load: '/fetching/with_load',
   fetching_without_load: '/fetching/without_load',
+  fetching_without_load_external_file: '/fetching/without_load_external_file',
   fetching_route_1: '/fetching/route_1',
   union_result: '/union-result',
   customIDs: '/customIDs',

--- a/e2e/kit/src/routes/fetching/page_gql/+page.gql
+++ b/e2e/kit/src/routes/fetching/page_gql/+page.gql
@@ -1,0 +1,6 @@
+query fetching_page_gql @blocking_disable {
+  user(id: 1, snapshot: "fetching_page_gql", delay: 500) {
+    id
+    name
+  }
+}

--- a/e2e/kit/src/routes/fetching/page_gql/+page.svelte
+++ b/e2e/kit/src/routes/fetching/page_gql/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import type { PageData } from '../route_3/$houdini';
+  export let data: PageData;
+  $: ({ fetching_page_gql } = data);
+  $: console.info(`fetching_page_gql - fetching: ${$fetching_page_gql.fetching}`);
+</script>
+
+<pre>{JSON.stringify($fetching_page_gql, null, 2)}</pre>

--- a/e2e/kit/src/routes/fetching/spec.ts
+++ b/e2e/kit/src/routes/fetching/spec.ts
@@ -59,6 +59,51 @@ test.describe('fetching', () => {
     expect(msg4.text()).toBe('without_load - fetching: false');
   });
 
+  test('+page.gql CSR', async ({ page }) => {
+    await goto(page, routes.Home);
+
+    // Switch page and check the first console log
+    const [msg1] = await Promise.all([
+      waitForConsole(page),
+      clientSideNavigation(page, routes.fetching_page_gql)
+    ]);
+    expect(msg1.text()).toBe('fetching_page_gql - fetching: true');
+
+    // wait for the fetching false
+    const msg2 = await waitForConsole(page);
+    expect(msg2.text()).toBe('fetching_page_gql - fetching: false');
+  });
+
+  test('without_load_external_file CSR', async ({ page }) => {
+    await goto(page, routes.Home);
+
+    // Switch page and check the first console log
+    const [msg] = await Promise.all([
+      waitForConsole(page),
+      clientSideNavigation(page, routes.fetching_without_load_external_file)
+    ]);
+    expect(msg.text()).toBe('without_load_external_fileStore - fetching: false');
+
+    const [msg2] = await Promise.all([
+      waitForConsole(page),
+      // manual fetch
+      locator_click(page, 'button')
+    ]);
+    expect(msg2.text()).toBe('without_load_external_fileStore - fetching: true');
+
+    // wait for the fetching false
+    const msg3 = await waitForConsole(page);
+    expect(msg3.text()).toBe('without_load_external_fileStore - fetching: false');
+
+    // second click should not refetch... so fetching should be false
+    const [msg4] = await Promise.all([
+      waitForConsole(page),
+      // manual fetch
+      locator_click(page, 'button')
+    ]);
+    expect(msg4.text()).toBe('without_load_external_fileStore - fetching: false');
+  });
+
   test('loading the same store somewhere else', async ({ page }) => {
     await goto(page, routes.fetching_route_1);
 

--- a/e2e/kit/src/routes/fetching/without_load_external_file/+page.svelte
+++ b/e2e/kit/src/routes/fetching/without_load_external_file/+page.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { without_load_external_fileStore } from '$houdini';
+  $: store = new without_load_external_fileStore();
+  const getData = () => {
+    store.fetch();
+  };
+  $: console.info(`without_load_external_fileStore - fetching: ${$store.fetching}`);
+</script>
+
+<button on:click={getData}>Fetch</button>
+
+<pre>{JSON.stringify($store, null, 2)}</pre>

--- a/e2e/kit/src/routes/fetching/without_load_external_file/+page.svelte
+++ b/e2e/kit/src/routes/fetching/without_load_external_file/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { without_load_external_fileStore } from '$houdini';
-  $: store = new without_load_external_fileStore();
+  $: store = new without_load_external_fileStore({ fetching: false });
   const getData = () => {
     store.fetch();
   };

--- a/e2e/kit/src/routes/fetching/without_load_external_file/without_load_external_file.gql
+++ b/e2e/kit/src/routes/fetching/without_load_external_file/without_load_external_file.gql
@@ -1,0 +1,6 @@
+query without_load_external_file {
+  user(id: 1, snapshot: "without_load_external_file", delay: 200) {
+    id
+    name
+  }
+}

--- a/packages/houdini-svelte/src/plugin/codegen/stores/query.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/stores/query.ts
@@ -39,11 +39,12 @@ import artifact from '$houdini/artifacts/${artifactName}'
 import { initClient } from '$houdini/plugins/houdini-svelte/runtime/client'
 
 export class ${storeName} extends ${store_class} {
-	constructor() {
+	constructor(args) {
 		super({
 			artifact,
 			storeName: ${JSON.stringify(storeName)},
 			variables: ${JSON.stringify(variables)},
+			...args,
 		})
 	}
 }

--- a/packages/houdini-svelte/src/runtime/stores/query.ts
+++ b/packages/houdini-svelte/src/runtime/stores/query.ts
@@ -42,10 +42,15 @@ export class QueryStore<
 	// the string identifying the store
 	protected storeName: string
 
-	constructor({ artifact, storeName, variables }: StoreConfig<_Data, _Input, QueryArtifact>) {
+	constructor({
+		artifact,
+		storeName,
+		variables,
+		fetching,
+	}: StoreConfig<_Data, _Input, QueryArtifact> & { fetching?: boolean }) {
 		// all queries should be with fetching: true by default (because auto fetching)
 		// except for manual queries, which should be false, it will be manualy triggered
-		const fetching = artifact.pluginData['houdini-svelte']?.isManualLoad !== true
+		fetching ??= artifact.pluginData['houdini-svelte']?.isManualLoad !== true
 
 		super({
 			artifact,


### PR DESCRIPTION
This PR is an alternative solution for #1085. It adds a `fetching` parameter to the query store constructor params so users can set the initial value. This stepping stone removes some of the pressure while we think through a better default value. This value effects cache subscriptions so I want to be very careful before we merge anything dramatic
