### PR TITLE
Handle unmarshalling lists of custom scalars from the cache

### DIFF
--- a/.changeset/dirty-flies-matter.md
+++ b/.changeset/dirty-flies-matter.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Make sure lists of custom scalars are unmarshaled item per item instead of as one list

--- a/packages/houdini/src/runtime/cache/cache.ts
+++ b/packages/houdini/src/runtime/cache/cache.ts
@@ -1113,7 +1113,14 @@ class CacheInternal {
 				const fnUnmarshal = this.config?.scalars?.[type]?.unmarshal
 				if (fnUnmarshal) {
 					// pass the primitive value to the unmarshal function
-					fieldTarget[attributeName] = fnUnmarshal(value) as GraphQLValue
+					// if value is an array of scalars, we need to unmarshal every single item individually.
+					if (Array.isArray(value)) {
+						fieldTarget[attributeName] = value.map(
+							(v) => fnUnmarshal(v) as GraphQLValue
+						)
+					} else {
+						fieldTarget[attributeName] = fnUnmarshal(value) as GraphQLValue
+					}
 				}
 				// the field does not have an unmarshal function
 				else {

--- a/packages/houdini/src/runtime/cache/tests/scalars.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/scalars.test.ts
@@ -71,6 +71,57 @@ test('extracting data with custom scalars unmarshals the value', () => {
 	})
 })
 
+test('reading a list of custom scalars unmarshals every scalar correctly', function () {
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			node: {
+				type: 'Node',
+
+				visible: true,
+				keyRaw: 'node',
+				selection: {
+					fields: {
+						dates: {
+							type: 'DateTime',
+
+							visible: true,
+							keyRaw: 'dates',
+						},
+						id: {
+							type: 'ID',
+
+							visible: true,
+							keyRaw: 'id',
+						},
+					},
+				},
+			},
+		},
+	}
+
+	const data = {
+		node: {
+			id: '1',
+			dates: [
+				new Date(1955, 2, 19).getTime(),
+				new Date(1948, 11, 21).getTime(),
+				new Date(1937, 5, 0).getTime(),
+			],
+		},
+	}
+
+	cache.write({ selection, data })
+
+	expect(cache.read({ parent: rootID, selection }).data).toEqual({
+		node: {
+			id: '1',
+			dates: data.node.dates.map((d) => new Date(d)),
+		},
+	})
+})
+
 test('can store and retrieve lists of lists of scalars', function () {
 	// instantiate the cache
 	const cache = new Cache(config)

--- a/packages/houdini/src/runtime/lib/scalars.test.ts
+++ b/packages/houdini/src/runtime/lib/scalars.test.ts
@@ -432,7 +432,7 @@ describe('marshal selection', function () {
 				selection: artifact.selection,
 				data,
 			})
-		).rejects.toThrow(/scalar type DateTime is missing a `marshal` function/)
+		).rejects.toThrow(/Scalar type DateTime is missing a `marshal` function/)
 	})
 
 	test('undefined', async function () {

--- a/packages/houdini/src/runtime/lib/scalars.ts
+++ b/packages/houdini/src/runtime/lib/scalars.ts
@@ -58,7 +58,7 @@ export async function marshalSelection({
 					const marshalFn = config!.scalars[type].marshal
 					if (!marshalFn) {
 						throw new Error(
-							`scalar type ${type} is missing a \`marshal\` function. see https://github.com/AlecAivazis/houdini#%EF%B8%8Fcustom-scalars`
+							`Scalar type ${type} is missing a \`marshal\` function. See https://houdinigraphql.com/api/config#custom-scalars for help on configuring custom scalars.`
 						)
 					}
 					if (Array.isArray(value)) {


### PR DESCRIPTION
Fixes #1321

The marshalling step already had an extra check to marshal the individual values if it encountered an array. The unmarshalling step, however, was not invited to the party and just passed the raw values from the cache to the unmarshalling handler in the config.
Now the unmarshalling step has been invited and will pass the individual values of arrays to the proper `unmarshall` handler in the user's config.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

