### PR TITLE
Add PaginateMode to the paginate api docs

### DIFF
--- a/site/src/routes/api/graphql-magic/+page.svx
+++ b/site/src/routes/api/graphql-magic/+page.svx
@@ -77,9 +77,13 @@ mutation NewItem($input: AddItemInput!) {
 
 `@cache` is used on a query document to customize the cache behavior. This includes informaton like what [cache policy](/guides/caching-data) should be used by the runtime or if you are okay with partial results from the cache. For a full list of cache policies, check out the [caching guide](/guides/caching-data) and for more information on partial responses, see the [section on partial data](/guides/caching-data#partial-data).
 
-### `@paginate(name: String)`
+### `@paginate(name: String, mode: PaginateMode)`
 
 A field marked with `@paginate` is updated with calls to the page loaders returned by the pagination function. For more information on pagination check out the [guide](/guides/pagination). If you pass a value for the `name` argument, the underlying list can be updated using the [operation fragments](/api/mutation#lists).
+
+You can overwrite the default pagination behavior on a per-list basis by passing a value to the `mode` argument:
+- `Infinite`: new results are added to the existing list.
+- `SinglePage`: new results will replace the contents of the existing list.
 
 ### `@blocking`
 


### PR DESCRIPTION
I noticed that the API docs didn't mention the `@paginate` directive's "mode" parameter at all, so I added a bit of documentation.

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [ ] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [ ] Includes a changeset if your fix affects the user with `pnpm changeset`

