### PR TITLE
Replace Server-side events with Server-sent events in documentation

### DIFF
--- a/site/src/routes/api/subscription/+page.svx
+++ b/site/src/routes/api/subscription/+page.svx
@@ -102,9 +102,9 @@ export default new HoudiniClient({
 })
 ```
 
-### Server-Side Events
+### Server-Sent Events
 
-If your server supports the latest Server-Side events, you can use them to power your subscriptions:
+If your server supports the latest [Server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events), you can use them to power your subscriptions:
 
 ```typescript:title=src/client.ts&typescriptToggle=true
 import { createClient } from 'graphql-sse'


### PR DESCRIPTION
The acronym SSE actually means "Server-**sent** events" (see https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events)

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

