### PR TITLE
Fix mutation list operations not working when passing `@with` directive

### DIFF
--- a/.changeset/rotten-cobras-grin.md
+++ b/.changeset/rotten-cobras-grin.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Mutation list operations now work if you need to pass a `@with` directive to the fragment spread

--- a/e2e/kit/src/lib/utils/routes.ts
+++ b/e2e/kit/src/lib/utils/routes.ts
@@ -20,6 +20,7 @@ export const routes = {
 
   Lists_all: '/lists/all?limit=15',
   Lists_fragment: '/lists/fragment',
+  Lists_mutation_insert: '/lists/mutation-insert',
   blocking: '/blocking',
 
   Stores_SSR: '/stores/ssr',

--- a/e2e/kit/src/routes/lists/mutation-insert/+page.gql
+++ b/e2e/kit/src/routes/lists/mutation-insert/+page.gql
@@ -1,5 +1,5 @@
 query UsersListMutationInsertUsers($someParam: Boolean!) {
-  usersConnection(first: 100, snapshot: "users-list-mutation-insert") @list(name: "MyList") {
+  usersConnection(first: 5, snapshot: "users-list-mutation-insert") @list(name: "MyList") {
     edges {
       node {
         id

--- a/e2e/kit/src/routes/lists/mutation-insert/+page.gql
+++ b/e2e/kit/src/routes/lists/mutation-insert/+page.gql
@@ -1,0 +1,11 @@
+query UsersListMutationInsertUsers($someParam: Boolean!) {
+  usersConnection(first: 100, snapshot: "users-list-mutation-insert") @list(name: "MyList") {
+    edges {
+      node {
+        id
+        name
+        testField(someParam: $someParam)
+      }
+    }
+  }
+}

--- a/e2e/kit/src/routes/lists/mutation-insert/+page.svelte
+++ b/e2e/kit/src/routes/lists/mutation-insert/+page.svelte
@@ -25,12 +25,14 @@
   };
 </script>
 
-<button on:click={addUser}>+ Add</button>
+<button id="addusers" on:click={addUser}>+ Add</button>
 
-{#if $UsersListMutationInsertUsers.data}
-  <ul>
-    {#each $UsersListMutationInsertUsers.data.usersConnection.edges as userEdge}
-      <li>{userEdge.node?.name} - {userEdge.node?.testField}</li>
-    {/each}
-  </ul>
-{/if}
+<div id="result">
+  {#if $UsersListMutationInsertUsers.data}
+    <ul>
+      {#each $UsersListMutationInsertUsers.data.usersConnection.edges as userEdge}
+        <li>{userEdge.node?.name} - {userEdge.node?.testField}</li>
+      {/each}
+    </ul>
+  {/if}
+</div>

--- a/e2e/kit/src/routes/lists/mutation-insert/+page.svelte
+++ b/e2e/kit/src/routes/lists/mutation-insert/+page.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { graphql } from '$houdini';
+  import type { PageData } from './$houdini';
+
+  export let data: PageData;
+  $: ({ UsersListMutationInsertUsers } = data);
+
+  const addUserMutation = graphql(`
+    mutation UsersListMutationInsertAddUser($name: String!) {
+      addUser(
+        name: $name
+        birthDate: "2024-01-01T00:00:00Z"
+        snapshot: "users-list-mutation-insert"
+      ) {
+        id
+        ...MyList_insert @with(someParam: true) @prepend
+      }
+    }
+  `);
+
+  const addUser = async () => {
+    addUserMutation.mutate({
+      name: 'Test User'
+    });
+  };
+</script>
+
+<button on:click={addUser}>+ Add</button>
+
+{#if $UsersListMutationInsertUsers.data}
+  <ul>
+    {#each $UsersListMutationInsertUsers.data.usersConnection.edges as userEdge}
+      <li>{userEdge.node?.name} - {userEdge.node?.testField}</li>
+    {/each}
+  </ul>
+{/if}

--- a/e2e/kit/src/routes/lists/mutation-insert/+page.ts
+++ b/e2e/kit/src/routes/lists/mutation-insert/+page.ts
@@ -1,0 +1,7 @@
+import type { UsersListMutationInsertUsersVariables } from './$houdini';
+
+export const _UsersListMutationInsertUsersVariables: UsersListMutationInsertUsersVariables = () => {
+  return {
+    someParam: true
+  };
+};

--- a/e2e/kit/src/routes/lists/mutation-insert/spec.ts
+++ b/e2e/kit/src/routes/lists/mutation-insert/spec.ts
@@ -1,0 +1,22 @@
+import { test } from '@playwright/test';
+import { routes } from '../../../lib/utils/routes.js';
+import { expect_to_be, goto, locator_click } from '../../../lib/utils/testsHelper.js';
+
+test('mutation list insert with @with directive', async ({ page }) => {
+  await goto(page, routes.Lists_mutation_insert);
+
+  // Verify the initial page data
+  await expect_to_be(
+    page,
+    'Bruce Willis - Hello worldSamuel Jackson - Hello worldMorgan Freeman - Hello worldTom Hanks - Hello worldWill Smith - Hello world'
+  );
+
+  // Add a user
+  await locator_click(page, `button[id="addusers"]`);
+
+  // Verify new user is at the top
+  await expect_to_be(
+    page,
+    'Test User - Hello worldBruce Willis - Hello worldSamuel Jackson - Hello worldMorgan Freeman - Hello worldTom Hanks - Hello worldWill Smith - Hello world'
+  );
+});

--- a/packages/houdini/src/codegen/generators/artifacts/tests/artifacts.test.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/tests/artifacts.test.ts
@@ -1984,6 +1984,124 @@ describe('mutation artifacts', function () {
 		`)
 	})
 
+	test('insert operation and @with directive', async function () {
+		// the config to use in tests
+		const config = testConfig()
+		const docs = [
+			mockCollectedDoc(
+				`mutation A {
+					addFriend {
+						friend {
+							...All_Users_insert @with(filter: "Hello World")
+						}
+					}
+				}`
+			),
+			mockCollectedDoc(
+				`query TestQuery($filter: String) {
+					users(stringValue: "foo") @list(name: "All_Users") {
+						firstName
+						field(filter: $filter)
+					}
+				}`
+			),
+		]
+
+		// execute the generator
+		await runPipeline(config, docs)
+
+		// load the contents of the file
+		expect(docs[0]).toMatchInlineSnapshot(`
+			export default {
+			    "name": "A",
+			    "kind": "HoudiniMutation",
+			    "hash": "b1ad7b854a43149aedac6832e6a5bff625e125f516e1fea5806bf4123c4ee687",
+
+			    "raw": \`mutation A {
+			  addFriend {
+			    friend {
+			      ...All_Users_insert_1oDy9M
+			      id
+			    }
+			  }
+			}
+
+			fragment All_Users_insert_1oDy9M on User {
+			  firstName
+			  field(filter: "Hello World")
+			  id
+			}
+			\`,
+
+			    "rootType": "Mutation",
+
+			    "selection": {
+			        "fields": {
+			            "addFriend": {
+			                "type": "AddFriendOutput",
+			                "keyRaw": "addFriend",
+
+			                "selection": {
+			                    "fields": {
+			                        "friend": {
+			                            "type": "User",
+			                            "keyRaw": "friend",
+
+			                            "operations": [{
+			                                "action": "insert",
+			                                "list": "All_Users",
+			                                "position": "last"
+			                            }],
+
+			                            "selection": {
+			                                "fields": {
+			                                    "firstName": {
+			                                        "type": "String",
+			                                        "keyRaw": "firstName"
+			                                    },
+
+			                                    "field": {
+			                                        "type": "String",
+			                                        "keyRaw": "field(filter: \\"Hello World\\")",
+			                                        "nullable": true
+			                                    },
+
+			                                    "id": {
+			                                        "type": "ID",
+			                                        "keyRaw": "id",
+			                                        "visible": true
+			                                    }
+			                                },
+
+			                                "fragments": {
+			                                    "All_Users_insert": {
+			                                        "arguments": {
+			                                            "filter": {
+			                                                "kind": "StringValue",
+			                                                "value": "Hello World"
+			                                            }
+			                                        }
+			                                    }
+			                                }
+			                            },
+
+			                            "visible": true
+			                        }
+			                    }
+			                },
+
+			                "visible": true
+			            }
+			        }
+			    },
+
+			    "pluginData": {}
+			};
+
+			"HoudiniHash=ba51f7673207e362cd0ba18f1dee123fc094a90123d0657b0d56c26d021426df";
+		`)
+	})
+
 	test('insert operation allList', async function () {
 		// the config to use in tests
 		const config = testConfig()
@@ -2086,6 +2204,125 @@ describe('mutation artifacts', function () {
 			};
 
 			"HoudiniHash=90d93ca64a69bec0880925b8af471b0da1cf76964df0b6b6c3af30b6fd877217";
+		`)
+	})
+
+	test('insert operation allList and @with directive', async function () {
+		// the config to use in tests
+		const config = testConfig()
+		const docs = [
+			mockCollectedDoc(
+				`mutation A {
+					addFriend {
+						friend {
+							...All_Users_insert @with(filter: "Hello World") @allLists
+						}
+					}
+				}`
+			),
+			mockCollectedDoc(
+				`query TestQuery($filter: String) {
+					users(stringValue: "foo") @list(name: "All_Users") {
+						firstName
+						field(filter: $filter)
+					}
+				}`
+			),
+		]
+
+		// execute the generator
+		await runPipeline(config, docs)
+
+		// load the contents of the file
+		expect(docs[0]).toMatchInlineSnapshot(`
+			export default {
+			    "name": "A",
+			    "kind": "HoudiniMutation",
+			    "hash": "b1ad7b854a43149aedac6832e6a5bff625e125f516e1fea5806bf4123c4ee687",
+
+			    "raw": \`mutation A {
+			  addFriend {
+			    friend {
+			      ...All_Users_insert_1oDy9M
+			      id
+			    }
+			  }
+			}
+
+			fragment All_Users_insert_1oDy9M on User {
+			  firstName
+			  field(filter: "Hello World")
+			  id
+			}
+			\`,
+
+			    "rootType": "Mutation",
+
+			    "selection": {
+			        "fields": {
+			            "addFriend": {
+			                "type": "AddFriendOutput",
+			                "keyRaw": "addFriend",
+
+			                "selection": {
+			                    "fields": {
+			                        "friend": {
+			                            "type": "User",
+			                            "keyRaw": "friend",
+
+			                            "operations": [{
+			                                "action": "insert",
+			                                "list": "All_Users",
+			                                "position": "last",
+			                                "target": "all"
+			                            }],
+
+			                            "selection": {
+			                                "fields": {
+			                                    "firstName": {
+			                                        "type": "String",
+			                                        "keyRaw": "firstName"
+			                                    },
+
+			                                    "field": {
+			                                        "type": "String",
+			                                        "keyRaw": "field(filter: \\"Hello World\\")",
+			                                        "nullable": true
+			                                    },
+
+			                                    "id": {
+			                                        "type": "ID",
+			                                        "keyRaw": "id",
+			                                        "visible": true
+			                                    }
+			                                },
+
+			                                "fragments": {
+			                                    "All_Users_insert": {
+			                                        "arguments": {
+			                                            "filter": {
+			                                                "kind": "StringValue",
+			                                                "value": "Hello World"
+			                                            }
+			                                        }
+			                                    }
+			                                }
+			                            },
+
+			                            "visible": true
+			                        }
+			                    }
+			                },
+
+			                "visible": true
+			            }
+			        }
+			    },
+
+			    "pluginData": {}
+			};
+
+			"HoudiniHash=f6b965893f6a89f0d97c9a63645b36de599756e3e135d8912b1e0b741164caeb";
 		`)
 	})
 
@@ -2289,6 +2526,125 @@ describe('mutation artifacts', function () {
 			};
 
 			"HoudiniHash=18243e748112d965c35ee2f2b0e29d430a9c472e30c96f253449296ae3fe636a";
+		`)
+	})
+
+	test('toggle operation allList and @with directive', async function () {
+		// the config to use in tests
+		const config = testConfig()
+		const docs = [
+			mockCollectedDoc(
+				`mutation A {
+					addFriend {
+						friend {
+							...All_Users_toggle @with(filter: "Hello World") @allLists @prepend
+						}
+					}
+				}`
+			),
+			mockCollectedDoc(
+				`query TestQuery($filter: String) {
+					users(stringValue: "foo") @list(name: "All_Users") {
+						firstName
+						field(filter: $filter)
+					}
+				}`
+			),
+		]
+
+		// execute the generator
+		await runPipeline(config, docs)
+
+		// load the contents of the file
+		expect(docs[0]).toMatchInlineSnapshot(`
+			export default {
+			    "name": "A",
+			    "kind": "HoudiniMutation",
+			    "hash": "d7187de06687137a262178ad23eecf315461cd5cef17e2b384cbcdd25fe1e752",
+
+			    "raw": \`mutation A {
+			  addFriend {
+			    friend {
+			      ...All_Users_toggle_1oDy9M
+			      id
+			    }
+			  }
+			}
+
+			fragment All_Users_toggle_1oDy9M on User {
+			  firstName
+			  field(filter: "Hello World")
+			  id
+			}
+			\`,
+
+			    "rootType": "Mutation",
+
+			    "selection": {
+			        "fields": {
+			            "addFriend": {
+			                "type": "AddFriendOutput",
+			                "keyRaw": "addFriend",
+
+			                "selection": {
+			                    "fields": {
+			                        "friend": {
+			                            "type": "User",
+			                            "keyRaw": "friend",
+
+			                            "operations": [{
+			                                "action": "toggle",
+			                                "list": "All_Users",
+			                                "position": "first",
+			                                "target": "all"
+			                            }],
+
+			                            "selection": {
+			                                "fields": {
+			                                    "firstName": {
+			                                        "type": "String",
+			                                        "keyRaw": "firstName"
+			                                    },
+
+			                                    "field": {
+			                                        "type": "String",
+			                                        "keyRaw": "field(filter: \\"Hello World\\")",
+			                                        "nullable": true
+			                                    },
+
+			                                    "id": {
+			                                        "type": "ID",
+			                                        "keyRaw": "id",
+			                                        "visible": true
+			                                    }
+			                                },
+
+			                                "fragments": {
+			                                    "All_Users_toggle": {
+			                                        "arguments": {
+			                                            "filter": {
+			                                                "kind": "StringValue",
+			                                                "value": "Hello World"
+			                                            }
+			                                        }
+			                                    }
+			                                }
+			                            },
+
+			                            "visible": true
+			                        }
+			                    }
+			                },
+
+			                "visible": true
+			            }
+			        }
+			    },
+
+			    "pluginData": {}
+			};
+
+			"HoudiniHash=2b2f4aafb54ec3bdba80389398aff1d4b6f478a5e58ec714bb6aa82c48e987b5";
 		`)
 	})
 
@@ -2609,6 +2965,124 @@ describe('mutation artifacts', function () {
 			};
 
 			"HoudiniHash=cc9a6fb32e9b6a79e2a3c46885d07b11078f84dcb8c52555fb96e3ff6f87f8b2";
+		`)
+	})
+
+	test('toggle operation and @with directive', async function () {
+		// the config to use in tests
+		const config = testConfig()
+		const docs = [
+			mockCollectedDoc(
+				`mutation A {
+					addFriend {
+						friend {
+							...All_Users_toggle @with(filter: "Hello World")
+						}
+					}
+				}`
+			),
+			mockCollectedDoc(
+				`query TestQuery($filter: String) {
+					users(stringValue: "foo") @list(name: "All_Users") {
+						firstName
+						field(filter: $filter)
+					}
+				}`
+			),
+		]
+
+		// execute the generator
+		await runPipeline(config, docs)
+
+		// load the contents of the file
+		expect(docs[0]).toMatchInlineSnapshot(`
+			export default {
+			    "name": "A",
+			    "kind": "HoudiniMutation",
+			    "hash": "d7187de06687137a262178ad23eecf315461cd5cef17e2b384cbcdd25fe1e752",
+
+			    "raw": \`mutation A {
+			  addFriend {
+			    friend {
+			      ...All_Users_toggle_1oDy9M
+			      id
+			    }
+			  }
+			}
+
+			fragment All_Users_toggle_1oDy9M on User {
+			  firstName
+			  field(filter: "Hello World")
+			  id
+			}
+			\`,
+
+			    "rootType": "Mutation",
+
+			    "selection": {
+			        "fields": {
+			            "addFriend": {
+			                "type": "AddFriendOutput",
+			                "keyRaw": "addFriend",
+
+			                "selection": {
+			                    "fields": {
+			                        "friend": {
+			                            "type": "User",
+			                            "keyRaw": "friend",
+
+			                            "operations": [{
+			                                "action": "toggle",
+			                                "list": "All_Users",
+			                                "position": "last"
+			                            }],
+
+			                            "selection": {
+			                                "fields": {
+			                                    "firstName": {
+			                                        "type": "String",
+			                                        "keyRaw": "firstName"
+			                                    },
+
+			                                    "field": {
+			                                        "type": "String",
+			                                        "keyRaw": "field(filter: \\"Hello World\\")",
+			                                        "nullable": true
+			                                    },
+
+			                                    "id": {
+			                                        "type": "ID",
+			                                        "keyRaw": "id",
+			                                        "visible": true
+			                                    }
+			                                },
+
+			                                "fragments": {
+			                                    "All_Users_toggle": {
+			                                        "arguments": {
+			                                            "filter": {
+			                                                "kind": "StringValue",
+			                                                "value": "Hello World"
+			                                            }
+			                                        }
+			                                    }
+			                                }
+			                            },
+
+			                            "visible": true
+			                        }
+			                    }
+			                },
+
+			                "visible": true
+			            }
+			        }
+			    },
+
+			    "pluginData": {}
+			};
+
+			"HoudiniHash=4a95f1e6dc9fdce153311e84965a99e72f76fc56a063fced1e28efefc50f143a";
 		`)
 	})
 


### PR DESCRIPTION
Fixes #1288

In the case of doing a `...MyList_insert @with(some: "param")`, the artifact generator that detects mutation list operations ran after the fragment spread hashing step, causing
`...MyList_insert @with(some: "param")`
to be transformed into
`...MyList_insert_asdf`

The code that tries to detect list operations works by checking if the fragment spread name ends with `_insert` or the like. Since we have the hash here at the end, this code would result in the code thinking this was not a list operation fragment.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

