### PR TITLE
Fix houdini-svelte crashing the Svelte LSP

### DIFF
--- a/.changeset/afraid-pillows-worry.md
+++ b/.changeset/afraid-pillows-worry.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix houdini-svelte occasionally causing the Svelte LSP to crash

--- a/packages/houdini-svelte/src/plugin/fsPatch.ts
+++ b/packages/houdini-svelte/src/plugin/fsPatch.ts
@@ -109,6 +109,10 @@ filesystem.readFileSync = function (fp, options) {
 
 // @ts-ignore
 filesystem.statSync = function (filepath: string, options: Parameters<filesystem.StatSyncFn>[1]) {
+    if (typeof filepath.includes !== "function") {
+        throw Error("[LOOK HERE] filepath.includes is not a function! filepath is " + JSON.stringify(filepath));
+    }
+
 	if (!filepath.includes('routes') || !path.basename(filepath).startsWith('+')) {
 		return _statSync(filepath, options as any)
 	}

--- a/packages/houdini-svelte/src/plugin/fsPatch.ts
+++ b/packages/houdini-svelte/src/plugin/fsPatch.ts
@@ -108,13 +108,11 @@ filesystem.readFileSync = function (fp, options) {
 }
 
 // @ts-ignore
-filesystem.statSync = function (filepath: string, options: Parameters<filesystem.StatSyncFn>[1]) {
-    if (typeof filepath.includes !== "function") {
-        throw Error("[LOOK HERE] filepath.includes is not a function! filepath is " + JSON.stringify(filepath));
-    }
+filesystem.statSync = function (fp: PathLike, options: Parameters<filesystem.StatSyncFn>[1]) {
+	let filepath = fp.toString()
 
 	if (!filepath.includes('routes') || !path.basename(filepath).startsWith('+')) {
-		return _statSync(filepath, options as any)
+		return _statSync(fp, options as any)
 	}
 
 	try {


### PR DESCRIPTION
Fixes #1292 

So it turns out that `fs.statSync` takes in a `string | Buffer | URL` as path - the last of which does not have a `.includes()` function. (https://nodejs.org/docs/v20.11.1/api/fs.html#fsstatsyncpath-options)

Occasionally it is passed an `URL`, which then causes an error which bubbles up and causes the svelte LSP to crash. This PR fixes the fsPatch `statSync` function to properly handle this.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

