### PR TITLE
feat: add using keyword support

### DIFF
--- a/.changeset/early-masks-compete.md
+++ b/.changeset/early-masks-compete.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+add support for the new 'using' syntax (explicit resource management: https://github.com/tc39/proposal-explicit-resource-management)

--- a/packages/houdini/src/lib/parse.ts
+++ b/packages/houdini/src/lib/parse.ts
@@ -11,7 +11,7 @@ export type ParsedFile = Maybe<{ script: Script; start: number; end: number }>
 // overload definitions
 export function parseJS(str: string, config?: Partial<ParserOptions>): Script {
 	const defaultConfig: ParserOptions = {
-		plugins: ['typescript', 'importAssertions', 'decorators-legacy'],
+		plugins: ['typescript', 'importAssertions', 'decorators-legacy', 'explicitResourceManagement'],
 		sourceType: 'module',
 	}
 	// @ts-ignore: babel doesn't perfectly match recast's types (the comments don't line up)

--- a/packages/houdini/src/lib/parse.ts
+++ b/packages/houdini/src/lib/parse.ts
@@ -11,7 +11,12 @@ export type ParsedFile = Maybe<{ script: Script; start: number; end: number }>
 // overload definitions
 export function parseJS(str: string, config?: Partial<ParserOptions>): Script {
 	const defaultConfig: ParserOptions = {
-		plugins: ['typescript', 'importAssertions', 'decorators-legacy', 'explicitResourceManagement'],
+		plugins: [
+			'typescript',
+			'importAssertions',
+			'decorators-legacy',
+			'explicitResourceManagement',
+		],
 		sourceType: 'module',
 	}
 	// @ts-ignore: babel doesn't perfectly match recast's types (the comments don't line up)


### PR DESCRIPTION
Resolves #1287

Context : 

The following error message appears when trying to use the new javascript `using` keyword (https://github.com/tc39/proposal-explicit-resource-management)

```
$ vite dev
:x: Encountered error in src/routes/sverdle/+page.server.ts
This experimental syntax requires enabling the parser plugin: "explicitResourceManagement". (14:1)
error when starting dev server:
undefined
```

Typescript >5.2 [support](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html#using-declarations-and-explicit-resource-management
) this out of the box, and there's a [babel plugin](https://babeljs.io/docs/babel-plugin-proposal-explicit-resource-management) that can be leveraged to support this.

I've tested the changes with a pnpm patch on a new sveltekit project and was able to start the dev server without any errors.



### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [ ] Includes a changeset if your fix affects the user with `pnpm changeset`

