### PR TITLE
Fix arguments to patched filesystem functions

### DIFF
--- a/.changeset/eighty-fishes-shake.md
+++ b/.changeset/eighty-fishes-shake.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix filesystem patches to not use illegal paths


### PR DESCRIPTION
When calculating a string filepath, use `URL.pathname` rather than `.toString()` if the given object is a URL.

Also pass the given filepath argument through to the underlying fs functions rather than using our generated string filepath.

These resolve an issue where `.toString()` on a URL returns a string prefixed with 'file://' even on POSIX devices, which cannot be used by the nodejs runtime bundled with Electron.

Fixes #1326

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

