### PR TITLE
Non string delete

### DIFF
--- a/.changeset/clever-pugs-switch.md
+++ b/.changeset/clever-pugs-switch.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Add support for non-string IDs when using the delete directive

--- a/packages/houdini/src/runtime/cache/cache.ts
+++ b/packages/houdini/src/runtime/cache/cache.ts
@@ -888,11 +888,7 @@ class CacheInternal {
 					}
 
 					// delete the target
-					else if (operation.action === 'delete' && operation.type) {
-						if (typeof target !== 'string') {
-							throw new Error('Cannot delete a record with a non-string ID')
-						}
-
+					else if (operation.action === 'delete' && operation.type && target) {
 						const targetID = this.id(operation.type, target)
 						if (!targetID) {
 							continue
@@ -1228,7 +1224,7 @@ class CacheInternal {
 	id(type: string, id: string): string | null
 	id(type: string, data: any): string | null {
 		// try to compute the id of the record
-		const id = typeof data === 'string' ? data : this.computeID(type, data)
+		const id = typeof data === 'object' ? this.computeID(type, data) : data
 		if (!id) {
 			return null
 		}


### PR DESCRIPTION
Fixes n/a

This PR adds support for using `@Foo_delete` on non-string values

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

