### PR TITLE
Fix typegen for component queries inside of a route

### DIFF
--- a/.changeset/small-pets-draw.md
+++ b/.changeset/small-pets-draw.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix typegen for component queries inside a route

--- a/e2e/kit/src/lib/QueryComponent.svelte
+++ b/e2e/kit/src/lib/QueryComponent.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { graphql } from '$houdini';
+  import type { ComponentQueryTestVariables } from './$houdini';
 
-  export function _ComponentQueryTestVariables({ props }: { props: { id?: string } }) {
+  export const _ComponentQueryTestVariables: ComponentQueryTestVariables = ({ props }) => {
     return {
       id: props.id || '3'
     };
-  }
+  };
 
   // svelte-ignore unused-export-let
   export let id = '';

--- a/e2e/kit/src/lib/utils/routes.ts
+++ b/e2e/kit/src/lib/utils/routes.ts
@@ -61,6 +61,7 @@ export const routes = {
   Plugin_query_multiple: '/plugin/query/multiple',
   Plugin_query_scalars: '/plugin/query/scalars',
   Plugin_query_component: '/plugin/query/component',
+  Plugin_query_componentInRoute: '/plugin/query/component-in-route',
   Plugin_query_beforeLoad: '/plugin/query/beforeLoad',
   Plugin_query_afterLoad: '/plugin/query/afterLoad',
   Plugin_query_onError: '/plugin/query/onError',

--- a/e2e/kit/src/routes/plugin/query/component-in-route/+page.gql
+++ b/e2e/kit/src/routes/plugin/query/component-in-route/+page.gql
@@ -1,0 +1,5 @@
+query ComponentInRoute_Route {
+  usersList(limit: 2, snapshot: "ComponentInRoute") {
+    id
+  }
+}

--- a/e2e/kit/src/routes/plugin/query/component-in-route/+page.svelte
+++ b/e2e/kit/src/routes/plugin/query/component-in-route/+page.svelte
@@ -8,8 +8,8 @@
 
 {#if $ComponentInRoute_Route.data}
   <ul>
-    {#each $ComponentInRoute_Route.data.usersList as user}
-      <li>
+    {#each $ComponentInRoute_Route.data.usersList as user, idx}
+      <li id="result-{idx}">
         <UserDetails userId={user.id.replace('ComponentInRoute:', '')} />
       </li>
     {/each}

--- a/e2e/kit/src/routes/plugin/query/component-in-route/+page.svelte
+++ b/e2e/kit/src/routes/plugin/query/component-in-route/+page.svelte
@@ -9,7 +9,9 @@
 {#if $ComponentInRoute_Route.data}
   <ul>
     {#each $ComponentInRoute_Route.data.usersList as user}
-      <UserDetails userId={user.id} />
+      <li>
+        <UserDetails userId={user.id.replace('ComponentInRoute:', '')} />
+      </li>
     {/each}
   </ul>
 {/if}

--- a/e2e/kit/src/routes/plugin/query/component-in-route/+page.svelte
+++ b/e2e/kit/src/routes/plugin/query/component-in-route/+page.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import type { PageData } from './$houdini';
+  import UserDetails from './UserDetails.svelte';
+
+  export let data: PageData;
+  $: ({ ComponentInRoute_Route } = data);
+</script>
+
+{#if $ComponentInRoute_Route.data}
+  <ul>
+    {#each $ComponentInRoute_Route.data.usersList as user}
+      <UserDetails userId={user.id} />
+    {/each}
+  </ul>
+{/if}

--- a/e2e/kit/src/routes/plugin/query/component-in-route/UserDetails.svelte
+++ b/e2e/kit/src/routes/plugin/query/component-in-route/UserDetails.svelte
@@ -4,7 +4,7 @@
 
   export let userId: string;
 
-  export let _ComponentInRoute_ComponentVariables: ComponentInRoute_ComponentVariables = ({
+  export const _ComponentInRoute_ComponentVariables: ComponentInRoute_ComponentVariables = ({
     props
   }) => {
     return {

--- a/e2e/kit/src/routes/plugin/query/component-in-route/UserDetails.svelte
+++ b/e2e/kit/src/routes/plugin/query/component-in-route/UserDetails.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { graphql } from '$houdini';
+  import type { ComponentInRoute_ComponentVariables } from './$houdini';
+
+  export let userId: string;
+
+  export let _ComponentInRoute_ComponentVariables: ComponentInRoute_ComponentVariables = ({
+    props
+  }) => {
+    return {
+      userId: props.userId
+    };
+  };
+
+  $: details = graphql(`
+    query ComponentInRoute_Component($userId: ID!) @load {
+      user(id: $userId, snapshot: "ComponentInRoute") {
+        name
+      }
+    }
+  `);
+</script>
+
+{#if $details.data}
+  {$details.data.user.name}
+{/if}

--- a/e2e/kit/src/routes/plugin/query/component-in-route/spec.ts
+++ b/e2e/kit/src/routes/plugin/query/component-in-route/spec.ts
@@ -1,0 +1,12 @@
+import { test } from '@playwright/test';
+import { routes } from '../../../../lib/utils/routes.js';
+import { expect_to_be, goto_expect_n_gql } from '../../../../lib/utils/testsHelper.js';
+
+test.describe('query preprocessor', () => {
+  test('component queries inside a route', async ({ page }) => {
+    await goto_expect_n_gql(page, routes.Plugin_query_componentInRoute, 2);
+
+    await expect_to_be(page, 'Bruce Willis', 'li[id=result-0]');
+    await expect_to_be(page, 'Samuel Jackson', 'li[id=result-1]');
+  });
+});

--- a/packages/houdini-svelte/src/plugin/codegen/components/index.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/components/index.ts
@@ -27,7 +27,7 @@ export default async function componentTypesGenerator(
 	}
 	let matches = Object.keys(queries).filter((filepath) => filepath.endsWith('.svelte'))
 
-	// if we are in kit, don't consider the source directory
+	// if we are in kit, don't consider the routes directory
 	if (framework === 'kit') {
 		matches = matches.filter((match) => !match.startsWith(config.routesDir))
 	}

--- a/packages/houdini-svelte/src/plugin/codegen/components/index.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/components/index.ts
@@ -72,6 +72,8 @@ export default async function componentTypesGenerator(
 	await walk_project(config, files, queries, config.projectRoot)
 }
 
+// The code for generating the types is copied into packages\houdini-svelte\src\plugin\codegen\routes\index.ts
+// In case of a bug in here, make sure to fix it in there as well.
 async function walk_project(
 	config: Config,
 	dirs: ProjectDirs,

--- a/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
@@ -57,7 +57,10 @@ export default async function svelteKitGenerator(
 			}
 
 			const componentNames: string[] = []
-			const uniqueComponentQueries: { query: OperationDefinitionNode, componentPath: string }[] = []
+			const uniqueComponentQueries: {
+				query: OperationDefinitionNode
+				componentPath: string
+			}[] = []
 			for (const component of componentQueries) {
 				if (!componentNames.includes(component.query.name!.value)) {
 					componentNames.push(component.query.name!.value)
@@ -93,7 +96,11 @@ export default async function svelteKitGenerator(
 					config,
 					uniqueLayoutQueries
 				)
-				const componentQueryTypeImports = getComponentTypeImports(dirpath, config, uniqueComponentQueries)
+				const componentQueryTypeImports = getComponentTypeImports(
+					dirpath,
+					config,
+					uniqueComponentQueries
+				)
 
 				// Util bools for ensuring no unnecessary types
 				const beforePageLoad = pageExports.includes(houdini_before_load_fn)
@@ -301,27 +308,30 @@ function getTypeImports(
 function getComponentTypeImports(
 	dirpath: string,
 	config: Config,
-	queries: { query: OperationDefinitionNode, componentPath: string }[]
+	queries: { query: OperationDefinitionNode; componentPath: string }[]
 ) {
 	// Don't output anything if we don't have any component queries
 	if (queries.length === 0) {
-		return "";
+		return ''
 	}
 
 	let typeFile = "\nimport type { ComponentProps } from 'svelte'\n"
-	return typeFile + queries
-		.map((query) => {
-			const no_ext = path.parse(query.componentPath).name;
-			const file = path.parse(query.componentPath);
+	return (
+		typeFile +
+		queries
+			.map((query) => {
+				const no_ext = path.parse(query.componentPath).name
+				const file = path.parse(query.componentPath)
 
-			return `
+				return `
 import ${no_ext} from './${file.base}'
 import type { ${query.query.name!.value}$input } from '${path
 					.relative(dirpath, path.join(config.artifactDirectory, query.query.name!.value))
 					.replace('/$houdini', '')}'
-`;
-		})
-		.join("\n")
+`
+			})
+			.join('\n')
+	)
 }
 
 function append_VariablesFunction(
@@ -368,19 +378,21 @@ function append_VariablesFunction(
 function append_ComponentVariablesFunction(
 	filepath: string,
 	config: Config,
-	queries: { query: OperationDefinitionNode, componentPath: string }[]
+	queries: { query: OperationDefinitionNode; componentPath: string }[]
 ) {
 	return queries
 		.map((query) => {
-			const no_ext = path.parse(query.componentPath).name;
+			const no_ext = path.parse(query.componentPath).name
 			const prop_type = no_ext + 'Props'
 
 			return `
 type ${prop_type} = ComponentProps<${no_ext}>
 export type ${config.variableFunctionName(
 				query.query.name!.value
-			)} = <_Props extends ${prop_type}>(args: { props: _Props }) => ${query.query.name!.value}$input
-`;
+			)} = <_Props extends ${prop_type}>(args: { props: _Props }) => ${
+				query.query.name!.value
+			}$input
+`
 		})
 		.join('\n')
 }

--- a/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
@@ -29,6 +29,7 @@ export default async function svelteKitGenerator(
 			svelteTypeFilePath,
 			layoutQueries,
 			pageQueries,
+			componentQueries,
 			layoutExports,
 			pageExports,
 		}) {
@@ -52,6 +53,15 @@ export default async function svelteKitGenerator(
 				if (!layoutNames.includes(layout.name!.value)) {
 					layoutNames.push(layout.name!.value)
 					uniqueLayoutQueries.push(layout)
+				}
+			}
+
+			const componentNames: string[] = []
+			const uniqueComponentQueries: { query: OperationDefinitionNode, componentPath: string }[] = []
+			for (const component of componentQueries) {
+				if (!componentNames.includes(component.query.name!.value)) {
+					componentNames.push(component.query.name!.value)
+					uniqueComponentQueries.push(component)
 				}
 			}
 
@@ -83,6 +93,7 @@ export default async function svelteKitGenerator(
 					config,
 					uniqueLayoutQueries
 				)
+				const componentQueryTypeImports = getComponentTypeImports(dirpath, config, uniqueComponentQueries)
 
 				// Util bools for ensuring no unnecessary types
 				const beforePageLoad = pageExports.includes(houdini_before_load_fn)
@@ -104,6 +115,12 @@ export default async function svelteKitGenerator(
 					dirpath,
 					config,
 					uniquePageQueries
+				)
+
+				const component_append_VariablesFunction = append_ComponentVariablesFunction(
+					dirpath,
+					config,
+					uniqueComponentQueries
 				)
 
 				const layout_append_beforeLoad = append_beforeLoad(beforeLayoutLoad, 'Layout')
@@ -172,6 +189,7 @@ export default async function svelteKitGenerator(
 					.concat(functionImports)
 					.concat(layoutTypeImports)
 					.concat(pageTypeImports)
+					.concat(componentQueryTypeImports)
 
 				// if we need Page/LayoutParams, generate this type.
 				// verify if necessary. might not be.
@@ -209,6 +227,7 @@ export default async function svelteKitGenerator(
 					.concat(page_append_onError)
 					.concat(layout_append_VariablesFunction)
 					.concat(page_append_VariablesFunction)
+					.concat(component_append_VariablesFunction)
 					//match all between 'LayoutData =' and ';' and combine additional types
 					.replace(
 						//regex to append our generated stores to the existing
@@ -278,6 +297,33 @@ function getTypeImports(
 		.join('\n')
 }
 
+// Copied and adapted from packages\houdini-svelte\src\plugin\codegen\components\index.ts
+function getComponentTypeImports(
+	dirpath: string,
+	config: Config,
+	queries: { query: OperationDefinitionNode, componentPath: string }[]
+) {
+	// Don't output anything if we don't have any component queries
+	if (queries.length === 0) {
+		return "";
+	}
+
+	let typeFile = "\nimport type { ComponentProps } from 'svelte'\n"
+	return typeFile + queries
+		.map((query) => {
+			const no_ext = path.parse(query.componentPath).name;
+			const file = path.parse(query.componentPath);
+
+			return `
+import ${no_ext} from './${file.base}'
+import type { ${query.query.name!.value}$input } from '${path
+					.relative(dirpath, path.join(config.artifactDirectory, query.query.name!.value))
+					.replace('/$houdini', '')}'
+`;
+		})
+		.join("\n")
+}
+
 function append_VariablesFunction(
 	type: `Page` | `Layout`,
 	filepath: string,
@@ -314,6 +360,27 @@ function append_VariablesFunction(
 			return `\nexport type ${config.variableFunctionName(
 				name
 			)} = VariableFunction<${type}Params, ${input_type}>;`
+		})
+		.join('\n')
+}
+
+// Copied and adapted from packages\houdini-svelte\src\plugin\codegen\components\index.ts
+function append_ComponentVariablesFunction(
+	filepath: string,
+	config: Config,
+	queries: { query: OperationDefinitionNode, componentPath: string }[]
+) {
+	return queries
+		.map((query) => {
+			const no_ext = path.parse(query.componentPath).name;
+			const prop_type = no_ext + 'Props'
+
+			return `
+type ${prop_type} = ComponentProps<${no_ext}>
+export type ${config.variableFunctionName(
+				query.query.name!.value
+			)} = <_Props extends ${prop_type}>(args: { props: _Props }) => ${query.query.name!.value}$input
+`;
 		})
 		.join('\n')
 }

--- a/packages/houdini-svelte/src/plugin/codegen/routes/kit.test.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/kit.test.ts
@@ -435,7 +435,6 @@ test('generates types for component queries defined in a route', async function 
 	// execute the generator
 	await generate({ config, documents: [], framework: 'kit', pluginRoot })
 
-
 	// load the contents of the file
 	const queryContents = await fs.readFile(
 		path.join(path.join(type_route_dir(config), 'myProfile', '$houdini.d.ts'))

--- a/packages/houdini-svelte/src/plugin/codegen/routes/kit.test.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/kit.test.ts
@@ -381,6 +381,117 @@ query MyPageQuery {
 	`)
 })
 
+test('generates types for component queries defined in a route', async function () {
+	await fs.mock({
+		[config.routesDir]: {
+			myProfile: {
+				'UserCard.svelte': `
+<script lang="ts">
+	import { graphql } from '$houdini';
+	import type { UserCardVariables } from './$houdini';
+
+	export let id: string;
+
+	export const _UserCardVariables: UserCardVariables = ({ props }) => {
+		return {
+			userId: props.id
+		};
+	};
+
+	$: data = graphql(\`
+		query UserCard($userId: ID!) {
+			user(id: $userId, snapshot: "UserCard") {
+				name
+			}
+		}
+	\`);
+</script>
+`,
+				'+page.svelte': `
+<script lang="ts">
+	import UserCard from './UserCard.svelte';
+</script>
+
+<UserCard id="1" />
+`,
+			},
+		},
+	})
+
+	await fs.mock({
+		[path.join(config.projectRoot, '.svelte-kit')]: {
+			types: {
+				src: {
+					routes: {
+						myProfile: {
+							'$types.d.ts': default_page_types,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	// execute the generator
+	await generate({ config, documents: [], framework: 'kit', pluginRoot })
+
+
+	// load the contents of the file
+	const queryContents = await fs.readFile(
+		path.join(path.join(type_route_dir(config), 'myProfile', '$houdini.d.ts'))
+	)
+
+	expect(queryContents).toBeTruthy()
+
+	const parsedQuery = await parseJS(queryContents!)
+
+	//verify contents
+	expect(parsedQuery).toMatchInlineSnapshot(`
+		import type * as Kit from "@sveltejs/kit";
+		import type { ComponentProps } from "svelte";
+		import UserCard from "./UserCard.svelte";
+		import type { UserCard$input } from "../../../artifacts/UserCard";
+
+		type Expand<T> = T extends infer O ? {
+		    [K in keyof O]: O[K];
+		} : never;
+
+		type RouteParams = {};
+		type MaybeWithVoid<T> = {} extends T ? T | void : T;
+
+		export type RequiredKeys<T> = {
+		    [K in keyof T]?: {} extends {
+		        [P in K]: T[K];
+		    } ? never : K;
+		}[keyof T];
+
+		type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>;
+		type EnsureDefined<T> = T extends null | undefined ? {} : T;
+
+		type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? {
+		    [P in Exclude<A, keyof U>]?: never;
+		} & U : never;
+
+		type PageParentData = EnsureDefined<import("../$houdini").LayoutData>;
+
+		type MakeOptional<Target, Keys extends keyof Target> = Omit<Target, Keys> & {
+		    [Key in Keys]?: Target[Key] | undefined | null;
+		};
+
+		export type PageServerData = null;
+		export type PageLoad<OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>> = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
+		export type PageLoadEvent = Parameters<PageLoad>[0];
+		export type PageData = Expand<Expand<Omit<PageParentData, keyof PageParentData & EnsureDefined<PageServerData>> & OptionalUnion<EnsureDefined<PageParentData & EnsureDefined<PageServerData>>>> & {}>;
+		type UserCardProps = ComponentProps<UserCard>;
+
+		export type UserCardVariables = <_Props extends UserCardProps>(
+		    args: {
+		        props: _Props;
+		    }
+		) => UserCard$input;
+	`)
+})
+
 test('generates types for layout onError', async function () {
 	// create the mock filesystem
 	await fs.mock({


### PR DESCRIPTION
Fixes #1131 

Types for component queries inside of the routes didn't get types generated properly. See issue for full explanation.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

