### PR TITLE
Optimize cache subscriptions

### DIFF
--- a/.changeset/three-comics-greet.md
+++ b/.changeset/three-comics-greet.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Optimize cache subscriptions

--- a/packages/houdini/src/runtime/cache/subscription.ts
+++ b/packages/houdini/src/runtime/cache/subscription.ts
@@ -354,9 +354,7 @@ export class InMemorySubscriptions {
 
 	reset() {
 		// Get all subscriptions that do not start with the rootID
-		const subscribers = [...this.subscribers.entries()].filter(
-			([id]) => !id.startsWith(rootID)
-		)
+		const subscribers = [...this.subscribers.entries()].filter(([id]) => !id.startsWith(rootID))
 
 		// Remove those subcribers from this.subscribers
 		for (const [id, _fields] of subscribers) {


### PR DESCRIPTION
Fixes (can make an issue if needed)

Improves the performance of the functions related to cache subscriptions. Profiling with a large table for a work project resulted in roughly 50% less CPU time (the table uses many subscriptions, this made it go from ~500ms to ~220ms). Most of the improvement comes from line 156, replacing the `map()` and `includes()` with `some()`.

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

