### PR TITLE
bump babel-parser version

### DIFF
--- a/.changeset/tall-clocks-march.md
+++ b/.changeset/tall-clocks-march.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix parsing error with export type \* from

--- a/packages/houdini/package.json
+++ b/packages/houdini/package.json
@@ -34,7 +34,7 @@
         "vitest": "^0.28.3"
     },
     "dependencies": {
-        "@babel/parser": "^7.20.5",
+        "@babel/parser": "^7.23.9",
         "@clack/prompts": "^0.6.3",
         "@graphql-tools/merge": "^9.0.0",
         "@graphql-tools/schema": "^9.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
         version: 4.9.4
       vite:
         specifier: ^4.1.4
-        version: 4.1.4
+        version: 4.1.4(@types/node@18.11.15)
       vitest:
         specifier: ^0.28.3
         version: 0.28.3(@vitest/ui@0.28.3)
@@ -180,7 +180,7 @@ importers:
         version: 4.9.4
       vite:
         specifier: ^4.1.4
-        version: 4.1.4
+        version: 4.1.4(@types/node@18.11.15)
       vite-plugin-lib-reporter:
         specifier: ^0.0.7
         version: 0.0.7
@@ -271,7 +271,7 @@ importers:
         version: 4.9.4
       vite:
         specifier: ^4.1.0
-        version: 4.1.4
+        version: 4.1.4(@types/node@18.11.15)
       wrangler:
         specifier: ^3.7.0
         version: 3.7.0
@@ -418,8 +418,8 @@ importers:
   packages/houdini:
     dependencies:
       '@babel/parser':
-        specifier: ^7.20.5
-        version: 7.20.7
+        specifier: ^7.23.9
+        version: 7.23.9
       '@clack/prompts':
         specifier: ^0.6.3
         version: 0.6.3
@@ -835,7 +835,7 @@ packages:
       '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.17.8)
       '@babel/helper-module-transforms': 7.21.2
       '@babel/helpers': 7.21.0
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.23.9
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.4
       '@babel/types': 7.21.5
@@ -858,7 +858,7 @@ packages:
       '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.20.7)
       '@babel/helper-module-transforms': 7.21.2
       '@babel/helpers': 7.21.0
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.23.9
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.4
       '@babel/types': 7.21.5
@@ -880,7 +880,7 @@ packages:
       '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.21.4)
       '@babel/helper-module-transforms': 7.21.2
       '@babel/helpers': 7.21.0
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.23.9
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.4
       '@babel/types': 7.21.5
@@ -1063,8 +1063,8 @@ packages:
     dependencies:
       '@babel/types': 7.21.5
 
-  /@babel/parser@7.21.8:
-    resolution: {integrity: sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==}
+  /@babel/parser@7.23.9:
+    resolution: {integrity: sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
@@ -1230,7 +1230,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.21.4
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.23.9
       '@babel/types': 7.21.5
 
   /@babel/traverse@7.17.3:
@@ -1243,7 +1243,7 @@ packages:
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.23.9
       '@babel/types': 7.21.5
       debug: 4.3.4(supports-color@9.3.1)
       globals: 11.12.0
@@ -1261,7 +1261,7 @@ packages:
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.23.9
       '@babel/types': 7.21.5
       debug: 4.3.4(supports-color@9.3.1)
       globals: 11.12.0
@@ -1279,7 +1279,7 @@ packages:
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.23.9
       '@babel/types': 7.21.5
       debug: 4.3.4(supports-color@9.3.1)
       globals: 11.12.0
@@ -2881,7 +2881,7 @@ packages:
       svelte: 3.57.0
       tiny-glob: 0.2.9
       undici: 5.20.0
-      vite: 4.1.4
+      vite: 4.1.4(@types/node@18.11.15)
     transitivePeerDependencies:
       - supports-color
 
@@ -2944,7 +2944,7 @@ packages:
       magic-string: 0.27.0
       svelte: 3.57.0
       svelte-hmr: 0.15.1(svelte@3.57.0)
-      vite: 4.1.4
+      vite: 4.1.4(@types/node@18.11.15)
       vitefu: 0.2.3(vite@4.1.4)
     transitivePeerDependencies:
       - supports-color
@@ -3663,7 +3663,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.21.4)
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.1.4
+      vite: 4.1.4(@types/node@18.11.15)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3735,7 +3735,7 @@ packages:
   /@vue/compiler-core@3.2.47:
     resolution: {integrity: sha512-p4D7FDnQb7+YJmO2iPEv0SQNeNzcbHdGByJDsT4lynf63AFkOTFN07HsiRSvjGo0QrxR/o3d0hUyNCUnBU2Tig==}
     dependencies:
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.23.9
       '@vue/shared': 3.2.47
       estree-walker: 2.0.2
       source-map: 0.6.1
@@ -3751,7 +3751,7 @@ packages:
   /@vue/compiler-sfc@3.2.47:
     resolution: {integrity: sha512-rog05W+2IFfxjMcFw10tM9+f7i/+FFpZJJ5XHX72NP9eC2uRD+42M3pYcQqDXVYoj74kHMSEdQ/WmCjt8JFksQ==}
     dependencies:
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.23.9
       '@vue/compiler-core': 3.2.47
       '@vue/compiler-dom': 3.2.47
       '@vue/compiler-ssr': 3.2.47
@@ -3759,7 +3759,7 @@ packages:
       '@vue/shared': 3.2.47
       estree-walker: 2.0.2
       magic-string: 0.25.9
-      postcss: 8.4.28
+      postcss: 8.4.31
       source-map: 0.6.1
     dev: true
 
@@ -3773,7 +3773,7 @@ packages:
   /@vue/reactivity-transform@3.2.47:
     resolution: {integrity: sha512-m8lGXw8rdnPVVIdIFhf0LeQ/ixyHkH5plYuS83yop5n7ggVJU+z5v0zecwEnX7fa7HNLBhh2qngJJkxpwEEmYA==}
     dependencies:
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.23.9
       '@vue/compiler-core': 3.2.47
       '@vue/shared': 3.2.47
       estree-walker: 2.0.2
@@ -7590,7 +7590,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@babel/core': 7.21.4
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.23.9
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.0
@@ -9357,6 +9357,7 @@ packages:
       nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: true
 
   /prebuild-install@7.1.1:
     resolution: {integrity: sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==}
@@ -9495,7 +9496,7 @@ packages:
   /puppeteer@1.20.0:
     resolution: {integrity: sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==}
     engines: {node: '>=6.4.0'}
-    deprecated: < 19.4.0 is no longer supported
+    deprecated: < 21.5.0 is no longer supported
     requiresBuild: true
     dependencies:
       debug: 4.3.4(supports-color@9.3.1)
@@ -11512,38 +11513,6 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
-  /vite@4.1.4:
-    resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.16.17
-      postcss: 8.4.31
-      resolve: 1.22.1
-      rollup: 3.27.1
-    optionalDependencies:
-      fsevents: 2.3.2
-
   /vite@4.1.4(@types/node@18.11.15):
     resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -11576,7 +11545,6 @@ packages:
       rollup: 3.27.1
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /vite@4.4.8(@types/node@18.11.15):
     resolution: {integrity: sha512-LONawOUUjxQridNWGQlNizfKH89qPigK36XhMI7COMGztz8KNY0JHim7/xDd71CZwGT4HtSRgI7Hy+RlhG0Gvg==}
@@ -11631,7 +11599,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.1.4
+      vite: 4.1.4(@types/node@18.11.15)
 
   /vitefu@0.2.3(vite@4.4.8):
     resolution: {integrity: sha512-75l7TTuU8isAhz1QFtNKjDkqjxvndfMC1AfIMjJ0ZQ59ZD0Ow9QOIsJJX16Wv9PS8f+zMzp6fHy5cCbKG/yVUQ==}


### PR DESCRIPTION
Fixes #1256 

This PR bumps the version of babel's parser that we use internally which seems to have fixed the support for the `export type * from` expression

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

