### PR TITLE
Fix cache read and write input param types being generated incorrectly

### DIFF
--- a/.changeset/red-feet-study.md
+++ b/.changeset/red-feet-study.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix cache read and write input param types being generated incorrectly

--- a/e2e/kit/src/routes/cache/+page.svelte
+++ b/e2e/kit/src/routes/cache/+page.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+  import { cache, graphql } from '$houdini';
+
+  // Query read without params
+  cache.read({
+    query: graphql(`
+      query CacheQueryRead {
+        usersList(snapshot: "Cache") {
+          id
+          name
+        }
+      }
+    `)
+  });
+
+  // Query read with params
+  cache.read({
+    query: graphql(`
+      query CacheQueryReadParams($userId: ID!) {
+        user(id: $userId, snapshot: "Cache") {
+          id
+          name
+          birthDate
+        }
+      }
+    `),
+    variables: {
+      userId: '1'
+    }
+  });
+
+  // Query write without params
+  cache.write({
+    query: graphql(`
+      query CacheQueryWrite {
+        user(id: 1, snapshot: "Cache") {
+          name
+        }
+      }
+    `),
+    data: {
+      user: { name: 'Harry' }
+    }
+  });
+
+  // Query write with params
+  cache.write({
+    query: graphql(`
+      query CacheQueryWriteParams($userId2: ID!) {
+        user(id: $userId2, snapshot: "Cache") {
+          name
+        }
+      }
+    `),
+    data: {
+      user: {
+        name: 'Harry'
+      }
+    },
+    variables: {
+      userId2: '1'
+    }
+  });
+
+  // Fragment read without params
+  cache.get('User', { id: '1' }).read({
+    fragment: graphql(`
+      fragment CacheFragmentRead on User {
+        name
+      }
+    `)
+  });
+
+  // Fragment write without params
+  cache.get('User', { id: '1' }).write({
+    fragment: graphql(`
+      fragment CacheFragmentWrite on User {
+        name
+      }
+    `),
+    data: {
+      name: 'Harry'
+    }
+  });
+</script>
+
+<p>
+  This route doesn't really do anything, it's just here to test the typings of
+  <code>cache.read</code> and <code>cache.write</code>.
+</p>

--- a/packages/houdini/src/runtime/public/types.ts
+++ b/packages/houdini/src/runtime/public/types.ts
@@ -131,6 +131,6 @@ export type QueryInput<List, _Target> = List extends [infer Head, ...infer Rest]
 	? Head extends [infer _Key, infer _Value, infer _Input]
 		? _Key extends _Target
 			? _Input
-			: QueryValue<Rest, _Target>
+			: QueryInput<Rest, _Target>
 		: 'Encountered unknown query.Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
 	: 'Encountered unknown query.Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'

--- a/packages/houdini/src/runtime/public/types.ts
+++ b/packages/houdini/src/runtime/public/types.ts
@@ -103,10 +103,31 @@ export type ListType<Def extends CacheTypeDef, Name extends ValidLists<Def>> = P
 // then typescript wasn't responding on every change... Having the duplication makes
 // it very responsive.
 
+/**
+ * Note on the `_Key extends _Target && _Target extends _Key` check:
+ * Sometimes two queries might have a similar shape/inputs, e.g.:
+ *
+ * query Query1($userId: ID!) {    |    query Query2($userId: ID!) {
+ *   user(id: $userId) {           |      user($id: $userId) {
+ *     id                          |        id
+ *     name                        |        name
+ *   }                             |        birthDate
+ * }                               |      }
+ *                                 |    }
+ *
+ * To TypeScript, it would look like Query2's result would extend Query1's result.
+ * But if Query2 was listed in front of Query1 in the queries array above, `_Key extends _Target` will evaluate to true,
+ * causing it to return Query2's input/result types, while you were looking for Query1's input/result types.
+ * The additional `_Target extends _Key` ensures that the two objects have exactly the same shape, at least prompting the
+ * user for the correct fields.
+ */
+
 export type FragmentVariables<_List, _Target> = _List extends [infer Head, ...infer Rest]
 	? Head extends [infer _Key, infer _Value, infer _Input]
 		? _Key extends _Target
-			? _Input
+			? _Target extends _Key
+				? _Input
+				: FragmentValue<Rest, _Target>
 			: FragmentValue<Rest, _Target>
 		: 'Encountered unknown fragment. Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
 	: 'Encountered unknown fragment. Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
@@ -114,7 +135,9 @@ export type FragmentVariables<_List, _Target> = _List extends [infer Head, ...in
 export type FragmentValue<List, _Target> = List extends [infer Head, ...infer Rest]
 	? Head extends [infer _Key, infer _Value, infer _Input]
 		? _Key extends _Target
-			? _Value
+			? _Target extends _Key
+				? _Value
+				: FragmentValue<Rest, _Target>
 			: FragmentValue<Rest, _Target>
 		: 'Encountered unknown fragment. Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
 	: 'Encountered unknown fragment. Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
@@ -122,7 +145,9 @@ export type FragmentValue<List, _Target> = List extends [infer Head, ...infer Re
 export type QueryValue<List, _Target> = List extends [infer Head, ...infer Rest]
 	? Head extends [infer _Key, infer _Value, infer _Input]
 		? _Key extends _Target
-			? _Value
+			? _Target extends _Key
+				? _Value
+				: QueryValue<Rest, _Target>
 			: QueryValue<Rest, _Target>
 		: 'Encountered unknown query.Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
 	: 'Encountered unknown query.Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
@@ -130,7 +155,9 @@ export type QueryValue<List, _Target> = List extends [infer Head, ...infer Rest]
 export type QueryInput<List, _Target> = List extends [infer Head, ...infer Rest]
 	? Head extends [infer _Key, infer _Value, infer _Input]
 		? _Key extends _Target
-			? _Input
+			? _Target extends _Key
+				? _Input
+				: QueryInput<Rest, _Target>
 			: QueryInput<Rest, _Target>
 		: 'Encountered unknown query.Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
 	: 'Encountered unknown query.Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'


### PR DESCRIPTION
Fixes #1129 

The type definition of QueryInput used QueryValue, which resulted into it becoming `MyQuery$result`, instead of the expected `MyQuery$input`.

I'm not 100% sure how to write a proper test for this, suggestions welcome 🙂 

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

