### PR TITLE
Strip unused variables on their way out

### DIFF
--- a/.changeset/fifty-llamas-cry.md
+++ b/.changeset/fifty-llamas-cry.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Strip unused variables on their way to the server

--- a/packages/houdini-svelte/src/plugin/artifactData.test.ts
+++ b/packages/houdini-svelte/src/plugin/artifactData.test.ts
@@ -61,6 +61,7 @@ describe('load', () => {
 			\`,
 
 			    "rootType": "Query",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -165,6 +166,7 @@ describe('blocking', () => {
 			\`,
 
 			    "rootType": "Query",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -209,6 +211,7 @@ describe('blocking', () => {
 			\`,
 
 			    "rootType": "Query",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {

--- a/packages/houdini/src/codegen/generators/artifacts/index.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/index.ts
@@ -136,6 +136,7 @@ export default function artifactGenerator(stats: {
 					// 1. all references to internal directives
 					// 2. all variables only used by internal directives
 					const usedVariableNames = new Set<string>()
+					const unusedVariables = new Set<string>()
 					let documentWithoutInternalDirectives = graphql.visit(document, {
 						Directive(node) {
 							// if the directive is one of the internal ones, remove it
@@ -162,6 +163,7 @@ export default function artifactGenerator(stats: {
 								const name = variableDefinitionNode.variable.name.value
 
 								if (!usedVariableNames.has(name)) {
+									unusedVariables.add(name)
 									return null
 								}
 							},
@@ -283,6 +285,7 @@ export default function artifactGenerator(stats: {
 						refetch: doc.refetch,
 						raw: rawString,
 						rootType,
+						stripVariables: [...unusedVariables],
 						selection: selection({
 							config,
 							filepath: doc.filename,

--- a/packages/houdini/src/codegen/generators/artifacts/tests/artifacts.test.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/tests/artifacts.test.ts
@@ -49,6 +49,7 @@ test('adds kind, name, and raw, response, and selection', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -82,6 +83,7 @@ test('adds kind, name, and raw, response, and selection', async function () {
 		\`,
 
 		    "rootType": "User",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -146,6 +148,7 @@ test('selection includes fragments', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -206,6 +209,7 @@ test('selection includes fragments', async function () {
 		\`,
 
 		    "rootType": "User",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -269,6 +273,7 @@ test('internal directives are scrubbed', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -355,6 +360,7 @@ test('variables only used by internal directives are scrubbed', async function (
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": ["parentID"],
 
 		    "selection": {
 		        "fields": {
@@ -447,6 +453,7 @@ test('overlapping query and fragment selection', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -528,6 +535,7 @@ test('interface to interface inline fragment', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -674,6 +682,7 @@ test('paginate over unions', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -905,6 +914,7 @@ test('overlapping query and fragment nested selection', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -1034,6 +1044,7 @@ test('selections with interfaces', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -1179,6 +1190,7 @@ test('selections with unions', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -1326,6 +1338,7 @@ test('selections with overlapping unions', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -1489,6 +1502,7 @@ test('selections with unions of abstract types', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -1654,6 +1668,7 @@ test('selections with concrete types matching multiple abstract types', async fu
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -1833,6 +1848,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -1927,6 +1943,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -2034,6 +2051,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -2136,6 +2154,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -2231,6 +2250,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -2339,6 +2359,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -2454,6 +2475,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -2553,6 +2575,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -2661,6 +2684,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -2780,6 +2804,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -2888,6 +2913,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -2993,6 +3019,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -3100,6 +3127,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -3215,6 +3243,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -3304,6 +3333,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -3382,6 +3412,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -3485,6 +3516,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -3595,6 +3627,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -3705,6 +3738,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -3815,6 +3849,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -3926,6 +3961,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -4037,6 +4073,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -4148,6 +4185,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -4259,6 +4297,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -4368,6 +4407,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Query",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -4503,6 +4543,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Mutation",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -4607,6 +4648,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Query",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -4740,6 +4782,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Query",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -4986,6 +5029,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Query",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -5202,6 +5246,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Query",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -5327,6 +5372,7 @@ describe('mutation artifacts', function () {
 			\`,
 
 			    "rootType": "Query",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -5465,6 +5511,7 @@ test('custom scalar shows up in artifact', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -5574,6 +5621,7 @@ test('operation inputs', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -5674,6 +5722,7 @@ describe('subscription artifacts', function () {
 			\`,
 
 			    "rootType": "Subscription",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -5761,6 +5810,7 @@ test('some artifactData added to artifact specific to plugins', async function (
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -5862,6 +5912,7 @@ test('nested recursive fragments', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -5987,6 +6038,7 @@ test('leave @include and @skip alone', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -6126,6 +6178,7 @@ test('fragment references are embedded in artifact', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -6241,6 +6294,7 @@ test('fragment variables are embedded in artifact', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -6360,6 +6414,7 @@ test('fragment nested in root', async function () {
 		\`,
 
 		    "rootType": "User",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -6475,6 +6530,7 @@ test('client nullability', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -6720,6 +6776,7 @@ test('nested abstract fragment on connection', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -7023,6 +7080,7 @@ test('nested abstract fragments', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -7165,6 +7223,7 @@ test('nested abstract fragments', async function () {
 		\`,
 
 		    "rootType": "AnimalConnection",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -7294,6 +7353,7 @@ test('runtimeScalars', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -7386,6 +7446,7 @@ describe('default arguments', function () {
 			\`,
 
 			    "rootType": "Query",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -7495,6 +7556,7 @@ describe('default arguments', function () {
 			\`,
 
 			    "rootType": "Query",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -7586,6 +7648,7 @@ describe('default arguments', function () {
 			\`,
 
 			    "rootType": "Query",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {

--- a/packages/houdini/src/codegen/generators/artifacts/tests/loadingState.test.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/tests/loadingState.test.ts
@@ -67,6 +67,7 @@ test('persists loading behavior in selection', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -297,6 +298,7 @@ test('loading state on mixed abstract type', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -507,6 +509,7 @@ test('loading state on multiple branches of an abstract selection', async functi
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -668,6 +671,7 @@ test('loading state on inline fragments', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -796,6 +800,7 @@ test('persist count in loading spec', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -950,6 +955,7 @@ test('loading state on definitions', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -1127,6 +1133,7 @@ test('loading cascade', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {

--- a/packages/houdini/src/codegen/generators/artifacts/tests/pagination.test.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/tests/pagination.test.ts
@@ -75,6 +75,7 @@ test('pagination arguments stripped from key', async function () {
 		\`,
 
 		    "rootType": "User",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -282,6 +283,7 @@ test('pagination arguments stays in key as it s a SinglePage Mode', async functi
 		\`,
 
 		    "rootType": "User",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -469,6 +471,7 @@ test('offset based pagination marks appropriate field', async function () {
 		\`,
 
 		    "rootType": "User",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -617,6 +620,7 @@ test('cursor as scalar gets the right pagination query argument types', async fu
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -912,6 +916,7 @@ test("sibling aliases don't get marked", async function () {
 		\`,
 
 		    "rootType": "User",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {

--- a/packages/houdini/src/codegen/generators/artifacts/tests/plugins.test.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/tests/plugins.test.ts
@@ -42,6 +42,7 @@ test("doesn't include directives defined in plugins", async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -109,6 +110,7 @@ test('plugins can customize the hash', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {

--- a/packages/houdini/src/codegen/generators/artifacts/tests/policy.test.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/tests/policy.test.ts
@@ -42,6 +42,7 @@ test('cache policy is persisted in artifact', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -130,6 +131,7 @@ test('can change default cache policy', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -213,6 +215,7 @@ test('partial opt-in is persisted', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -301,6 +304,7 @@ test('can set default partial opt-in', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {

--- a/packages/houdini/src/codegen/generators/artifacts/tests/selection.test.ts
+++ b/packages/houdini/src/codegen/generators/artifacts/tests/selection.test.ts
@@ -145,6 +145,7 @@ test('list of fragment unions', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -303,6 +304,7 @@ test('fragments in lists', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -502,6 +504,7 @@ test('concrete selection applies mask over abstract selection', async function (
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -836,6 +839,7 @@ test("multiple abstract selections don't conflict", async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -1079,6 +1083,7 @@ test('componentFields get embedded in the selection', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -1177,6 +1182,7 @@ test('componentFields get embedded in the selection', async function () {
 		\`,
 
 		    "rootType": "User",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -1265,6 +1271,7 @@ test('fragment argument passed to directive', async function () {
 		\`,
 
 		    "rootType": "User",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {

--- a/packages/houdini/src/codegen/generators/typescript/documentTypes.test.ts
+++ b/packages/houdini/src/codegen/generators/typescript/documentTypes.test.ts
@@ -179,6 +179,7 @@ test('generate document types', async function () {
 		}
 		\`;
 		    "rootType": "Query";
+		    "stripVariables": [];
 		    "selection": {
 		        "fields": {
 		            "user": {
@@ -245,75 +246,76 @@ test('generate document types', async function () {
 
 	expect(recast.parse(fragmentArtifactContents!, { parser: typescriptParser }))
 		.toMatchInlineSnapshot(`
-		import { MyEnum } from "$houdini/graphql/enums";
-		import type { ValueOf } from "$houdini/runtime/lib/types";
-		export type otherInfo$input = {};
+			import { MyEnum } from "$houdini/graphql/enums";
+			import type { ValueOf } from "$houdini/runtime/lib/types";
+			export type otherInfo$input = {};
 
-		export type otherInfo = {
-		    readonly "shape"?: otherInfo$data;
-		    readonly " $fragments": {
-		        "otherInfo": any;
-		    };
-		};
+			export type otherInfo = {
+			    readonly "shape"?: otherInfo$data;
+			    readonly " $fragments": {
+			        "otherInfo": any;
+			    };
+			};
 
-		export type otherInfo$data = {
-		    /**
-		     * An enum value
-		    */
-		    readonly enumValue: ValueOf<typeof MyEnum> | null;
-		    readonly age: number | null;
-		    /**
-		     * The user's first name
-		     * @deprecated Use firstName instead
-		    */
-		    readonly firstname: string;
-		};
+			export type otherInfo$data = {
+			    /**
+			     * An enum value
+			    */
+			    readonly enumValue: ValueOf<typeof MyEnum> | null;
+			    readonly age: number | null;
+			    /**
+			     * The user's first name
+			     * @deprecated Use firstName instead
+			    */
+			    readonly firstname: string;
+			};
 
-		export type otherInfo$artifact = {
-		    "name": "otherInfo";
-		    "kind": "HoudiniFragment";
-		    "hash": "ea797186970659edb8c7a021812ce5652a9fb1d4ca5f6b9acde4e0aa734e0a3e";
-		    "raw": \`fragment otherInfo on User {
-		  enumValue
-		  age
-		  firstname
-		  id
-		  __typename
-		}
-		\`;
-		    "rootType": "User";
-		    "selection": {
-		        "fields": {
-		            "enumValue": {
-		                "type": "MyEnum";
-		                "keyRaw": "enumValue";
-		                "nullable": true;
-		                "visible": true;
-		            };
-		            "age": {
-		                "type": "Int";
-		                "keyRaw": "age";
-		                "nullable": true;
-		                "visible": true;
-		            };
-		            "firstname": {
-		                "type": "String";
-		                "keyRaw": "firstname";
-		                "visible": true;
-		            };
-		            "id": {
-		                "type": "ID";
-		                "keyRaw": "id";
-		                "visible": true;
-		            };
-		            "__typename": {
-		                "type": "String";
-		                "keyRaw": "__typename";
-		                "visible": true;
-		            };
-		        };
-		    };
-		    "pluginData": {};
-		};
-	`)
+			export type otherInfo$artifact = {
+			    "name": "otherInfo";
+			    "kind": "HoudiniFragment";
+			    "hash": "ea797186970659edb8c7a021812ce5652a9fb1d4ca5f6b9acde4e0aa734e0a3e";
+			    "raw": \`fragment otherInfo on User {
+			  enumValue
+			  age
+			  firstname
+			  id
+			  __typename
+			}
+			\`;
+			    "rootType": "User";
+			    "stripVariables": [];
+			    "selection": {
+			        "fields": {
+			            "enumValue": {
+			                "type": "MyEnum";
+			                "keyRaw": "enumValue";
+			                "nullable": true;
+			                "visible": true;
+			            };
+			            "age": {
+			                "type": "Int";
+			                "keyRaw": "age";
+			                "nullable": true;
+			                "visible": true;
+			            };
+			            "firstname": {
+			                "type": "String";
+			                "keyRaw": "firstname";
+			                "visible": true;
+			            };
+			            "id": {
+			                "type": "ID";
+			                "keyRaw": "id";
+			                "visible": true;
+			            };
+			            "__typename": {
+			                "type": "String";
+			                "keyRaw": "__typename";
+			                "visible": true;
+			            };
+			        };
+			    };
+			    "pluginData": {};
+			};
+		`)
 })

--- a/packages/houdini/src/codegen/generators/typescript/loadingState.test.ts
+++ b/packages/houdini/src/codegen/generators/typescript/loadingState.test.ts
@@ -92,6 +92,7 @@ test('@loading on fragment - happy path', async function () {
 		}
 		\`;
 		    "rootType": "User";
+		    "stripVariables": [];
 		    "selection": {
 		        "fields": {
 		            "id": {
@@ -250,6 +251,7 @@ test('@loading on query - happy path', async function () {
 		}
 		\`;
 		    "rootType": "Query";
+		    "stripVariables": [];
 		    "selection": {
 		        "fields": {
 		            "user": {
@@ -397,6 +399,7 @@ test('@loading on list', async function () {
 		}
 		\`;
 		    "rootType": "Query";
+		    "stripVariables": [];
 		    "selection": {
 		        "fields": {
 		            "users": {
@@ -502,6 +505,7 @@ test('generated types include fragment loading state', async function () {
 		}
 		\`;
 		    "rootType": "Query";
+		    "stripVariables": [];
 		    "selection": {
 		        "fields": {
 		            "users": {
@@ -624,6 +628,7 @@ test('global @loading on fragment', async function () {
 		}
 		\`;
 		    "rootType": "Query";
+		    "stripVariables": [];
 		    "selection": {
 		        "fields": {
 		            "users": {

--- a/packages/houdini/src/codegen/generators/typescript/typescript.test.ts
+++ b/packages/houdini/src/codegen/generators/typescript/typescript.test.ts
@@ -142,6 +142,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "User";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "firstName": {
@@ -226,6 +227,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "user": {
@@ -317,6 +319,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "user": {
@@ -409,6 +412,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "User";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "firstName": {
@@ -502,6 +506,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "User";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "firstName": {
@@ -593,6 +598,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "User";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "firstName": {
@@ -678,6 +684,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "user": {
@@ -755,6 +762,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "users": {
@@ -835,6 +843,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "user": {
@@ -930,6 +939,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "entity": {
@@ -1079,6 +1089,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Mutation";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "doThing": {
@@ -1212,6 +1223,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Mutation";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "doThing": {
@@ -1314,6 +1326,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "user": {
@@ -1443,6 +1456,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "user": {
@@ -1544,6 +1558,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "user": {
@@ -1650,6 +1665,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "nodes": {
@@ -1773,6 +1789,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "entities": {
@@ -1900,6 +1917,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "nodes": {
@@ -2042,6 +2060,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "entities": {
@@ -2180,6 +2199,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "allItems": {
@@ -2276,6 +2296,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "allItems": {
@@ -2361,6 +2382,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "listOfLists": {
@@ -2459,6 +2481,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "user": {
@@ -2643,6 +2666,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Mutation";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "doThing": {
@@ -2753,6 +2777,7 @@ describe('typescript', function () {
 			\`,
 
 			    "rootType": "Query",
+			    "stripVariables": [],
 
 			    "selection": {
 			        "fields": {
@@ -2932,6 +2957,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "user": {
@@ -3097,6 +3123,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "user": {
@@ -3209,6 +3236,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "User";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "friends": {
@@ -3352,6 +3380,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "user": {
@@ -3468,6 +3497,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "User";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "friends": {
@@ -3565,6 +3595,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "user": {
@@ -3668,6 +3699,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "user": {
@@ -3765,6 +3797,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "user": {
@@ -3877,6 +3910,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "user": {
@@ -3994,6 +4028,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Query";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "user": {
@@ -4130,6 +4165,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "User";
+			    "stripVariables": [];
 			    "selection": {
 			        "fields": {
 			            "id": {
@@ -4349,6 +4385,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Node";
+			    "stripVariables": [];
 			    "selection": {
 			        "abstractFields": {
 			            "fields": {
@@ -4453,6 +4490,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Entity";
+			    "stripVariables": [];
 			    "selection": {
 			        "abstractFields": {
 			            "fields": {
@@ -4558,6 +4596,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Entity";
+			    "stripVariables": [];
 			    "selection": {
 			        "abstractFields": {
 			            "fields": {
@@ -4675,6 +4714,7 @@ describe('typescript', function () {
 			}
 			\`;
 			    "rootType": "Entity";
+			    "stripVariables": [];
 			    "selection": {
 			        "abstractFields": {
 			            "fields": {
@@ -4784,6 +4824,7 @@ test('overlapping fragments', async function () {
 		}
 		\`;
 		    "rootType": "User";
+		    "stripVariables": [];
 		    "selection": {
 		        "fields": {
 		            "id": {
@@ -4880,6 +4921,7 @@ test('componentField scalars', async function () {
 		}
 		\`;
 		    "rootType": "Query";
+		    "stripVariables": [];
 		    "selection": {
 		        "fields": {
 		            "users": {

--- a/packages/houdini/src/codegen/transforms/fragmentVariables.test.ts
+++ b/packages/houdini/src/codegen/transforms/fragmentVariables.test.ts
@@ -60,6 +60,7 @@ test('pass argument values to generated fragments', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -156,6 +157,7 @@ test('pass structured values as argument values to generated fragments', async f
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -263,6 +265,7 @@ test("nullable arguments with no values don't show up in the query", async funct
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -354,6 +357,7 @@ test("fragment arguments with default values don't rename the fragment", async f
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -458,6 +462,7 @@ test('thread query variables to inner fragments', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -593,6 +598,7 @@ test('inner fragment with intermediate default value', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -706,6 +712,7 @@ test("default values don't overwrite unless explicitly passed", async function (
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -806,6 +813,7 @@ test('default arguments', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -898,6 +906,7 @@ test('list arguments', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -988,6 +997,7 @@ test('persists fragment variables in artifact', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -1170,6 +1180,7 @@ test('variables referenced deeply in objects', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -1233,6 +1244,7 @@ test('variables referenced deeply in objects', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -1329,6 +1341,7 @@ test('can use the same fragment/argument combo multiple times', async function (
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -1391,6 +1404,7 @@ test('can use the same fragment/argument combo multiple times', async function (
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {

--- a/packages/houdini/src/codegen/transforms/paginate.test.ts
+++ b/packages/houdini/src/codegen/transforms/paginate.test.ts
@@ -562,6 +562,7 @@ test('embeds node pagination query as a separate document', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -848,6 +849,7 @@ test('embeds custom pagination query as a separate document', async function () 
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -1649,6 +1651,7 @@ test('generated query has same refetch spec', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {
@@ -1957,6 +1960,7 @@ test('default defaultPaginateMode to SinglePage', async function () {
 		\`,
 
 		    "rootType": "Query",
+		    "stripVariables": [],
 
 		    "selection": {
 		        "fields": {

--- a/packages/houdini/src/runtime/client/plugins/fetchParams.ts
+++ b/packages/houdini/src/runtime/client/plugins/fetchParams.ts
@@ -7,6 +7,13 @@ export const fetchParams: (fn?: FetchParamFn) => ClientPlugin =
 	(fn = () => ({})) =>
 	() => ({
 		start(ctx, { next, marshalVariables }) {
+			// before we move onto the next plugin, we need to strip the variables as they go through
+			if (ctx.variables) {
+				for (const variable of ctx.artifact.stripVariables) {
+					delete ctx.variables[variable]
+				}
+			}
+
 			next({
 				...ctx,
 				fetchParams: fn({

--- a/packages/houdini/src/runtime/client/plugins/optimisticKeys.test.ts
+++ b/packages/houdini/src/runtime/client/plugins/optimisticKeys.test.ts
@@ -31,6 +31,7 @@ test('OptimisticKeys Plugin', async function () {
 	const first = createStore({
 		artifact: {
 			kind: ArtifactKind.Mutation,
+			stripVariables: [],
 			hash: '7777',
 			raw: 'RAW_TEXT',
 			name: 'TestArtifact',
@@ -112,6 +113,7 @@ test('OptimisticKeys Plugin', async function () {
 	const second = createStore({
 		artifact: {
 			kind: ArtifactKind.Mutation,
+			stripVariables: [],
 			hash: '7777',
 			raw: 'RAW_TEXT',
 			name: 'TestArtifact',

--- a/packages/houdini/src/runtime/client/plugins/test.ts
+++ b/packages/houdini/src/runtime/client/plugins/test.ts
@@ -28,6 +28,7 @@ export function createStore(
 		pipeline: args.pipeline ? createPluginHooks(client.plugins) : undefined,
 		client,
 		artifact: args.artifact ?? {
+			stripVariables: [],
 			kind: ArtifactKind.Query,
 			hash: '7777',
 			raw: 'RAW_TEXT',

--- a/packages/houdini/src/runtime/lib/types.ts
+++ b/packages/houdini/src/runtime/lib/types.ts
@@ -113,6 +113,7 @@ export type BaseCompiledDocument<_Kind extends ArtifactKinds> = {
 	rootType: string
 	input?: InputObject
 	hasComponents?: boolean
+	stripVariables: Array<string>
 	refetch?: {
 		path: string[]
 		method: 'cursor' | 'offset'

--- a/packages/houdini/src/runtime/public/tests/test.ts
+++ b/packages/houdini/src/runtime/public/tests/test.ts
@@ -159,6 +159,7 @@ export const testCache = () => new Cache<CacheTypeDefTest>(new _Cache(testConfig
 
 export const testFragment = (selection: SubscriptionSelection): { artifact: FragmentArtifact } => ({
 	artifact: {
+		stripVariables: [],
 		kind: ArtifactKind.Fragment,
 		hash: '',
 		raw: '',
@@ -171,6 +172,7 @@ export const testFragment = (selection: SubscriptionSelection): { artifact: Frag
 
 export const testQuery = (selection: SubscriptionSelection): { artifact: QueryArtifact } => ({
 	artifact: {
+		stripVariables: [],
 		kind: ArtifactKind.Query,
 		hash: '',
 		raw: '',


### PR DESCRIPTION
Fixes https://discord.com/channels/1024421016405016718/1268152875914104853

This PR fixes an issue when using the `@parentID` directive powered by a query variable. Before the variable would be sent along with the query (even tho it wasn't actually used). In some server runtimes, this causes an error.


### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

