### PR TITLE
Fix plugin runtime search

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -6,7 +6,7 @@ on:
     push:
         branches:
             - next
-            - component-fields
+            - plugin-runtime-search
 
 env:
     CI: true

--- a/packages/houdini-react/src/runtime/routing/Router.tsx
+++ b/packages/houdini-react/src/runtime/routing/Router.tsx
@@ -167,14 +167,11 @@ function usePageData({
 			last_variables.set(artifact, variables)
 		}
 
-		console.log('loading query', artifact.name)
-
 		// TODO: AbortController on send()
 		// TODO: we can read from cache here before making an asynchronous network call
 
 		// if there is a pending request and we were asked to load, don't do anything
 		if (ssr_signals.has(id)) {
-			console.log('using ssr signal', id)
 			return ssr_signals.get(id)!
 		}
 
@@ -187,7 +184,6 @@ function usePageData({
 			resolve = res
 			reject = rej
 
-			console.log('sending query', id, variables)
 			observer
 				.send({
 					variables: variables,
@@ -195,7 +191,6 @@ function usePageData({
 					session,
 				})
 				.then(() => {
-					console.log('resolved query', id, variables)
 					data_cache.set(id, observer)
 
 					// if we are building up a stream (on the server), we want to add something
@@ -255,7 +250,6 @@ function usePageData({
 									}
 
 
-									console.log('clearing ssr signal', artifactName)
 									// trigger the signal
 									window.__houdini__nav_caches__.ssr_signals.get(artifactName).resolve()
 									window.__houdini__nav_caches__.ssr_signals.delete(artifactName)

--- a/packages/houdini/src/codegen/generators/runtime/pluginRuntime.ts
+++ b/packages/houdini/src/codegen/generators/runtime/pluginRuntime.ts
@@ -1,0 +1,67 @@
+import { moduleStatments } from '.'
+import type { Config, Document } from '../../../lib'
+import { fs, HoudiniError, path, houdini_mode } from '../../../lib'
+
+export async function generatePluginRuntimes({
+	config,
+	docs,
+}: {
+	config: Config
+	docs: Document[]
+}) {
+	if (houdini_mode.is_testing) {
+		return
+	}
+
+	// generate the import statements
+	const { importStatement, exportDefaultStatement, exportStarStatement } = moduleStatments(config)
+
+	// generate the runtime for each plugin
+	await Promise.all(
+		config.plugins
+			.filter((plugin) => plugin.includeRuntime)
+			.map(async (plugin) => {
+				// a plugin has told us to include a runtime then the path is relative to the plugin file
+				const runtime_path = config.pluginRuntimeSource(plugin)
+				if (!runtime_path) {
+					return
+				}
+
+				// make sure the source file exists
+				try {
+					await fs.stat(runtime_path)
+				} catch {
+					throw new HoudiniError({
+						message: 'Cannot find runtime to generate for ' + plugin.name,
+						description: 'Maybe it was bundled?',
+					})
+				}
+
+				// copy the runtime
+				const pluginDir = config.pluginRuntimeDirectory(plugin.name)
+				let transformMap = plugin.transformRuntime ?? {}
+				if (transformMap && typeof transformMap === 'function') {
+					transformMap = transformMap(docs, { config })
+				}
+
+				await fs.mkdirp(pluginDir)
+				await fs.recursiveCopy(
+					runtime_path,
+					pluginDir,
+					Object.fromEntries(
+						Object.entries(transformMap).map(([key, value]) => [
+							path.join(runtime_path, key),
+							(content) =>
+								value({
+									config,
+									content,
+									importStatement,
+									exportDefaultStatement,
+									exportStarStatement,
+								}),
+						])
+					)
+				)
+			})
+	)
+}

--- a/packages/houdini/src/codegen/index.ts
+++ b/packages/houdini/src/codegen/index.ts
@@ -4,16 +4,11 @@ import type { Config, PluginHooks, Document, LogLevels } from '../lib'
 import { runPipeline as run, LogLevel, find_graphql, parseJS, HoudiniError, fs, path } from '../lib'
 import { ArtifactKind, type ArtifactKinds } from '../runtime/lib/types'
 import * as generators from './generators'
-import { generatePluginRuntimes } from './generators/runtime'
 import * as transforms from './transforms'
 import * as validators from './validators'
 
 // the main entry point of the compile script
 export default async function compile(config: Config) {
-	// before we collect the documents, we need to generate the plugin runtimes
-	// so that they can include documents in the user's project
-	await generatePluginRuntimes({ config })
-
 	// grab the graphql documents
 	const documents = await collectDocuments(config)
 

--- a/packages/houdini/src/lib/config.test.ts
+++ b/packages/houdini/src/lib/config.test.ts
@@ -119,6 +119,9 @@ test('Config.include includes plugin runtimes', () => {
 	]
 
 	// make sure we are including the plugin runtime
-	const includePath = path.relative(config.projectRoot, config.pluginDirectory('test-plugin'))
+	const includePath = path.relative(
+		config.projectRoot,
+		config.pluginRuntimeSource(config.plugins[0])!
+	)
 	expect(config.include.some((path) => path.includes(includePath))).toBeTruthy()
 })

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -202,13 +202,15 @@ export class Config {
 		// if any of the plugins specify included runtimes then their paths might have
 		// documents
 		for (const plugin of this.plugins) {
+			const runtimeDir = this.pluginRuntimeSource(plugin)
+
 			// skip plugins that dont' include runtimes
-			if (!plugin.includeRuntime) {
+			if (!runtimeDir) {
 				continue
 			}
 
 			// the include path is relative to root of the vite project
-			const includePath = path.relative(this.projectRoot, this.pluginDirectory(plugin.name))
+			const includePath = path.relative(this.projectRoot, runtimeDir)
 
 			// add the plugin's directory to the include pile
 			include.push(`${includePath}/**/*{${extensions.join(',')}}`)
@@ -278,6 +280,19 @@ export class Config {
 
 		// we're done
 		return headers
+	}
+
+	pluginRuntimeSource(plugin: PluginMeta) {
+		if (!plugin.includeRuntime) {
+			return null
+		}
+
+		return path.join(
+			path.dirname(plugin.filepath),
+			typeof plugin.includeRuntime === 'string'
+				? plugin.includeRuntime
+				: plugin.includeRuntime?.[this.module]
+		)
 	}
 
 	async sourceFiles() {


### PR DESCRIPTION
This PR fixes a bug reported in discord that was caused by https://github.com/HoudiniGraphql/houdini/pull/1223. The end behavior is the same now but the runtime is only generated once (at the end like before) instead of multiple times with different content which was causing an infinite loop with `watch-and-run`.