### PR TITLE
Users can configure a type to always be embedded by setting keys to []

### DIFF
--- a/.changeset/silver-fans-speak.md
+++ b/.changeset/silver-fans-speak.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Users can specify that a type is always embedded by setting keys to []

--- a/packages/houdini/src/runtime/cache/cache.ts
+++ b/packages/houdini/src/runtime/cache/cache.ts
@@ -562,10 +562,10 @@ class CacheInternal {
 
 				// figure out if this is an embedded object or a linked one by looking for all of the fields marked as
 				// required to compute the entity's id
+				const idFields = this.idFields(linkedType)
 				const embedded =
-					this.idFields(linkedType)?.filter(
-						(field) => typeof value[field] === 'undefined'
-					).length > 0
+					idFields.length === 0 ||
+					idFields.filter((field) => typeof value[field] === 'undefined').length > 0
 
 				// figure out the new target of the object link
 				let linkedID: string | null = null
@@ -1378,10 +1378,11 @@ class CacheInternal {
 
 			// figure out if this is an embedded list or a linked one by looking for all of the fields marked as
 			// required to compute the entity's id
+			const idFields = this.idFields(linkedType)
 			const embedded =
-				this.idFields(linkedType)?.filter(
-					(field) => typeof (entry as GraphQLObject)[field] === 'undefined'
-				).length > 0
+				idFields.length === 0 ||
+				idFields.filter((field) => typeof (entry as GraphQLObject)[field] === 'undefined')
+					.length > 0
 
 			let innerType = linkedType
 

--- a/packages/houdini/src/runtime/cache/cache.ts
+++ b/packages/houdini/src/runtime/cache/cache.ts
@@ -567,7 +567,7 @@ class CacheInternal {
 				let linkedID: string | null = null
 				if (value !== null) {
 					// if the value is embedded then the id needs to be keyed by the field
-					linkedID = !this.isEmbeded(linkedType, value)
+					linkedID = !this.isEmbedded(linkedType, value)
 						? this.id(linkedType, value)
 						: `${parent}.${key}`
 				}
@@ -1049,10 +1049,10 @@ class CacheInternal {
 			// if we run into a null cursor that is inside of a connection then
 			// we know its a generated value and should not force us to mark the whole parent as
 			// null (prevent the null cascade) or be treated as partial data
-			const embededCursor = key === 'cursor' && stepsFromConnection === 1
+			const embeddedCursor = key === 'cursor' && stepsFromConnection === 1
 
 			// if we dont have a value, we know this result is going to be partial
-			if (typeof value === 'undefined' && !embededCursor) {
+			if (typeof value === 'undefined' && !embeddedCursor) {
 				partial = true
 			}
 
@@ -1167,7 +1167,7 @@ class CacheInternal {
 
 			// regardless of how the field was processed, if we got a null value assigned
 			// and the field is not nullable, we need to cascade up
-			if (fieldTarget[attributeName] === null && !nullable && !embededCursor) {
+			if (fieldTarget[attributeName] === null && !nullable && !embeddedCursor) {
 				// if we got a null value assigned and the field is not nullable, we need to cascade up
 				// except when it's an abstract type with @required children - then we return a dummy object
 				if (abstractHasRequired) {
@@ -1216,6 +1216,14 @@ class CacheInternal {
 
 	computeID(type: string, data: any): string {
 		return computeID(this.config, type, data)
+	}
+
+	isEmbedded(linkedType: string, value: GraphQLObject) {
+		const idFields = this.idFields(linkedType)
+		return (
+			idFields.length === 0 ||
+			idFields.filter((field) => typeof value[field] === 'undefined').length > 0
+		)
 	}
 
 	hydrateNestedList({
@@ -1385,7 +1393,7 @@ class CacheInternal {
 			}
 
 			// if this isn't an embedded reference, use the entry's id in the link list
-			if (!this.isEmbeded(linkedType, entry as GraphQLObject)) {
+			if (!this.isEmbedded(linkedType, entry as GraphQLObject)) {
 				const id = this.id(innerType, entry as {})
 				if (id) {
 					linkedID = id
@@ -1422,14 +1430,6 @@ class CacheInternal {
 		if (this.storage.layerCount === 1) {
 			this.storage.topLayer.removeUndefinedFields()
 		}
-	}
-
-	isEmbeded(linkedType: string, value: GraphQLObject) {
-		const idFields = this.idFields(linkedType)
-		return (
-			idFields.length === 0 ||
-			idFields.filter((field) => typeof value[field] === 'undefined').length > 0
-		)
 	}
 }
 

--- a/packages/houdini/src/runtime/cache/cache.ts
+++ b/packages/houdini/src/runtime/cache/cache.ts
@@ -1215,6 +1215,8 @@ class CacheInternal {
 		return computeID(this.config, type, data)
 	}
 
+	// figure out if this is an embedded object or a linked one by looking for all of the fields marked as
+	// required to compute the entity's id
 	isEmbedded(linkedType: string, value: GraphQLObject) {
 		const idFields = this.idFields(linkedType)
 		return (

--- a/packages/houdini/src/runtime/cache/cache.ts
+++ b/packages/houdini/src/runtime/cache/cache.ts
@@ -560,9 +560,6 @@ class CacheInternal {
 					}
 				}
 
-				// figure out if this is an embedded object or a linked one by looking for all of the fields marked as
-				// required to compute the entity's id
-
 				// figure out the new target of the object link
 				let linkedID: string | null = null
 				if (value !== null) {

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -362,12 +362,12 @@ export class List {
 			if (!embeddedConnection) {
 				return
 			}
-			const embeddedConnectionID = embeddedConnection as string
+			const embededConnectionID = embeddedConnection as string
 
 			// look at every embedded edge for the one with a node corresponding to the element
 			// we want to delete
 			const { value: edges } = this.cache._internal_unstable.storage.get(
-				embeddedConnectionID,
+				embededConnectionID,
 				'edges'
 			)
 			for (const edge of flatten(edges as NestedList) || []) {
@@ -388,7 +388,7 @@ export class List {
 					targetID = edgeID
 				}
 			}
-			parentID = embeddedConnectionID
+			parentID = embededConnectionID
 			targetKey = 'edges'
 		}
 

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -362,12 +362,12 @@ export class List {
 			if (!embeddedConnection) {
 				return
 			}
-			const embededConnectionID = embeddedConnection as string
+			const embeddedConnectionID = embeddedConnection as string
 
 			// look at every embedded edge for the one with a node corresponding to the element
 			// we want to delete
 			const { value: edges } = this.cache._internal_unstable.storage.get(
-				embededConnectionID,
+				embeddedConnectionID,
 				'edges'
 			)
 			for (const edge of flatten(edges as NestedList) || []) {
@@ -388,7 +388,7 @@ export class List {
 					targetID = edgeID
 				}
 			}
-			parentID = embededConnectionID
+			parentID = embeddedConnectionID
 			targetKey = 'edges'
 		}
 

--- a/packages/houdini/src/runtime/cache/tests/readwrite.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/readwrite.test.ts
@@ -2330,3 +2330,91 @@ test('can perform full query check while retrieving masked value', function () {
 		},
 	})
 })
+
+test('embedded types can be configured with an empty list', function () {
+	// instantiate the cache
+	const cache = new Cache({
+		...config,
+		types: {
+			Embedded: {
+				keys: [],
+			},
+		},
+	})
+
+	const selection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						embedded: {
+							type: 'Embedded',
+							keyRaw: 'embedded',
+							visible: true,
+							selection: {
+								fields: {
+									id: {
+										type: 'ID',
+										visible: true,
+										keyRaw: 'id',
+									},
+									firstName: {
+										type: 'String',
+										visible: true,
+										keyRaw: 'firstName',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// write the user data without the nested value
+	cache.write({
+		selection,
+		data: {
+			viewer: {
+				embedded: [
+					{
+						id: '1',
+						firstName: 'John',
+					},
+					{
+						id: '1',
+						firstName: 'Jacob',
+					},
+				],
+			},
+		},
+	})
+
+	expect(
+		cache.read({
+			selection,
+			fullCheck: true,
+		})
+	).toEqual({
+		partial: false,
+		stale: false,
+		data: {
+			viewer: {
+				embedded: [
+					{
+						id: '1',
+						firstName: 'John',
+					},
+					{
+						id: '1',
+						firstName: 'Jacob',
+					},
+				],
+			},
+		},
+	})
+})


### PR DESCRIPTION
Fixes an issue reported in discord where someone needed a type to always be emebeded but couldn't use `[]` to do that.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

