### PR TITLE
Include types in houdini-svelte/runtime import (resolves QueryStoreFetchParams import failures)

### DIFF
--- a/.changeset/dull-hairs-confess.md
+++ b/.changeset/dull-hairs-confess.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Include types in houdini-svelte/runtime import (resolves QueryStoreFetchParams import failures)

--- a/packages/houdini-svelte/src/runtime/index.ts
+++ b/packages/houdini-svelte/src/runtime/index.ts
@@ -4,6 +4,7 @@ export * from './adapter'
 export * from './stores'
 export * from './fragments'
 export * from './session'
+export * from './types'
 
 type LoadResult = Promise<{ [key: string]: QueryStore<any, {}> }>
 type LoadAllInput = LoadResult | Record<string, LoadResult>


### PR DESCRIPTION
Resolves an issue where `QueryStoreFetchParams` cannot be imported from `$houdini`, meaning that generated operation files do not type-check their variables or event inputs.

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

