### PR TITLE
filepath ignoring QueryString

### DIFF
--- a/.changeset/two-vans-drive.md
+++ b/.changeset/two-vans-drive.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+fix: config.include now checks against files ignoring QueryString

--- a/packages/houdini/src/lib/config.test.ts
+++ b/packages/houdini/src/lib/config.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
+import { path } from '.'
+import { testConfig } from '../test'
 import type { PluginMeta } from './config'
 import { orderedPlugins, readConfigFile } from './config'
 
@@ -78,4 +80,29 @@ test(`orderedPlugins - per group then keeping the order of plugings`, async () =
 test(`orderedPlugins - empty => empty`, async () => {
 	const o = orderedPlugins([]).map((p) => p.name)
 	expect(o).toMatchInlineSnapshot('[]')
+})
+
+test(`Files that should be included`, async () => {
+	const config = testConfig()
+
+	// defaults
+	expect(config.includeFile(path.join(process.cwd(), 'src/routes/page.ts'))).toBe(true)
+	expect(config.includeFile(path.join(process.cwd(), 'src/routes/page.js'))).toBe(true)
+	expect(config.includeFile(path.join(process.cwd(), 'src/routes/page.gql'))).toBe(true)
+	expect(config.includeFile(path.join(process.cwd(), 'src/routes/page.graphql'))).toBe(true)
+
+	// with some "?"
+	expect(config.includeFile(path.join(process.cwd(), 'src/routes/page.ts?sentry'))).toBe(true)
+	expect(config.includeFile(path.join(process.cwd(), 'src/rou?tes/page.ts?sentry'))).toBe(true)
+	expect(config.includeFile(path.join(process.cwd(), 'src/page.ts?s?e?n?t?r?y'))).toBe(true)
+})
+
+test(`Files that should not be included`, async () => {
+	const config = testConfig()
+
+	expect(config.includeFile(path.join(process.cwd(), 'src/routes/test'))).toBe(false)
+	expect(config.includeFile(path.join(process.cwd(), 'src/routes/test.'))).toBe(false)
+	expect(config.includeFile(path.join(process.cwd(), 'src/routes/test.jts'))).toBe(false)
+	expect(config.includeFile(path.join(process.cwd(), 'src/routes/test?'))).toBe(false)
+	expect(config.includeFile(path.join(process.cwd(), 'src/rou?tes/page.nop?s?e'))).toBe(false)
 })

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -473,11 +473,6 @@ export class Config {
 		return false
 	}
 
-	private pathRmvQueryString(filepath: string) {
-		const parsed = path.parse(filepath)
-		return `${parsed.dir}/${parsed.name}${parsed.ext.split('?')[0]}`
-	}
-
 	includeFile(
 		filepath: string,
 		{
@@ -485,7 +480,8 @@ export class Config {
 			ignore_plugins = false,
 		}: { root?: string; ignore_plugins?: boolean } = {}
 	) {
-		filepath = this.pathRmvQueryString(filepath)
+		const parsed = path.parse(filepath)
+		filepath =  `${parsed.dir}/${parsed.name}${parsed.ext.split('?')[0]}`
 
 		let included = false
 		// plugins might define custom include logic

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -473,6 +473,11 @@ export class Config {
 		return false
 	}
 
+	private pathRmvQueryString(filepath: string) {
+		const parsed = path.parse(filepath)
+		return `${parsed.dir}/${parsed.name}${parsed.ext.split('?')[0]}`
+	}
+
 	includeFile(
 		filepath: string,
 		{
@@ -480,6 +485,8 @@ export class Config {
 			ignore_plugins = false,
 		}: { root?: string; ignore_plugins?: boolean } = {}
 	) {
+		filepath = this.pathRmvQueryString(filepath)
+
 		let included = false
 		// plugins might define custom include logic
 		for (const plugin of ignore_plugins ? [] : this.plugins) {

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -481,7 +481,7 @@ export class Config {
 		}: { root?: string; ignore_plugins?: boolean } = {}
 	) {
 		const parsed = path.parse(filepath)
-		filepath =  `${parsed.dir}/${parsed.name}${parsed.ext.split('?')[0]}`
+		filepath = `${parsed.dir}/${parsed.name}${parsed.ext.split('?')[0]}`
 
 		let included = false
 		// plugins might define custom include logic


### PR DESCRIPTION
Fixes [#discord](https://discord.com/channels/1024421016405016718/1111684053880553482/1111780792033628170)

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

---

FYI @Lms24
- This PR is to remove `?sentry-auto-wrap`
- Also, just to confirm, `houdini` needs to come before `sentrySvelteKit` in the vite config (to transform file)
