### PR TITLE
Allow for required arguments on paginated fragments

### DIFF
--- a/.changeset/neat-cameras-pay.md
+++ b/.changeset/neat-cameras-pay.md
@@ -1,0 +1,6 @@
+---
+'houdini-svelte': patch
+'houdini': patch
+---
+
+Add support for required arguments in paginated fragments

--- a/e2e/_api/graphql.mjs
+++ b/e2e/_api/graphql.mjs
@@ -260,6 +260,9 @@ export const resolvers = {
 		usersConnection: (user, args) => {
 			return connectionFromArray(getUserSnapshot(user.snapshot), args)
 		},
+		usersConnectionSnapshot: (user, args) => {
+			return connectionFromArray(getUserSnapshot(args.snapshot), args)
+		},
 		userSearch: (_, args) => {
 			const allUsers = [...getUserSnapshot(args.snapshot)]
 
@@ -270,11 +273,11 @@ export const resolvers = {
 		enumValue: () => 'Value1',
 		testField: (user, args) => {
 			if (args.someParam) {
-				return "Hello world";
+				return 'Hello world'
 			}
 
-			return null;
-		}
+			return null
+		},
 	},
 
 	Mutation: {

--- a/e2e/_api/schema.graphql
+++ b/e2e/_api/schema.graphql
@@ -105,6 +105,7 @@ type User implements Node {
 	friendsConnection(after: String, before: String, first: Int, last: Int): UserConnection!
 	"This is the same list as what's used globally. its here to tests fragments"
 	usersConnection(after: String, before: String, first: Int, last: Int): UserConnection!
+    usersConnectionSnapshot(after: String, before: String, first: Int, last: Int, snapshot: String!): UserConnection!
 	"This is the same list as what's used globally. its here to tests fragments"
 	userSearch(filter: UserNameFilter!, snapshot: String!): [User!]!
 	friendsList(limit: Int, offset: Int): [User!]!

--- a/e2e/kit/src/lib/utils/routes.ts
+++ b/e2e/kit/src/lib/utils/routes.ts
@@ -98,6 +98,7 @@ export const routes = {
   Pagination_fragment_backwards_cursor: '/pagination/fragment/backwards-cursor',
   Pagination_fragment_bidirectional_cursor: '/pagination/fragment/bidirectional-cursor',
   Pagination_fragment_offset: '/pagination/fragment/offset',
+  Pagination_fragment_required_arguments: '/pagination/fragment/required-arguments',
 
   nested_argument_fragments: '/nested-argument-fragments',
   nested_argument_fragments_masking: '/nested-argument-fragments-masking',

--- a/e2e/kit/src/routes/pagination/fragment/required-arguments/+page.svelte
+++ b/e2e/kit/src/routes/pagination/fragment/required-arguments/+page.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import { graphql, paginatedFragment } from '$houdini';
+
+  $: queryResult = graphql(`
+    query UserFragmentRequiredArgsQuery(
+      $snapshot: String! = "pagination-fragment-required-arguments"
+    ) @load {
+      user(id: "1", snapshot: $snapshot) {
+        id
+        name
+
+        ...TestFragment @with(snapshot: $snapshot)
+      }
+    }
+  `);
+
+  $: fragmentResult = paginatedFragment(
+    $queryResult.data?.user ?? null,
+    graphql(`
+      fragment TestFragment on User @arguments(snapshot: { type: "String!" }) {
+        usersConnectionSnapshot(first: 2, snapshot: $snapshot) @paginate {
+          edges {
+            node {
+              id
+              name
+            }
+          }
+        }
+      }
+    `)
+  );
+</script>
+
+<div id="result">
+  {$fragmentResult.data?.usersConnectionSnapshot.edges.map(({ node }) => node?.name).join(', ')}
+</div>
+
+<button id="next" on:click={() => fragmentResult.loadNextPage()}>next</button>

--- a/e2e/kit/src/routes/pagination/fragment/required-arguments/+page.svelte
+++ b/e2e/kit/src/routes/pagination/fragment/required-arguments/+page.svelte
@@ -35,4 +35,8 @@
   {$fragmentResult.data?.usersConnectionSnapshot.edges.map(({ node }) => node?.name).join(', ')}
 </div>
 
+<div id="pageInfo">
+  {JSON.stringify($fragmentResult.pageInfo)}
+</div>
+
 <button id="next" on:click={() => fragmentResult.loadNextPage()}>next</button>

--- a/e2e/kit/src/routes/pagination/fragment/required-arguments/spec.ts
+++ b/e2e/kit/src/routes/pagination/fragment/required-arguments/spec.ts
@@ -1,0 +1,48 @@
+import { routes } from '$lib/utils/routes';
+import {
+  expectToContain,
+  expect_0_gql,
+  expect_1_gql,
+  expect_to_be,
+  goto
+} from '$lib/utils/testsHelper';
+import test from '@playwright/test';
+
+test.describe('forwards cursor paginatedFragment with required arguments', () => {
+  test('loadNextPage', async ({ page }) => {
+    await goto(page, routes.Pagination_fragment_required_arguments);
+    await expect_to_be(page, 'Bruce Willis, Samuel Jackson');
+
+    // wait for the api response
+    await expect_1_gql(page, 'button[id=next]');
+
+    // make sure we got the new content
+    await expect_to_be(page, 'Bruce Willis, Samuel Jackson, Morgan Freeman, Tom Hanks');
+  });
+
+  test('page info tracks connection state', async ({ page }) => {
+    await goto(page, routes.Pagination_fragment_required_arguments);
+
+    const data = [
+      'Bruce Willis, Samuel Jackson, Morgan Freeman, Tom Hanks',
+      'Bruce Willis, Samuel Jackson, Morgan Freeman, Tom Hanks, Will Smith, Harrison Ford',
+      'Bruce Willis, Samuel Jackson, Morgan Freeman, Tom Hanks, Will Smith, Harrison Ford, Eddie Murphy, Clint Eastwood'
+    ];
+
+    // load the next 3 pages
+    for (let i = 0; i < 3; i++) {
+      // wait for the request to resolve
+      await expect_1_gql(page, 'button[id=next]');
+
+      // check the page info
+      await expect_to_be(page, data[i]);
+    }
+
+    // make sure we have all of the data loaded
+    await expect_to_be(page, data[2]);
+
+    await expectToContain(page, `"hasNextPage":false`);
+
+    await expect_0_gql(page, 'button[id=next]');
+  });
+});

--- a/e2e/kit/src/routes/pagination/fragment/required-arguments/spec.ts
+++ b/e2e/kit/src/routes/pagination/fragment/required-arguments/spec.ts
@@ -1,12 +1,12 @@
-import { routes } from '$lib/utils/routes';
+import { test } from '@playwright/test';
+import { routes } from '../../../../lib/utils/routes.js';
 import {
   expectToContain,
   expect_0_gql,
   expect_1_gql,
   expect_to_be,
   goto
-} from '$lib/utils/testsHelper';
-import test from '@playwright/test';
+} from '../../../../lib/utils/testsHelper.js';
 
 test.describe('forwards cursor paginatedFragment with required arguments', () => {
   test('loadNextPage', async ({ page }) => {

--- a/packages/houdini-svelte/src/plugin/artifactData.test.ts
+++ b/packages/houdini-svelte/src/plugin/artifactData.test.ts
@@ -131,7 +131,8 @@ describe('load', () => {
 			            "id": "ID"
 			        },
 
-			        "types": {}
+			        "types": {},
+			        "defaults": {}
 			    },
 
 			    "policy": "CacheOrNetwork",

--- a/packages/houdini-svelte/src/runtime/stores/query.ts
+++ b/packages/houdini-svelte/src/runtime/stores/query.ts
@@ -161,13 +161,20 @@ This will result in duplicate queries. If you are trying to ensure there is alwa
 		// we might not want to actually wait for the fetch to resolve
 		const fakeAwait = clientStarted && isBrowser && !need_to_block
 
+		// spreading the default variables frist so that if the user provides one of these params themselves,
+		// those params get overwritten with the correct value
+		const usedVariables = {
+			...this.artifact.input?.defaults,
+			...params.variables,
+		}
+
 		// we want to try to load cached data before we potentially fake the await
 		// this makes sure that the UI feels snappy as we click between cached pages
 		// (no loaders)
 		if (policy !== CachePolicy.NetworkOnly && fakeAwait) {
 			await this.observer.send({
 				fetch: context.fetch,
-				variables: params.variables,
+				variables: usedVariables,
 				metadata: params.metadata,
 				session: context.session,
 				policy: CachePolicy.CacheOnly,
@@ -181,7 +188,7 @@ This will result in duplicate queries. If you are trying to ensure there is alwa
 		// since CacheOrNetwork behaves the same as CacheAndNetwork
 		const request = this.observer.send({
 			fetch: context.fetch,
-			variables: params.variables,
+			variables: usedVariables,
 			metadata: params.metadata,
 			session: context.session,
 			policy: policy,

--- a/packages/houdini/src/codegen/generators/artifacts/tests/artifacts.test.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/tests/artifacts.test.ts
@@ -6895,7 +6895,7 @@ describe('default arguments', function () {
 		`)
 	})
 
-	test('handles complext default arguments', async function () {
+	test('handles complex default arguments', async function () {
 		// the config to use in tests
 		const config = testConfig()
 		// the documents to test

--- a/packages/houdini/src/codegen/generators/artifacts/tests/pagination.test.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/tests/pagination.test.ts
@@ -199,7 +199,11 @@ test('pagination arguments stripped from key', async function () {
 		            "before": "String"
 		        },
 
-		        "types": {}
+		        "types": {},
+
+		        "defaults": {
+		            "first": 10
+		        }
 		    }
 		};
 
@@ -406,7 +410,11 @@ test('pagination arguments stays in key as it s a SinglePage Mode', async functi
 		            "before": "String"
 		        },
 
-		        "types": {}
+		        "types": {},
+
+		        "defaults": {
+		            "first": 10
+		        }
 		    }
 		};
 
@@ -506,7 +514,11 @@ test('offset based pagination marks appropriate field', async function () {
 		            "offset": "Int"
 		        },
 
-		        "types": {}
+		        "types": {},
+
+		        "defaults": {
+		            "limit": 10
+		        }
 		    }
 		};
 
@@ -768,7 +780,11 @@ test('cursor as scalar gets the right pagination query argument types', async fu
 		            "before": "Cursor"
 		        },
 
-		        "types": {}
+		        "types": {},
+
+		        "defaults": {
+		            "first": 10
+		        }
 		    },
 
 		    "policy": "CacheOrNetwork",
@@ -1132,7 +1148,11 @@ test("sibling aliases don't get marked", async function () {
 		            "before": "String"
 		        },
 
-		        "types": {}
+		        "types": {},
+
+		        "defaults": {
+		            "first": 10
+		        }
 		    }
 		};
 

--- a/packages/houdini/src/codegen/generators/typescript/typescript.test.ts
+++ b/packages/houdini/src/codegen/generators/typescript/typescript.test.ts
@@ -262,6 +262,7 @@ describe('typescript', function () {
 			            "name": "ID";
 			        };
 			        "types": {};
+			        "defaults": {};
 			    };
 			};
 		`)
@@ -351,6 +352,7 @@ describe('typescript', function () {
 			            "name": "ID";
 			        };
 			        "types": {};
+			        "defaults": {};
 			    };
 			};
 		`)
@@ -862,6 +864,7 @@ describe('typescript', function () {
 			            "enum": "MyEnum";
 			        };
 			        "types": {};
+			        "defaults": {};
 			    };
 			    "policy": "CacheOrNetwork";
 			    "partial": false;
@@ -1124,6 +1127,7 @@ describe('typescript', function () {
 			                "enum": "MyEnum";
 			            };
 			        };
+			        "defaults": {};
 			    };
 			};
 		`)
@@ -1351,6 +1355,7 @@ describe('typescript', function () {
 			                "enum": "MyEnum";
 			            };
 			        };
+			        "defaults": {};
 			    };
 			    "policy": "CacheOrNetwork";
 			    "partial": false;
@@ -2283,6 +2288,7 @@ describe('typescript', function () {
 			            "date": "DateTime";
 			        };
 			        "types": {};
+			        "defaults": {};
 			    };
 			    "policy": "CacheOrNetwork";
 			    "partial": false;
@@ -2686,6 +2692,7 @@ describe('typescript', function () {
 			                "enum": "MyEnum";
 			            };
 			        };
+			        "defaults": {};
 			    };
 			};
 		`)
@@ -2801,7 +2808,8 @@ describe('typescript', function () {
 			            "id": "ID"
 			        },
 
-			        "types": {}
+			        "types": {},
+			        "defaults": {}
 			    },
 
 			    "policy": "CacheOrNetwork",

--- a/packages/houdini/src/codegen/transforms/fragmentVariables.test.ts
+++ b/packages/houdini/src/codegen/transforms/fragmentVariables.test.ts
@@ -518,7 +518,8 @@ test('thread query variables to inner fragments', async function () {
 		            "name": "String"
 		        },
 
-		        "types": {}
+		        "types": {},
+		        "defaults": {}
 		    },
 
 		    "policy": "CacheOrNetwork",
@@ -1022,7 +1023,12 @@ test('persists fragment variables in artifact', async function () {
 		            "cool": "Boolean"
 		        },
 
-		        "types": {}
+		        "types": {},
+
+		        "defaults": {
+		            "name": "Hello",
+		            "cool": true
+		        }
 		    }
 		};
 
@@ -1196,7 +1202,8 @@ test('variables referenced deeply in objects', async function () {
 		            "name": "String"
 		        },
 
-		        "types": {}
+		        "types": {},
+		        "defaults": {}
 		    }
 		};
 

--- a/packages/houdini/src/codegen/transforms/fragmentVariables.ts
+++ b/packages/houdini/src/codegen/transforms/fragmentVariables.ts
@@ -122,7 +122,7 @@ function inlineFragmentArgs({
 	 * ```
 	 *
 	 * It replaced every VariableNode with its explicit value. If there is not argument provided,
-	 * error if the argument is required or delete the node if the argument is optional.
+	 * delete the node if the argument is optional.
 	 *
 	 * @param node any ValueNode
 	 * @returns the node where all variable nodes get replaced with their explicit values. And null if the argument is optional and not set
@@ -168,12 +168,9 @@ function inlineFragmentArgs({
 			return newValue
 		}
 
-		// if the argument is required
+		// if the argument is required, make sure we keep it
 		if (definitionArgs[node.name.value] && definitionArgs[node.name.value].required) {
-			throw new HoudiniError({
-				filepath,
-				message: 'Missing value for required arg: ' + node.name.value,
-			})
+			return node
 		}
 
 		// The argument is optional and not set in parent => delete the node.

--- a/packages/houdini/src/codegen/transforms/paginate.test.ts
+++ b/packages/houdini/src/codegen/transforms/paginate.test.ts
@@ -742,7 +742,11 @@ test('embeds node pagination query as a separate document', async function () {
 		            "id": "ID"
 		        },
 
-		        "types": {}
+		        "types": {},
+
+		        "defaults": {
+		            "first": 10
+		        }
 		    },
 
 		    "policy": "CacheOrNetwork",
@@ -1013,7 +1017,11 @@ test('embeds custom pagination query as a separate document', async function () 
 		            "aka": "String"
 		        },
 
-		        "types": {}
+		        "types": {},
+
+		        "defaults": {
+		            "first": 10
+		        }
 		    },
 
 		    "policy": "CacheOrNetwork",
@@ -1797,7 +1805,12 @@ test('generated query has same refetch spec', async function () {
 		            "before": "String"
 		        },
 
-		        "types": {}
+		        "types": {},
+
+		        "defaults": {
+		            "first": 10,
+		            "after": "1234"
+		        }
 		    },
 
 		    "policy": "CacheOrNetwork",
@@ -2056,7 +2069,11 @@ test('default defaultPaginateMode to SinglePage', async function () {
 		            "before": "String"
 		        },
 
-		        "types": {}
+		        "types": {},
+
+		        "defaults": {
+		            "first": 10
+		        }
 		    }
 		};
 

--- a/packages/houdini/src/codegen/transforms/paginate.test.ts
+++ b/packages/houdini/src/codegen/transforms/paginate.test.ts
@@ -323,6 +323,71 @@ test('paginate adds backwards cursor args to the fragment', async function () {
 	`)
 })
 
+test('adds required fragment args to pagination query', async function () {
+	const docs = [
+		mockCollectedDoc(
+			`
+                fragment PaginatedFragment on User @arguments(snapshot: { type: "String!" }) {
+                    friendsByCursorSnapshot(first: 2, snapshot: $snapshot) @paginate {
+                        edges {
+                            node {
+                                id
+                                name
+                            }
+                        }
+                    }
+                }
+			`
+		),
+	]
+
+	// run the pipeline
+	const config = testConfig()
+	await runPipeline(config, docs)
+
+	// load the contents of the file
+	expect(docs[1]?.document).toMatchInlineSnapshot(`
+		query PaginatedFragment_Pagination_Query($snapshot: String!, $first: Int = 2, $after: String, $last: Int, $before: String, $id: ID!) {
+		  node(id: $id) {
+		    __typename
+		    id
+		    ...PaginatedFragment_2XQ2zF @with(snapshot: $snapshot, first: $first, after: $after, last: $last, before: $before) @mask_disable
+		  }
+		}
+
+		fragment PaginatedFragment_2XQ2zF on User @arguments(snapshot: {type: "String!"}, first: {type: "Int", default: 2}, after: {type: "String"}, last: {type: "Int"}, before: {type: "String"}) {
+		  friendsByCursorSnapshot(
+		    first: $first
+		    snapshot: $snapshot
+		    after: $after
+		    last: $last
+		    before: $before
+		  ) @paginate {
+		    edges {
+		      node {
+		        id
+		        name
+		      }
+		    }
+		    edges {
+		      cursor
+		      node {
+		        __typename
+		      }
+		    }
+		    pageInfo {
+		      hasPreviousPage
+		      hasNextPage
+		      startCursor
+		      endCursor
+		    }
+		  }
+		  id
+		  __typename
+		}
+	`)
+})
+
 test('sets before with default value', async function () {
 	const docs = [
 		mockCollectedDoc(

--- a/packages/houdini/src/codegen/validators/typeCheck.test.ts
+++ b/packages/houdini/src/codegen/validators/typeCheck.test.ts
@@ -779,8 +779,8 @@ const table: Row[] = [
 		],
 	},
 	{
-		title: "@paginate can't show up in a document with required args",
-		pass: false,
+		title: "@paginate can show up in a document with required args",
+		pass: true,
 		documents: [
 			`
 			fragment UserPaginatedA on User @arguments(foo: { type: "String!" }) {

--- a/packages/houdini/src/codegen/validators/typeCheck.test.ts
+++ b/packages/houdini/src/codegen/validators/typeCheck.test.ts
@@ -779,7 +779,7 @@ const table: Row[] = [
 		],
 	},
 	{
-		title: "@paginate can show up in a document with required args",
+		title: '@paginate can show up in a document with required args',
 		pass: true,
 		documents: [
 			`

--- a/packages/houdini/src/codegen/validators/typeCheck.ts
+++ b/packages/houdini/src/codegen/validators/typeCheck.ts
@@ -860,27 +860,6 @@ function paginateArgs(config: Config, filepath: string) {
 				// make sure we fail if we see another paginated field
 				alreadyPaginated = true
 
-				// find the definition containing the directive
-				const { definition } = definitionFromAncestors(ancestors)
-
-				// look at the fragment arguments
-				const definitionArgs = collectFragmentArguments(
-					config,
-					filepath,
-					definition as graphql.FragmentDefinitionNode
-				)
-
-				// a fragment marked for pagination can't have required args
-				const hasRequiredArgs = definitionArgs.find((arg) => arg.required)
-				if (hasRequiredArgs) {
-					ctx.reportError(
-						new graphql.GraphQLError(
-							'@paginate cannot appear on a document with required args'
-						)
-					)
-					return
-				}
-
 				// look at the field the directive is applied to
 				const targetFieldType = parentTypeFromAncestors(
 					config.schema,

--- a/packages/houdini/src/runtime/cache/tests/variables.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/variables.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, describe } from 'vitest'
 
 import type { GraphQLObject, ValueMap } from '../../lib/types'
-import { evaluateFragmentVariables } from '../cache'
+import { evaluateVariables } from '../cache'
 
 describe('evaluateFragmentVariables', function () {
 	const table: { title: string; input: ValueMap; variables: GraphQLObject; expected: any }[] = [
@@ -122,7 +122,7 @@ describe('evaluateFragmentVariables', function () {
 
 	for (const row of table) {
 		test(row.title, function () {
-			expect(evaluateFragmentVariables(row.input, row.variables)).toEqual(row.expected)
+			expect(evaluateVariables(row.input, row.variables)).toEqual(row.expected)
 		})
 	}
 })

--- a/packages/houdini/src/runtime/lib/types.ts
+++ b/packages/houdini/src/runtime/lib/types.ts
@@ -94,6 +94,7 @@ export type RefetchUpdateModes = ValuesOf<typeof RefetchUpdateMode>
 export type InputObject = {
 	fields: Record<string, string>
 	types: Record<string, Record<string, string>>
+	defaults: Record<string, any>
 }
 
 export type BaseCompiledDocument<_Kind extends ArtifactKinds> = {

--- a/packages/houdini/src/test/index.ts
+++ b/packages/houdini/src/test/index.ts
@@ -26,7 +26,7 @@ export function testConfigFile({ plugins, ...config }: Partial<ConfigFile> = {})
 				firstName: String!
 				friends: [User!]!
 				friendsByCursor(first: Int, after: String, last: Int, before: String, filter: String): UserConnection!
-                friendsByCursorSnapshot(snapshot: String!, first: Int, after: String, last: Int, before: String): UserConnection!
+				friendsByCursorSnapshot(snapshot: String!, first: Int, after: String, last: Int, before: String): UserConnection!
 				friendsByCursorScalar(first: Int, after: Cursor, last: Int, before: Cursor, filter: String): UserConnection!
 				friendsByBackwardsCursor(last: Int, before: String, filter: String): UserConnectionScalar!
 				friendsByForwardsCursor(first: Int, after: String, filter: String): UserConnection!

--- a/packages/houdini/src/test/index.ts
+++ b/packages/houdini/src/test/index.ts
@@ -26,6 +26,7 @@ export function testConfigFile({ plugins, ...config }: Partial<ConfigFile> = {})
 				firstName: String!
 				friends: [User!]!
 				friendsByCursor(first: Int, after: String, last: Int, before: String, filter: String): UserConnection!
+                friendsByCursorSnapshot(snapshot: String!, first: Int, after: String, last: Int, before: String): UserConnection!
 				friendsByCursorScalar(first: Int, after: Cursor, last: Int, before: Cursor, filter: String): UserConnection!
 				friendsByBackwardsCursor(last: Int, before: String, filter: String): UserConnectionScalar!
 				friendsByForwardsCursor(first: Int, after: String, filter: String): UserConnection!


### PR DESCRIPTION
Fixes #1143

This PR adds functionality to allow required arguments inside paginated fragments.

I'll leave this PR as draft while I test it more thoroughly in our app for work, to make sure nothing else accidentally got broken :)

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

