### PR TITLE
Fix bug when structured values are used for fragment variables 

### DIFF
--- a/.changeset/mean-bikes-allow.md
+++ b/.changeset/mean-bikes-allow.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+fixed a bug when fragment variables were set to structured values

--- a/packages/houdini/src/codegen/generators/artifacts/index.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/index.ts
@@ -415,6 +415,7 @@ export default function artifactGenerator(stats: {
 
 					// the artifact should be the default export of the file
 					const _houdiniHash = hashOriginal({ document: doc })
+
 					const file = AST.program([
 						moduleExport(config, 'default', serializeValue(artifact)),
 						AST.expressionStatement(AST.stringLiteral(`HoudiniHash=${_houdiniHash}`)),

--- a/packages/houdini/src/codegen/generators/artifacts/selection.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/selection.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../runtime/lib/types'
 import { connectionSelection } from '../../transforms/list'
 import fieldKey from './fieldKey'
-import { convertValue, serializeValue } from './utils'
+import { convertValue } from './utils'
 
 // we're going to generate the selection in two passes. the first will create the various field selections
 // and then the second will map the concrete selections onto the abstract ones

--- a/packages/houdini/src/codegen/generators/artifacts/selection.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/selection.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../runtime/lib/types'
 import { connectionSelection } from '../../transforms/list'
 import fieldKey from './fieldKey'
-import { convertValue } from './utils'
+import { convertValue, serializeValue } from './utils'
 
 // we're going to generate the selection in two passes. the first will create the various field selections
 // and then the second will map the concrete selections onto the abstract ones

--- a/packages/houdini/src/codegen/generators/artifacts/utils.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/utils.ts
@@ -17,10 +17,13 @@ export function serializeValue(value: any): ExpressionKind {
 	if (typeof value === 'object' && value !== null) {
 		return AST.objectExpression(
 			Object.entries(value)
-				.filter(([, value]) => typeof value !== 'undefined')
-				.map(([key, value]) =>
-					AST.objectProperty(AST.stringLiteral(key), serializeValue(value))
+				.filter(
+					([key, value]) =>
+						typeof value !== 'undefined' && key !== 'prev' && key !== 'next'
 				)
+				.map(([key, val]) => {
+					return AST.objectProperty(AST.stringLiteral(key), serializeValue(val))
+				})
 		)
 	}
 

--- a/packages/houdini/src/test/index.ts
+++ b/packages/houdini/src/test/index.ts
@@ -15,6 +15,10 @@ export function testConfigFile({ plugins, ...config }: Partial<ConfigFile> = {})
 
 			directive @live on QUERY
 
+			input MyInput {
+				string: String
+			}
+
 			type User implements Node & Friend & CatOwner {
 				id: ID!
 				name: String!


### PR DESCRIPTION
Fixes #1165 

This PR fixes a bug when fragment variables were set to structured elements

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

