### PR TITLE
Improve error reporting in react bindings

### DIFF
--- a/.changeset/great-shrimps-admire.md
+++ b/.changeset/great-shrimps-admire.md
@@ -1,0 +1,5 @@
+---
+'houdini-react': patch
+---
+
+next

--- a/.changeset/great-shrimps-admire.md
+++ b/.changeset/great-shrimps-admire.md
@@ -2,4 +2,4 @@
 'houdini-react': patch
 ---
 
-next
+Queries now throw errors when they are encountered in an API response

--- a/packages/houdini-react/src/runtime/routing/Router.tsx
+++ b/packages/houdini-react/src/runtime/routing/Router.tsx
@@ -267,7 +267,6 @@ function usePageData({
 		// communicate with the client when we're done
 		const resolvable = { ...promise, resolve, reject }
 		if (!globalThis.window) {
-			console.log('setting ssr signal')
 			ssr_signals.set(id, resolvable)
 		}
 

--- a/packages/houdini-react/src/runtime/routing/Router.tsx
+++ b/packages/houdini-react/src/runtime/routing/Router.tsx
@@ -531,7 +531,7 @@ export function useQueryResult<_Data extends GraphQLObject, _Input extends Graph
 
 	// if there is an error in the response we need to throw to the nearest boundary
 	if (errors && errors.length > 0) {
-		throw errors
+		throw new Error(JSON.stringify(errors))
 	}
 
 	return [data, observer]

--- a/packages/houdini-react/src/runtime/routing/Router.tsx
+++ b/packages/houdini-react/src/runtime/routing/Router.tsx
@@ -520,18 +520,6 @@ const VariableContext = React.createContext<GraphQLVariables>(null)
 export function useQueryResult<_Data extends GraphQLObject, _Input extends GraphQLVariables>(
 	name: string
 ): [_Data | null, DocumentStore<_Data, _Input>] {
-	console.log(
-		'useQueryResult',
-		name,
-		JSON.stringify(
-			Object.fromEntries(
-				[...useRouterContext().data_cache._map.entries()].map(([key, value]) => [
-					key,
-					value.state,
-				])
-			)
-		)
-	)
 	const store_ref = useRouterContext().data_cache.get(name)! as unknown as DocumentStore<
 		_Data,
 		_Input

--- a/packages/houdini-react/src/runtime/routing/Router.tsx
+++ b/packages/houdini-react/src/runtime/routing/Router.tsx
@@ -513,7 +513,18 @@ const VariableContext = React.createContext<GraphQLVariables>(null)
 export function useQueryResult<_Data extends GraphQLObject, _Input extends GraphQLVariables>(
 	name: string
 ): [_Data | null, DocumentStore<_Data, _Input>] {
-	console.log('useQueryResult', name, useRouterContext().data_cache)
+	console.log(
+		'useQueryResult',
+		name,
+		JSON.stringify(
+			Object.fromEntries(
+				[...useRouterContext().data_cache._map.entries()].map(([key, value]) => [
+					key,
+					value.state,
+				])
+			)
+		)
+	)
 	const store_ref = useRouterContext().data_cache.get(name)! as unknown as DocumentStore<
 		_Data,
 		_Input

--- a/packages/houdini-react/src/runtime/routing/Router.tsx
+++ b/packages/houdini-react/src/runtime/routing/Router.tsx
@@ -179,7 +179,7 @@ function usePageData({
 		const observer = client.observe({ artifact, cache })
 
 		let resolve: () => void = () => {}
-		let reject: () => void = () => {}
+		let reject: (message: string) => void = () => {}
 		const promise = new Promise<void>((res, rej) => {
 			resolve = res
 			reject = rej
@@ -192,6 +192,13 @@ function usePageData({
 				})
 				.then(() => {
 					data_cache.set(id, observer)
+
+					// if there is an error, we need to reject the promise
+					if (observer.state.errors && observer.state.errors.length > 0) {
+						reject(observer.state.errors.map((e) => e.message).join('\n'))
+						return
+					}
+
 					console.log('resolving', observer.state)
 					// if we are building up a stream (on the server), we want to add something
 					// to the client that resolves the pending request with the

--- a/packages/houdini-react/src/runtime/routing/Router.tsx
+++ b/packages/houdini-react/src/runtime/routing/Router.tsx
@@ -529,8 +529,9 @@ export function useQueryResult<_Data extends GraphQLObject, _Input extends Graph
 		observer: store_ref,
 	})
 
+	// if there is an error in the response we need to throw to the nearest boundary
 	if (errors && errors.length > 0) {
-		throw new Error(errors.map((e) => e.message).join('\n'))
+		throw errors
 	}
 
 	return [data, observer]

--- a/packages/houdini-react/src/runtime/routing/Router.tsx
+++ b/packages/houdini-react/src/runtime/routing/Router.tsx
@@ -475,7 +475,7 @@ type RouterContext = {
 }
 
 export type PendingCache = SuspenseCache<
-	Promise<void> & { resolve: () => void; reject: () => void }
+	Promise<void> & { resolve: () => void; reject: (message: string) => void }
 >
 
 const Context = React.createContext<RouterContext | null>(null)

--- a/packages/houdini-react/src/runtime/routing/Router.tsx
+++ b/packages/houdini-react/src/runtime/routing/Router.tsx
@@ -274,7 +274,6 @@ function usePageData({
 		// communicate with the client when we're done
 		const resolvable = { ...promise, resolve, reject }
 		if (!globalThis.window) {
-			console.log('setting ssr signal')
 			ssr_signals.set(id, resolvable)
 		}
 
@@ -525,10 +524,14 @@ export function useQueryResult<_Data extends GraphQLObject, _Input extends Graph
 		_Input
 	>
 	// get the live data from the store
-	const [{ data }, observer] = useDocumentStore<_Data, _Input>({
+	const [{ data, errors }, observer] = useDocumentStore<_Data, _Input>({
 		artifact: store_ref.artifact,
 		observer: store_ref,
 	})
+
+	if (errors && errors.length > 0) {
+		throw new Error(errors.map((e) => e.message).join('\n'))
+	}
 
 	return [data, observer]
 }

--- a/packages/houdini-react/src/runtime/routing/Router.tsx
+++ b/packages/houdini-react/src/runtime/routing/Router.tsx
@@ -199,7 +199,6 @@ function usePageData({
 						return
 					}
 
-					console.log('resolving', observer.state)
 					// if we are building up a stream (on the server), we want to add something
 					// to the client that resolves the pending request with the
 					// data that we just got

--- a/packages/houdini-react/src/runtime/routing/Router.tsx
+++ b/packages/houdini-react/src/runtime/routing/Router.tsx
@@ -192,7 +192,7 @@ function usePageData({
 				})
 				.then(() => {
 					data_cache.set(id, observer)
-
+					console.log('resolving', observer.state)
 					// if we are building up a stream (on the server), we want to add something
 					// to the client that resolves the pending request with the
 					// data that we just got
@@ -267,6 +267,7 @@ function usePageData({
 		// communicate with the client when we're done
 		const resolvable = { ...promise, resolve, reject }
 		if (!globalThis.window) {
+			console.log('setting ssr signal')
 			ssr_signals.set(id, resolvable)
 		}
 
@@ -431,7 +432,7 @@ export function RouterContextProvider({
 				artifact_cache,
 				component_cache,
 				data_cache,
-				ssr_signals: ssr_signals,
+				ssr_signals,
 				last_variables,
 				session,
 			}}
@@ -512,6 +513,7 @@ const VariableContext = React.createContext<GraphQLVariables>(null)
 export function useQueryResult<_Data extends GraphQLObject, _Input extends GraphQLVariables>(
 	name: string
 ): [_Data | null, DocumentStore<_Data, _Input>] {
+	console.log('useQueryResult', name, useRouterContext().data_cache)
 	const store_ref = useRouterContext().data_cache.get(name)! as unknown as DocumentStore<
 		_Data,
 		_Input


### PR DESCRIPTION
This PR causes the react router to throw errors as exceptions when they are encountered in a query response. Since the component with the prop does the store, error boundaries compose into layouts naturally.

### To help everyone out, please make sure your PR does the following:

- [ ] ~Update the first line to point to the ticket that this PR fixes~
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

