### PR TITLE
Refresh query result API docs

### DIFF
--- a/site/src/routes/api/query/+page.svx
+++ b/site/src/routes/api/query/+page.svx
@@ -80,7 +80,7 @@ query MyProfileInfo {
 {$MyProfileInfo.data.viewer.firstName}
 ```
 
-This example takes advantage of Houdini's powerful [load generator](#generating-loaders) and
+This example takes advantage of Houdini's powerful [load generator](#automatic-loading) and
 is just one of many ways to get access to a store that can drive your server-side rendered routes.
 For more information, check out the [Working with GraphQL](/guides/working-with-graphql) guide.
 
@@ -89,9 +89,10 @@ For more information, check out the [Working with GraphQL](/guides/working-with-
 A query store holds an object with the following fields that accessed like `$store.data`:
 
 - `data` contains the result of the query. It's value will update as mutations, subscriptions, and other queries provide more recent information.
-- `loading` contains the loading state (`true` or `false`) for a query found outside of a route component (ie, not defined in `src/routes`)
+- `fetching` contains the loading state (`true` or `false`). See the [Loading States](#loading-states) section for more info for fine-grained loading states.
 - `errors` contains any error values that occur for a query found outside of a route component (ie, not defined in `src/routes`). If you want to use this for managing your errors, you should enable the [quietQueryError](/api/config) configuration option.
 - `partial` contains a boolean that indicates if the result has a partial match
+- `variables` contains the variables that were sent in the last query, mutation or subscription request.
 
 ### Methods
 
@@ -394,7 +395,7 @@ look at the `fetching` value in the response:
 	$: ({ MyQuery } = data)
 </script>
 
-{#if MyQuery.fetching}
+{#if $MyQuery.fetching}
 	loading...
 {:else}
 	{$MyQuery.data....}


### PR DESCRIPTION
I couldn't remember if `fetching` or `loading` was the current way to check if a query is loading and I couldn't remember if that var exists on the store or on the store value. I went to the [API query docs](https://houdinigraphql.com/api/query)... and they confused me more :)  So I went to the type definition and source code and I think I was able to get it straightened out. Suggesting some updates to that page of the docs:

Here's the current docs on the query store fields:
https://github.com/HoudiniGraphql/houdini/blob/8bba6c3/site/src/routes/api/query/%2Bpage.svx#L91-L94

Here's the current type definition. I think `loading` was replaced by `fetching` a while ago. `variables` seems useful.
https://github.com/HoudiniGraphql/houdini/blob/8bba6c3/packages/houdini/src/runtime/lib/types.ts#L235-L243

I didn't add `stale` and `source` since they seem to be more internal.

I didn't see any docs about how to handle the user wanting to refresh your query. I'm assuming this would be the recommended way?
```
MyQuery.fetch({ variables: $MyQuery.variables, policy: CachePolicy.NetworkOnly });
```

I added a note about that to the query store fetch method.

I also noticed what seems to be a typo here:
https://github.com/HoudiniGraphql/houdini/blob/8bba6c3/site/src/routes/api/query/%2Bpage.svx#LL397C23-L397C23
I think that should be `{#if $MyQuery.fetching}`
