### PR TITLE
Fix typings of `loadAll()` function

### DIFF
--- a/.changeset/soft-toes-learn.md
+++ b/.changeset/soft-toes-learn.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix typings of loadAll() function

--- a/e2e/kit/src/lib/utils/routes.ts
+++ b/e2e/kit/src/lib/utils/routes.ts
@@ -34,6 +34,7 @@ export const routes = {
   Stores_Mutation_Scalar_Multi_Upload: '/stores/mutation-scalar-multi-upload',
   Stores_Mutation_Enums: '/stores/mutation-enums',
   Stores_Network_One_Store_Multivariables: '/stores/network-one-store-multivariables',
+  Stores_SSR_LoadAll_Store_Without_Variables: '/stores/ssr-loadall-store-without-variables',
   Stores_SSR_One_Store_Multivariables: '/stores/ssr-one-store-multivariables',
   Stores_Fragment_Null: '/stores/fragment-null',
   Stores_Metadata: '/stores/metadata',

--- a/e2e/kit/src/routes/stores/ssr-loadall-store-without-variables/+page.svelte
+++ b/e2e/kit/src/routes/stores/ssr-loadall-store-without-variables/+page.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { HelloStore } from '$houdini';
+  import type { PageData } from './$houdini';
+
+  export let data: PageData;
+
+  $: ({ Hello } = data);
+
+  const checkTypes = () => {
+    return (
+      `${data.Hello instanceof HelloStore}`
+    );
+  };
+</script>
+
+<h1>ssr-loadall-store-without-variables</h1>
+
+<div id="result">
+  {$Hello.data?.hello}
+</div>
+
+<div id="result-types">
+  {checkTypes()}
+</div>

--- a/e2e/kit/src/routes/stores/ssr-loadall-store-without-variables/+page.svelte
+++ b/e2e/kit/src/routes/stores/ssr-loadall-store-without-variables/+page.svelte
@@ -7,9 +7,7 @@
   $: ({ Hello } = data);
 
   const checkTypes = () => {
-    return (
-      `${data.Hello instanceof HelloStore}`
-    );
+    return `${data.Hello instanceof HelloStore}`;
   };
 </script>
 

--- a/e2e/kit/src/routes/stores/ssr-loadall-store-without-variables/+page.ts
+++ b/e2e/kit/src/routes/stores/ssr-loadall-store-without-variables/+page.ts
@@ -1,0 +1,6 @@
+import { load_Hello, loadAll } from '$houdini';
+import type { LoadEvent } from '@sveltejs/kit';
+
+export async function load(event: LoadEvent) {
+  return await loadAll(load_Hello({ event }));
+}

--- a/e2e/kit/src/routes/stores/ssr-loadall-store-without-variables/spec.ts
+++ b/e2e/kit/src/routes/stores/ssr-loadall-store-without-variables/spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test';
+import { routes } from '../../../lib/utils/routes.js';
+import { expect_to_be, goto } from '../../../lib/utils/testsHelper.js';
+
+test.describe('ssr-loadall-store-without-variables Page', () => {
+  test('loadAll should brings correct types', async ({ page }) => {
+    await goto(page, routes.Stores_SSR_LoadAll_Store_Without_Variables);
+
+    await expect_to_be(page, 'true', 'div[id=result-types]');
+  });
+});

--- a/packages/houdini-svelte/src/runtime/index.ts
+++ b/packages/houdini-svelte/src/runtime/index.ts
@@ -1,3 +1,4 @@
+import type { GraphQLVariables } from '$houdini/runtime/lib/types'
 import type { QueryStore } from './stores'
 
 export * from './adapter'
@@ -6,7 +7,7 @@ export * from './fragments'
 export * from './session'
 export * from './types'
 
-type LoadResult = Promise<{ [key: string]: QueryStore<any, {}> }>
+type LoadResult = Promise<{ [key: string]: QueryStore<any, GraphQLVariables> }>
 type LoadAllInput = LoadResult | Record<string, LoadResult>
 
 // gets all the values from an object


### PR DESCRIPTION
Fixes #1208

This PR fixes the typings of the `loadAll()` function. 

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

