### PR TITLE
Fix watchFiles error with vite 5.3

### DIFF
--- a/.changeset/lemon-zebras-collect.md
+++ b/.changeset/lemon-zebras-collect.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix "Cannot read properties of undefined (reading 'watchFiles')" error using vite 5.3

--- a/packages/houdini/src/vite/houdini.ts
+++ b/packages/houdini/src/vite/houdini.ts
@@ -238,7 +238,7 @@ export default function Plugin(opts: PluginConfig = {}): VitePlugin {
 			// bundle up the contextual stuff
 			const ctx: TransformPage = {
 				content: code,
-				watch_file: this.addWatchFile,
+				watch_file: this.addWatchFile.bind(this),
 				config: config,
 				filepath,
 				// @ts-ignore


### PR DESCRIPTION
Fixes #1306 

Since the `addWatchFile` is context-aware, it ended up being invalid by the time the houdini plugins came around to use the function.
This PR is a quick fix to ensure that people can keep using Houdini with the latest version of Vite.
We'll need to properly rewrite the Vite plugin at one point so that `this.addWatchFile` is only called from within the houdini vite plugin itself.

For more context, take a look at the referenced issue, or [this thread](https://discord.com/channels/1024421016405016718/1254666346852126720) in Discord

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

