### PR TITLE
Persist docs preference cookies across browser sessions

### DIFF
--- a/site/src/components/Toolbar.svelte
+++ b/site/src/components/Toolbar.svelte
@@ -14,14 +14,16 @@
 		{ label: 'dark', icon: 'sun' }
 	]
 
+	const COOKIE_TIMEOUT = 60 * 60 * 24 * 365 // One year
+
 	function setLang() {
-		document.cookie = `lang=${other_lang};path=/;SameSite=Lax`
+		document.cookie = `lang=${other_lang};path=/;SameSite=Lax;max-age=${COOKIE_TIMEOUT}`
 		lang = other_lang
 	}
 
 	function setTheme() {
 		ui_theme = ui_theme ? 0 : 1
-		document.cookie = `ui_theme=${ui_theme};path=/;SameSite=Lax`
+		document.cookie = `ui_theme=${ui_theme};path=/;SameSite=Lax;max-age=${COOKIE_TIMEOUT}`
 	}
 </script>
 


### PR DESCRIPTION
Previously the preferences such as language and theme were stored as session cookies, which means they got cleared whenever the browser shut down. Adding the max-age makes sure that they stay if you close the browser.

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [ ] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [ ] Includes a changeset if your fix affects the user with `pnpm changeset`

