### PR TITLE
Decorators are allowed in the project

### DIFF
--- a/.changeset/few-chicken-sell.md
+++ b/.changeset/few-chicken-sell.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Support projects using `experimentalDecorators: true` flag in there tsconfig.json

--- a/packages/houdini/src/lib/parse.test.ts
+++ b/packages/houdini/src/lib/parse.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe } from 'vitest'
 
-import { parseJSON } from './parse'
+import { parseJS, parseJSON } from './parse'
 
 describe('parse', function () {
 	test('parseJSON without comments', async function () {
@@ -71,5 +71,22 @@ describe('parse', function () {
 				noImplicitAny: true,
 			},
 		})
+	})
+
+	test('parseJS with decorators', async function () {
+		const parsed = parseJS(`
+			const a = 1
+			const b = 2
+
+			@annotation
+			class Test {}
+		`)
+		expect(parsed).toMatchInlineSnapshot(`
+			const a = 1;
+			const b = 2;
+
+			@annotation
+			class Test {}
+		`)
 	})
 })

--- a/packages/houdini/src/lib/parse.ts
+++ b/packages/houdini/src/lib/parse.ts
@@ -11,7 +11,7 @@ export type ParsedFile = Maybe<{ script: Script; start: number; end: number }>
 // overload definitions
 export function parseJS(str: string, config?: Partial<ParserOptions>): Script {
 	const defaultConfig: ParserOptions = {
-		plugins: ['typescript', 'importAssertions'],
+		plugins: ['typescript', 'importAssertions', 'decorators'],
 		sourceType: 'module',
 	}
 	// @ts-ignore: babel doesn't perfectly match recast's types (the comments don't line up)


### PR DESCRIPTION
I have a project where I have `experimentalDecorators: true` with a few decorators in some `ts` files.
Adding the 'decorators' plugin into the parseJS fix the issue.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] ~Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`~
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

