### PR TITLE
Implement cache policy "NoCache"

### DIFF
--- a/.changeset/four-cobras-peel.md
+++ b/.changeset/four-cobras-peel.md
@@ -1,0 +1,5 @@
+---
+'houdini': minor
+---
+
+Implement cache policy "NoCache"

--- a/e2e/kit/src/lib/utils/testsHelper.ts
+++ b/e2e/kit/src/lib/utils/testsHelper.ts
@@ -102,15 +102,15 @@ export async function expect_n_gql(
     // default increment
     const tim_inc = 11;
 
-    // did he waited enough?
+    // did it wait enough?
     let waited_enough = false;
 
     // reset and start from 0 to start the loop.
     time_waiting = 0;
 
     // While
-    // - n !== nbResponse => We don't have the right number of response
-    // - time_waiting < 9999 => We don't reach the global timeout
+    // - n !== nbResponse => We don't have the right number of responses
+    // - time_waiting < 9999 => We haven't reached the global timeout
     // - !waited_enough => We didn't wait enough
     while (n !== nbResponse && time_waiting < 9999 && !waited_enough) {
       // inc

--- a/packages/houdini-svelte/package.json
+++ b/packages/houdini-svelte/package.json
@@ -24,6 +24,7 @@
     },
     "devDependencies": {
         "@types/minimatch": "^5.1.2",
+        "prettier-plugin-svelte": "^2.9.0",
         "scripts": "workspace:^",
         "vitest": "^0.28.3"
     },

--- a/packages/houdini-svelte/src/runtime/stores/query.ts
+++ b/packages/houdini-svelte/src/runtime/stores/query.ts
@@ -171,7 +171,8 @@ This will result in duplicate queries. If you are trying to ensure there is alwa
 		// we want to try to load cached data before we potentially fake the await
 		// this makes sure that the UI feels snappy as we click between cached pages
 		// (no loaders)
-		if (policy !== CachePolicy.NetworkOnly && fakeAwait) {
+		const refersToCache = policy !== CachePolicy.NetworkOnly && policy !== CachePolicy.NoCache
+		if (refersToCache && fakeAwait) {
 			await this.observer.send({
 				fetch: context.fetch,
 				variables: usedVariables,

--- a/packages/houdini/src/codegen/generators/definitions/schema.test.ts
+++ b/packages/houdini/src/codegen/generators/definitions/schema.test.ts
@@ -83,6 +83,7 @@ test('adds internal documents to schema', async function () {
 			  CacheOnly
 			  CacheOrNetwork
 			  NetworkOnly
+			  NoCache
 			}
 
 			"""The Component scalar is only defined if the user has any component fields"""
@@ -169,6 +170,7 @@ test('list operations are included', async function () {
 			  CacheOnly
 			  CacheOrNetwork
 			  NetworkOnly
+			  NoCache
 			}
 
 			"""The Component scalar is only defined if the user has any component fields"""
@@ -274,6 +276,7 @@ test('list operations are included but delete directive should not be in when we
 			  CacheOnly
 			  CacheOrNetwork
 			  NetworkOnly
+			  NoCache
 			}
 
 			"""The Component scalar is only defined if the user has any component fields"""
@@ -392,6 +395,7 @@ test("writing twice doesn't duplicate definitions", async function () {
 			  CacheOnly
 			  CacheOrNetwork
 			  NetworkOnly
+			  NoCache
 			}
 
 			"""The Component scalar is only defined if the user has any component fields"""

--- a/packages/houdini/src/codegen/transforms/schema.ts
+++ b/packages/houdini/src/codegen/transforms/schema.ts
@@ -18,6 +18,7 @@ enum CachePolicy {
 	${CachePolicy.CacheOnly}
 	${CachePolicy.CacheOrNetwork}
 	${CachePolicy.NetworkOnly}
+	${CachePolicy.NoCache}
 }
 
 """

--- a/packages/houdini/src/runtime/client/documentStore.ts
+++ b/packages/houdini/src/runtime/client/documentStore.ts
@@ -250,7 +250,7 @@ export class DocumentStore<
 				return new Response(JSON.stringify(result.length === 1 ? result[0] : result))
 			}
 
-			// we dont have a proxy so just use the default fetch
+			// we don't have a proxy so just use the default fetch
 			return await globalThis.fetch(input, init)
 		}
 	}
@@ -362,7 +362,7 @@ export class DocumentStore<
 				// invoke the target with the correct handlers
 				const result = target(draft, handlers)
 
-				// if we got _something_ back its a promise so we need to make
+				// if we got _something_ back it's a promise so we need to make
 				// sure something is listening for error
 				result?.catch((err) => {
 					this.#step('error', { ...ctx, index: index - 1 }, err)
@@ -376,7 +376,7 @@ export class DocumentStore<
 		}
 
 		/// if we got this far, we are at one of the bounds
-		/// we're need to move onto the next phase
+		/// we either need to move onto the next phase
 		/// or we are at the end of the pipeline so we need to resolve
 		/// or there is no call to resolve in the enter hooks so we need to catch
 
@@ -417,7 +417,7 @@ export class DocumentStore<
 			if (!ctx.promise.resolved) {
 				ctx.promise.reject(value)
 
-				// make sure we dont do anything else to the promise
+				// make sure we don't do anything else to the promise
 				ctx.promise.resolved = true
 			}
 
@@ -447,7 +447,7 @@ export class DocumentStore<
 		if (!ctx.promise.resolved) {
 			ctx.promise.resolve(value)
 
-			// make sure we dont resolve it again
+			// make sure we don't resolve it again
 			ctx.promise.resolved = true
 		}
 
@@ -675,13 +675,13 @@ export type ClientPluginEnterHandlers = {
 	marshalVariables: typeof marshalVariables
 }
 
-/** Exit handlers are the same as enter handles but don't need to resolve with a specific value */
+/** Exit handlers are the same as enter handlers but don't need to resolve with a specific value */
 export type ClientPluginExitHandlers = Omit<ClientPluginEnterHandlers, 'resolve'> & {
 	resolve: (ctx: ClientPluginContext, data?: QueryResult) => void
 	value: QueryResult
 }
 
-/** Exit handlers are the same as enter handles but don't need to resolve with a specific value */
+/** Exit handlers are the same as enter handlers but don't need to resolve with a specific value */
 export type ClientPluginErrorHandlers = ClientPluginEnterHandlers & {
 	error: unknown
 }

--- a/packages/houdini/src/runtime/client/plugins/cache.ts
+++ b/packages/houdini/src/runtime/client/plugins/cache.ts
@@ -34,8 +34,10 @@ export const cachePolicy =
 					// prefers network data we need to send a request (the onLoad of the component will
 					// resolve the next data)
 
-					// if the cache policy allows for cached data, look at the caches value first
-					if (policy !== CachePolicy.NetworkOnly) {
+					// if the cache policy allows for cached data, look at the cache's value first
+					const policyAllowsCache =
+						policy !== CachePolicy.NetworkOnly && policy !== CachePolicy.NoCache
+					if (policyAllowsCache) {
 						// look up the current value in the cache
 						const value = localCache.read({
 							selection: artifact.selection,
@@ -62,7 +64,7 @@ export const cachePolicy =
 							})
 						}
 
-						// if we have data, use that unless its partial data and we dont allow that
+						// if we have data, use that unless it's partial data and we don't allow that
 						useCache = !!(value.data !== null && allowed)
 
 						if (useCache) {
@@ -99,7 +101,7 @@ export const cachePolicy =
 				}
 
 				// if we got this far, we are resolving something against the network
-				// dont set the fetching state to true if we accepted a cache value
+				// don't set the fetching state to true if we accepted a cache value
 				if (!ctx.stuff?.silenceLoading) {
 					// don't set the fetching state to true if we accepted a cache value
 					let fetchingState: GraphQLObject | null = null
@@ -122,6 +124,7 @@ export const cachePolicy =
 			afterNetwork(ctx, { resolve, value, marshalVariables }) {
 				// if we have data coming in from the cache, we should write it and move on
 				if (
+					ctx.policy !== CachePolicy.NoCache &&
 					value.source !== DataSource.Cache &&
 					enabled &&
 					value.data &&
@@ -154,7 +157,7 @@ export const cachePolicy =
 
 					// we need to embed the fragment context values in our response
 					// and apply masking other value transforms. In order to do that,
-					// we're goin to read back what we just wrote. This only incurs
+					// we're going to read back what we just wrote. This only incurs
 					// extra computation on the server-side since we have to write the values
 					// before we can read them (instead of just transforming the value directly)
 					value = {

--- a/packages/houdini/src/runtime/lib/types.ts
+++ b/packages/houdini/src/runtime/lib/types.ts
@@ -5,6 +5,7 @@ export const CachePolicy = {
 	CacheOnly: 'CacheOnly',
 	NetworkOnly: 'NetworkOnly',
 	CacheAndNetwork: 'CacheAndNetwork',
+	NoCache: 'NoCache',
 } as const
 
 export type CachePolicies = ValuesOf<typeof CachePolicy>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -648,6 +648,9 @@ importers:
       '@types/minimatch':
         specifier: ^5.1.2
         version: 5.1.2
+      prettier-plugin-svelte:
+        specifier: ^2.9.0
+        version: 2.9.0(prettier@2.8.3)(svelte@3.57.0)
       scripts:
         specifier: workspace:^
         version: link:../_scripts
@@ -2300,7 +2303,7 @@ packages:
     resolution: {integrity: sha512-SKlIcMA71Dha5JnEWlw4XxcaJ+YupuXg0QCZgl2TOLFz4SkGCwU/geAsJvUJFwK2RbVLpQv/UMq67lOaBuwDtg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: 15.5.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@graphql-tools/utils': 10.0.6(graphql@15.5.0)
       '@graphql-typed-document-node/core': 3.2.0(graphql@15.5.0)
@@ -2313,7 +2316,7 @@ packages:
   /@graphql-tools/merge@8.3.14(graphql@15.5.0):
     resolution: {integrity: sha512-zV0MU1DnxJLIB0wpL4N3u21agEiYFsjm6DI130jqHpwF0pR9HkF+Ni65BNfts4zQelP0GjkHltG+opaozAJ1NA==}
     peerDependencies:
-      graphql: 15.5.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@graphql-tools/utils': 9.1.3(graphql@15.5.0)
       graphql: 15.5.0
@@ -2324,7 +2327,7 @@ packages:
     resolution: {integrity: sha512-J7/xqjkGTTwOJmaJQJ2C+VDBDOWJL3lKrHJN4yMaRLAJH3PosB7GiPRaSDZdErs0+F77sH2MKs2haMMkywzx7Q==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: 15.5.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@graphql-tools/utils': 10.0.6(graphql@15.5.0)
       graphql: 15.5.0
@@ -2335,7 +2338,7 @@ packages:
     resolution: {integrity: sha512-kf3qOXMFcMs2f/S8Y3A8fm/2w+GaHAkfr3Gnhh2LOug/JgpY/ywgFVxO3jOeSpSEdoYcDKLcXVjMigNbY4AdQg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: 15.5.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@graphql-tools/merge': 9.0.0(graphql@15.5.0)
       '@graphql-tools/utils': 10.0.6(graphql@15.5.0)
@@ -2347,7 +2350,7 @@ packages:
   /@graphql-tools/schema@9.0.12(graphql@15.5.0):
     resolution: {integrity: sha512-DmezcEltQai0V1y96nwm0Kg11FDS/INEFekD4nnVgzBqawvznWqK6D6bujn+cw6kivoIr3Uq//QmU/hBlBzUlQ==}
     peerDependencies:
-      graphql: 15.5.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@graphql-tools/merge': 8.3.14(graphql@15.5.0)
       '@graphql-tools/utils': 9.1.3(graphql@15.5.0)
@@ -2360,7 +2363,7 @@ packages:
     resolution: {integrity: sha512-hZMjl/BbX10iagovakgf3IiqArx8TPsotq5pwBld37uIX1JiZoSbgbCIFol7u55bh32o6cfDEiiJgfAD5fbeyQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: 15.5.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@15.5.0)
       dset: 3.1.2
@@ -2371,7 +2374,7 @@ packages:
   /@graphql-tools/utils@9.1.3(graphql@15.5.0):
     resolution: {integrity: sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==}
     peerDependencies:
-      graphql: 15.5.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 15.5.0
       tslib: 2.6.2
@@ -2380,7 +2383,7 @@ packages:
   /@graphql-tools/utils@9.2.1(graphql@15.5.0):
     resolution: {integrity: sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==}
     peerDependencies:
-      graphql: 15.5.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@15.5.0)
       graphql: 15.5.0
@@ -2390,7 +2393,7 @@ packages:
   /@graphql-typed-document-node/core@3.2.0(graphql@15.5.0):
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
-      graphql: 15.5.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 15.5.0
     dev: false
@@ -2406,7 +2409,7 @@ packages:
     resolution: {integrity: sha512-pjA7xLIYVCugxyM/FwG7SlbPVPxn8cr5AFT0I4EsgwK2z6D0oM+fN6guPam7twTVKr0BmA/EtVm2RWkik114Mw==}
     peerDependencies:
       '@graphql-tools/utils': ^9.2.1
-      graphql: 15.5.0
+      graphql: ^15.2.0 || ^16.0.0
       graphql-yoga: ^3.9.1
     dependencies:
       '@graphql-tools/utils': 9.2.1(graphql@15.5.0)
@@ -2767,7 +2770,7 @@ packages:
   /@pothos/core@3.38.0(graphql@15.5.0):
     resolution: {integrity: sha512-2jlnvkrCmbrHxK269745TXxl185LwJtC5oMz4nbFP40LmVV9zbDV3WKqbG7D+3rg9hvxBe0RmmwWrOjNcGpICA==}
     peerDependencies:
-      graphql: 15.5.0
+      graphql: '>=15.1.0'
     dependencies:
       graphql: 15.5.0
     dev: false
@@ -2776,7 +2779,7 @@ packages:
     resolution: {integrity: sha512-7eOsgKL2qCQ+/hHpye4sNNbR2mYogDXPWpQboqniYvUdOjez3VDYjAuOn8Ntw73kZQF0N1iloZPikhCxvY7xuw==}
     peerDependencies:
       '@pothos/core': '*'
-      graphql: 15.5.0
+      graphql: '>=15.1.0'
     dependencies:
       '@pothos/core': 3.38.0(graphql@15.5.0)
       graphql: 15.5.0
@@ -2786,7 +2789,7 @@ packages:
     resolution: {integrity: sha512-CgZJLaHLt1Q30j+XCiWV6qVJcae1ksiUFdi8kz4sEsOhCNfdVwz64s8rx7SSqsdmPbjb68dJIDKpq2Qg9VZb8g==}
     peerDependencies:
       '@pothos/core': '*'
-      graphql: 15.5.0
+      graphql: '>=15.1.0'
     dependencies:
       '@pothos/core': 3.38.0(graphql@15.5.0)
       graphql: 15.5.0
@@ -7045,7 +7048,7 @@ packages:
     resolution: {integrity: sha512-44yBuw2/DLNEiMypbNZBt1yMDbBmyVPVesPywnteGGALiBmdyy1JP8jSg8ClLePg8ZZxk0O4BLhd1a6U/1jDOQ==}
     engines: {node: ^12.20.0 || ^14.15.0 || >= 15.9.0}
     peerDependencies:
-      graphql: 15.5.0
+      graphql: ^16.2.0
     dependencies:
       graphql: 15.5.0
     dev: false
@@ -7054,7 +7057,7 @@ packages:
     resolution: {integrity: sha512-4EiZ3/UXYcjm+xFGP544/yW1+DVI8ZpKASFbzrV5EDTFWJp0ZvLl4Dy2fSZAzz9imKp5pZMIcjB0x/H69Pv/6w==}
     engines: {node: '>=10'}
     peerDependencies:
-      graphql: 15.5.0
+      graphql: '>=0.11 <=16'
     dependencies:
       graphql: 15.5.0
     dev: false
@@ -7063,7 +7066,7 @@ packages:
     resolution: {integrity: sha512-MvCLhFecYNIKuxAZisPjpIL9lxRYbpgPSNKENDO/8CV3oiFlsLJHZb5dp2sVAeLafXHeZ9TgkijLthUBc1+Jag==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: 15.5.0
+      graphql: ^15.2.0 || ^16.0.0
     dependencies:
       '@envelop/core': 4.0.1
       '@graphql-tools/executor': 1.2.0(graphql@15.5.0)
@@ -9278,22 +9281,6 @@ packages:
       postcss: 8.4.31
     dev: true
 
-  /postcss-load-config@4.0.1:
-    resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
-    engines: {node: '>= 14'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 2.0.5
-      yaml: 2.2.1
-    dev: true
-
   /postcss-load-config@4.0.1(postcss@8.4.31):
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
     engines: {node: '>= 14'}
@@ -11004,7 +10991,7 @@ packages:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.1
+      postcss-load-config: 4.0.1(postcss@8.4.31)
       resolve-from: 5.0.0
       rollup: 3.27.1
       source-map: 0.8.0-beta.0

--- a/site/src/routes/guides/caching-data/+page.svx
+++ b/site/src/routes/guides/caching-data/+page.svx
@@ -22,6 +22,7 @@ There are a few different policies that can be specified:
 - `CacheAndNetwork` will use cached data if it exists and always send a network request after the component has mounted to retrieve the latest data from the server. The cached portion of this might contain partial data if you opt-in.
 - `NetworkOnly` will never check if the data exists in the cache and always send a network request
 - `CacheOnly` will only ever return cache data which can be a partial response
+- `NoCache` is like `NetworkOnly` but also will never write to the cache
 
 The default cache policy as well as other parameters can be changed in your [config file](/api/config).
 


### PR DESCRIPTION
Fixes #356

Implement the policy "NoCache", mirroring Apollo, which serves a request without reading from or writing to the cache.

Tests are failing for me locally with messages like this:

```
TypeError: Cannot read properties of undefined (reading 'on')
 ❯ vitest.setup.ts:12:1
     10| process.env.HOUDINI_TEST = 'true'
     11| 
     12| beforeEach(clearMock)
       | ^
     13| 
     14| const config = testConfig()
```

This happens even without my changes, but it means I'm not able to write tests for the change.

### To help everyone out, please make sure your PR does the following:

- [X] Update the first line to point to the ticket that this PR fixes
- [X] Add a message that clearly describes the fix
~~- [ ] If applicable, add a test that would fail without this fix
~~- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [X ] Includes a changeset if your fix affects the user with `pnpm changeset`

