### PR TITLE
Fix when marshal is intentionally an array

### DIFF
--- a/.changeset/chilled-parents-sin.md
+++ b/.changeset/chilled-parents-sin.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+when using marshal with array types, you were not able to input those as mutation variables.

--- a/packages/houdini/src/runtime/lib/scalars.test.ts
+++ b/packages/houdini/src/runtime/lib/scalars.test.ts
@@ -19,6 +19,15 @@ const config = defaultConfigValues({
 				return JSON.stringify(array)
 			},
 		},
+		MultiDimStringArray: {
+			type: 'string[][][]',
+			unmarshal(value): string[] {
+				return JSON.parse(value) ?? []
+			},
+			marshal(array: string[]): string {
+				return JSON.stringify(array)
+			},
+		},
 		GenericArray: {
 			type: 'Array<string>',
 			unmarshal(value): string[] {
@@ -111,6 +120,7 @@ const artifact: QueryArtifact = {
 			Array: {
 				stringArray: 'StringArray',
 				genericArray: 'GenericArray',
+				multiDimArray: 'MultiDimStringArray',
 			},
 			NestedDate: {
 				date: 'DateTime',
@@ -197,7 +207,8 @@ describe('marshal inputs', function () {
 
 	test('marshal intentional arrays', async function () {
 		// some dates to check against
-		const array1 = ['foo', 'bar']
+		const array1: string[] = ['foo', 'bar']
+		const multiDim: string[][][] = [[], [array1, array1], [array1]]
 
 		// compute the inputs
 		const inputs = marshalInputs({
@@ -208,6 +219,7 @@ describe('marshal inputs', function () {
 					{
 						stringArray: array1,
 						genericArray: array1,
+						multiDimArray: multiDim,
 					},
 				],
 			},
@@ -219,6 +231,7 @@ describe('marshal inputs', function () {
 				{
 					stringArray: JSON.stringify(array1),
 					genericArray: JSON.stringify(array1),
+					multiDimArray: JSON.stringify(multiDim),
 				},
 			],
 		})
@@ -228,6 +241,7 @@ describe('marshal inputs', function () {
 
 		const array1 = ['foo', 'bar']
 		const array2 = ['oof', 'rab']
+		const multiDim: string[][][] = [[], [array1, array1], [array1]]
 
 		// compute the inputs
 		const inputs = marshalInputs({
@@ -237,6 +251,7 @@ describe('marshal inputs', function () {
 				array: [
 					{
 						stringArray: [array1, array2],
+						multiDimArray: [multiDim, [array1], []],
 					},
 				],
 			},
@@ -247,6 +262,11 @@ describe('marshal inputs', function () {
 			array: [
 				{
 					stringArray: [JSON.stringify(array1), JSON.stringify(array2)],
+					multiDimArray: [
+						JSON.stringify(multiDim),
+						JSON.stringify([array1]),
+						JSON.stringify([]),
+					],
 				},
 			],
 		})

--- a/packages/houdini/src/runtime/lib/scalars.ts
+++ b/packages/houdini/src/runtime/lib/scalars.ts
@@ -110,9 +110,12 @@ export function marshalInputs<T>({
 
 			// is the type something that requires marshaling
 			const marshalFn = config.scalars?.[type]?.marshal
+			const scalarType = config.scalars?.[type]?.type
 			if (marshalFn) {
-				// if we are looking at a list of scalars
-				if (Array.isArray(value)) {
+				const shouldBeArray =
+					scalarType?.endsWith('[]') || scalarType?.match(/Array<.*>/) || false
+				// if we are looking at a list of scalars that should not be arrays
+				if (Array.isArray(value) && !shouldBeArray) {
 					return [fieldName, value.map(marshalFn)]
 				}
 				return [fieldName, marshalFn(value)]


### PR DESCRIPTION
Fixes the following bug:

When having an array as scalar type houdini does not marhash the array, because it gets interpreted as a list.
https://github.com/HoudiniGraphql/houdini/blob/7e2977ff5f1e737aebbb606e473708036f303d02/packages/houdini/src/runtime/lib/scalars.ts#L114

E.g.
```ts
houdini.config.js
...
_text: {
  type: 'string[]',

  unmarshal(val) {
    return val;
  },

  marshal(array) {
    console.log(array, typeof array);
  return `{${array.toString()}}`;
  }
}
...
```

would log the values of the array when using this type as an input.

E.g. this mutation would result in "foo" and "bar" as two console.logs with type string

```graphql
mutation updateUser($otherLanguages: _text!) {
  insertUserDataOne(object: {otherLanguages: $otherLanguages}) {
    id
  }
}
```
```ts
.mutate({variables: {otherLanguages: ["foo", "bar"]}});
```


This PR fixes this behaviour for mutations. It currently doesn't look into queries.


A note to the code:
https://github.com/Morstis/houdini/blob/28efb4c35db3e3016e44bf25cab4a858c12ba13f/packages/houdini/src/runtime/lib/scalars.ts#L126
the deep exploration will be slow, because it will explore the whole array. When inputting very big multidimensional arrays this code is not optimal!


- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

