### PR TITLE
Fix vitePreprocess import in init script

### DIFF
--- a/.changeset/big-pianos-pull.md
+++ b/.changeset/big-pianos-pull.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix init script to use the correct vitePreprocess import

--- a/packages/houdini/src/cmd/init.ts
+++ b/packages/houdini/src/cmd/init.ts
@@ -412,7 +412,7 @@ async function svelteConfig(targetPath: string, typescript: boolean) {
 	const svelteConfigPath = path.join(targetPath, 'svelte.config.js')
 
 	const newContentTs = `import adapter from '@sveltejs/adapter-auto';
-import { vitePreprocess } from '@sveltejs/kit/vite';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {


### PR DESCRIPTION
Fixes https://discord.com/channels/1024421016405016718/1214698361106472981

The old import was no longer supported since SvelteKit 2.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

