### PR TITLE
Optimistic key mutations

### DIFF
--- a/.changeset/swift-panthers-hug.md
+++ b/.changeset/swift-panthers-hug.md
@@ -1,0 +1,6 @@
+---
+'houdini-react': patch
+'houdini': patch
+---
+
+Various fixes for optimistic use cases

--- a/e2e/react/package.json
+++ b/e2e/react/package.json
@@ -6,7 +6,6 @@
 	"scripts": {
 		"build:": "cd ../../ && ((pnpm run build && cd -) || (cd - && exit 1))",
 		"build:dev": "pnpm build: && pnpm dev",
-		"build:web": "pnpm build: && pnpm web",
 		"build:test": "pnpm build: && pnpm test",
 		"build:generate": "pnpm build: && pnpm houdini generate",
 		"build:build": "pnpm build: && pnpm build",

--- a/e2e/react/src/routes/optimistic-keys/test.ts
+++ b/e2e/react/src/routes/optimistic-keys/test.ts
@@ -40,3 +40,24 @@ test('@optimisticKey', async ({ page }) => {
 	// the value in the last row should be 'final value'
 	expect(await getValue()).toBe('final value')
 })
+
+test('@optimisticKey - double click', async ({ page }) => {
+	await goto(page, routes.optimistic_keys)
+
+	// all we have to do is double click twice and make sure we didn't get an error when it resolves
+	await page.click('[data-test-action="create"]')
+	await page.click('[data-test-action="create"]')
+
+	// wait a few seconds and make sure there are no errors
+	await sleep(300)
+
+	// wait a few seconds and make sure there are no errors
+	await sleep(300)
+	let found = false
+	try {
+		await page.waitForSelector('h1', { timeout: 100 })
+		found = true
+	} catch {}
+
+	expect(found).toBe(false)
+})

--- a/packages/houdini-react/src/runtime/hooks/useFragment.ts
+++ b/packages/houdini-react/src/runtime/hooks/useFragment.ts
@@ -29,6 +29,7 @@ export function useFragment<
 	// on the client, we want to ensure that we apply masking to the initial value by
 	// loading the value from cache
 	if (reference && parent) {
+		// console.log('reading from cache', parent)
 		cachedValue = cache.read({
 			selection: document.artifact.selection,
 			parent,

--- a/packages/houdini-react/src/runtime/hooks/useFragment.ts
+++ b/packages/houdini-react/src/runtime/hooks/useFragment.ts
@@ -29,7 +29,6 @@ export function useFragment<
 	// on the client, we want to ensure that we apply masking to the initial value by
 	// loading the value from cache
 	if (reference && parent) {
-		// console.log('reading from cache', parent)
 		cachedValue = cache.read({
 			selection: document.artifact.selection,
 			parent,

--- a/packages/houdini/src/runtime/cache/cache.ts
+++ b/packages/houdini/src/runtime/cache/cache.ts
@@ -744,7 +744,6 @@ class CacheInternal {
 							// look up the node reference
 							const { value } = this.storage.get(id, 'node')
 							const node = value as string
-
 							// if the id is being adding and is part of the empty edges, don't include it
 							if (newNodeIDs.includes(node) && emptyEdges.includes(node)) {
 								return false

--- a/packages/houdini/src/runtime/cache/cache.ts
+++ b/packages/houdini/src/runtime/cache/cache.ts
@@ -163,7 +163,7 @@ export class Cache {
 			this._internal_unstable.subscriptions.removeAllSubscribers(recordID)
 
 			// make sure we remove the id from any lists that it appears in
-			const removed = this._internal_unstable.lists.removeIDFromAllLists(recordID, layer)
+			this._internal_unstable.lists.removeIDFromAllLists(recordID, layer)
 
 			// delete the record from the store
 			this._internal_unstable.storage.delete(recordID, layer)

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -120,11 +120,16 @@ export class ListManager {
 	}
 
 	removeIDFromAllLists(id: string, layer?: Layer) {
+		let removed = false
 		for (const fieldMap of this.lists.values()) {
 			for (const list of fieldMap.values()) {
-				list.removeID(id, undefined, layer)
+				if (list.removeID(id, undefined, layer)) {
+					removed = true
+				}
 			}
 		}
+
+		return removed
 	}
 
 	deleteField(parentID: string, field: string) {
@@ -544,7 +549,14 @@ export class ListCollection {
 	}
 
 	removeID(...args: Parameters<List['removeID']>) {
-		this.lists.forEach((list) => list.removeID(...args))
+		let removed = false
+		this.lists.forEach((list) => {
+			if (list.removeID(...args)) {
+				removed = true
+			}
+		})
+
+		return removed
 	}
 
 	remove(...args: Parameters<List['remove']>) {

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -239,7 +239,7 @@ export class List {
 		// figure out the id of the type we are adding
 		const dataID = this.cache._internal_unstable.id(listType, data)
 
-		// if there are conditions for this operation
+		// validate any conditions for this operation
 		if (!this.validateWhen() || !dataID) {
 			return
 		}

--- a/packages/houdini/src/runtime/cache/storage.ts
+++ b/packages/houdini/src/runtime/cache/storage.ts
@@ -153,7 +153,11 @@ export class InMemoryStorage {
 						}
 						// inserts are sorted by location
 						if (isInsertOperation(op)) {
-							operations.insert[op.location].unshift(op.id)
+							if (op.location === OperationLocation.end) {
+								operations.insert[op.location].unshift(op.id)
+							} else {
+								operations.insert[op.location].push(op.id)
+							}
 						}
 						// if we found a delete operation, we're done
 						if (isDeleteOperation(op)) {
@@ -519,7 +523,7 @@ export class Layer {
 			const fields: OperationMap['fieldName']['fields'] = {}
 
 			// merge the two operation maps
-			for (const opMap of [this.operations[id], layer.operations[id]].filter(Boolean)) {
+			for (const opMap of [layer.operations[id], this.operations[id]].filter(Boolean)) {
 				for (const [fieldName, operations] of Object.entries(opMap.fields || {})) {
 					fields[fieldName] = [...(fields[fieldName] || []), ...operations]
 				}

--- a/packages/houdini/src/runtime/cache/storage.ts
+++ b/packages/houdini/src/runtime/cache/storage.ts
@@ -10,7 +10,7 @@ export class InMemoryStorage {
 	data: Layer[]
 	private idCount = 1
 	private rank = 0
-	private idMaps: Record<string | number, string | number> = {}
+	idMaps: Record<string | number, string | number> = {}
 
 	constructor() {
 		this.data = []

--- a/packages/houdini/src/runtime/cache/storage.ts
+++ b/packages/houdini/src/runtime/cache/storage.ts
@@ -10,7 +10,7 @@ export class InMemoryStorage {
 	data: Layer[]
 	private idCount = 1
 	private rank = 0
-	idMaps: Record<string | number, string | number> = {}
+	idMaps: Record<string, string> = {}
 
 	constructor() {
 		this.data = []
@@ -24,8 +24,9 @@ export class InMemoryStorage {
 		return this.rank++
 	}
 
-	registerIDMapping(from: string | number, to: string | number) {
+	registerIDMapping(from: string, to: string) {
 		this.idMaps[from] = to
+		this.idMaps[to] = from
 	}
 
 	// create a layer and return its id
@@ -45,12 +46,12 @@ export class InMemoryStorage {
 		return this.topLayer.insert(id, field, location, target)
 	}
 
-	remove(id: string, field: string, target: string, layerToUser = this.topLayer) {
-		return layerToUser.remove(id, field, target)
+	remove(id: string, field: string, target: string, layer = this.topLayer) {
+		return layer.remove(id, field, target)
 	}
 
-	delete(id: string, layerToUser = this.topLayer) {
-		return layerToUser.delete(id)
+	delete(id: string, layer = this.topLayer) {
+		return layer.delete(id)
 	}
 
 	deleteField(id: string, field: string) {
@@ -112,6 +113,9 @@ export class InMemoryStorage {
 						return
 					}
 					operations.remove.add(v)
+					if (this.idMaps[v]) {
+						operations.remove.add(this.idMaps[v])
+					}
 				})
 
 				// if we don't have a value to return, we're done

--- a/packages/houdini/src/runtime/cache/subscription.ts
+++ b/packages/houdini/src/runtime/cache/subscription.ts
@@ -389,9 +389,8 @@ export class InMemorySubscriptions {
 			return
 		}
 		const subscriberField = subscriber.get(fieldName)
-
 		for (const spec of specs) {
-			const counts = subscriber.get(fieldName)?.referenceCounts
+			const counts = subscriberField?.referenceCounts
 
 			// if we dont know this field/set combo, there's nothing to do (probably a bug somewhere)
 			if (!counts?.has(spec.set)) {
@@ -431,49 +430,24 @@ export class InMemorySubscriptions {
 		// get the list of subscriptions specs for the id if we didn't provide a specific list
 		if (!targets) {
 			targets = [...(this.subscribers.get(id)?.values() || [])].flatMap((spec) =>
-				spec.selections[0].flatMap((sel) => Object.values(sel || {})!)
+				spec.selections.flatMap((sel) => sel[0]!)
 			)
 		}
 
-		return this._walk_removeAllSubscribers(id, targets)
-	}
-
-	_walk_removeAllSubscribers(id: string, targets: SubscriptionSpec[], visited: string[] = []) {
-		visited.push(id)
-
-		const subscriber = this.subscribers.get(id)
-		// every field that currently being subscribed to needs to be cleaned up
-		for (const [key, val] of subscriber?.entries() ?? []) {
-			// grab the current set of subscribers
-			const subscribers = targets || val.selections.map(([spec]) => spec)
-
-			// delete the subscriber for the field
-			this.removeSubscribers(id, key, subscribers)
-
-			// look up the value for the field so we can remove any subscribers that existed because of a
-			// subscriber to this record
-			const { value, kind } = this.cache._internal_unstable.storage.get(id, key)
-
-			// if the field is a scalar, there's nothing more to do
-			if (kind === 'scalar') {
-				continue
-			}
-
-			// if the value is a single link , wrap it in a list. otherwise, flatten the link list
-			const nextTargets = Array.isArray(value)
-				? flatten(value as NestedList)
-				: [value as string]
-
-			for (const id of nextTargets) {
-				// if we have already visited this id, move on
-				if (visited.includes(id)) {
-					continue
-				}
-
-				// keep walking down
-				this._walk_removeAllSubscribers(id, subscribers, visited)
+		for (const target of targets) {
+			// we shouldn't use the root selection here because we only care about the subselections
+			// related to the target
+			for (const subselection of this.findSubSelections(
+				target.parentID || rootID,
+				target.selection,
+				target.variables || {},
+				id
+			)) {
+				this.remove(id, subselection, targets, target.variables || {})
 			}
 		}
+
+		return
 	}
 
 	get size() {
@@ -485,5 +459,59 @@ export class InMemorySubscriptions {
 		}
 
 		return size
+	}
+
+	findSubSelections(
+		parentID: string,
+		selection: SubscriptionSelection,
+		variables: {},
+		searchTarget: string,
+		selections = [] as Array<SubscriptionSelection>
+	): Array<SubscriptionSelection> {
+		// walk down the selection, looking up cached information along the way to identity instances where
+		// the target id is embedded inside of the selection
+
+		// figure out the correct selection
+		const __typename = this.cache._internal_unstable.storage.get(parentID, '__typename')
+			.value as string
+		let targetSelection = getFieldsForType(selection, __typename, false)
+
+		// look at the fields for ones corresponding to links
+		for (const fieldSelection of Object.values(targetSelection || {})) {
+			// if the field points to a link then we need to see if the linked record
+			// is the one we are looking for
+			if (!fieldSelection.selection) {
+				continue
+			}
+
+			const key = evaluateKey(fieldSelection.keyRaw, variables || {})
+
+			const linkedRecord = this.cache._internal_unstable.storage.get(parentID, key)
+			// if the links aren't an array then wrap it
+			const links = !Array.isArray(linkedRecord.value)
+				? [linkedRecord.value as string]
+				: flatten(linkedRecord.value as NestedList)
+
+			// if we found a selection that includes the target, great - we're done and walking down
+			// will unsubscribe from everything
+			if (links.includes(searchTarget)) {
+				selections.push(fieldSelection.selection)
+			}
+			// if we didn't find the target, we need to keep walking down the selection. maybe its somewhere
+			else {
+				// we need to keep walking down the selection
+				for (const link of links) {
+					this.findSubSelections(
+						link,
+						fieldSelection.selection,
+						variables,
+						searchTarget,
+						selections
+					)
+				}
+			}
+		}
+
+		return selections
 	}
 }

--- a/packages/houdini/src/runtime/cache/tests/list.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/list.test.ts
@@ -1553,8 +1553,11 @@ test('inserting data with an update overwrites a record inserted with list.appen
 		selection,
 	})
 
+	const layer = cache._internal_unstable.storage.createLayer(true)
+
 	// insert an element into the list (no parent ID)
 	cache.list('All_Users').append({
+		layer,
 		selection: {
 			fields: {
 				id: { visible: true, type: 'ID', keyRaw: 'id' },
@@ -1684,6 +1687,40 @@ test('inserting data with an update overwrites a record inserted with list.appen
 				],
 			},
 		},
+	})
+
+	cache._internal_unstable.storage.resolveLayer(layer.id)
+
+	expect(
+		cache.read({
+			selection,
+		})
+	).toEqual({
+		data: {
+			viewer: {
+				friends: {
+					edges: [
+						{
+							node: {
+								__typename: 'User',
+								firstName: 'jane',
+								id: '2',
+							},
+						},
+						{
+							node: {
+								__typename: 'User',
+								firstName: 'mary',
+								id: '3',
+							},
+						},
+					],
+				},
+				id: '1',
+			},
+		},
+		partial: false,
+		stale: false,
 	})
 })
 
@@ -5327,8 +5364,42 @@ test('inserting in list at a specific layer affects just that layer', function (
 		{}
 	)
 
+	// write some data before the layer
+	cache.write({
+		selection: {
+			fields: {
+				newUser: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'newUser',
+					operations: [
+						{
+							action: 'insert',
+							list: 'All_Users',
+						},
+					],
+					selection: {
+						fields: {
+							id: {
+								type: 'ID',
+								visible: true,
+								keyRaw: 'id',
+							},
+						},
+					},
+				},
+			},
+		},
+		data: {
+			newUser: {
+				id: '2',
+			},
+		},
+	})
+
 	// create a layer that we will write against
 	const layer = cache._internal_unstable.storage.createLayer(true)
+
 	// write some data to the specific layer
 	cache.write({
 		selection: {
@@ -5363,6 +5434,12 @@ test('inserting in list at a specific layer affects just that layer', function (
 		},
 	})
 
-	// make sure the layer has what we expect
-	expect(layer.links['User:1'].friends).toEqual(['User:3'])
+	expect(layer.operations['User:1'].fields['friends']).toEqual([
+		{
+			id: 'User:3',
+			kind: 'insert',
+			location: 'end',
+		},
+	])
+	expect(layer.links['User:1']).not.toBeDefined()
 })

--- a/packages/houdini/src/runtime/cache/tests/list.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/list.test.ts
@@ -1522,7 +1522,7 @@ test('inserting data with an update overwrites a record inserted with list.appen
 		},
 	}
 
-	// start off associated with one object
+	// start off associated with just one object
 	cache.write({
 		selection,
 		data: {
@@ -1553,11 +1553,8 @@ test('inserting data with an update overwrites a record inserted with list.appen
 		selection,
 	})
 
-	const layer = cache._internal_unstable.storage.createLayer(true)
-
 	// insert an element into the list (no parent ID)
 	cache.list('All_Users').append({
-		layer,
 		selection: {
 			fields: {
 				id: { visible: true, type: 'ID', keyRaw: 'id' },
@@ -1688,8 +1685,6 @@ test('inserting data with an update overwrites a record inserted with list.appen
 			},
 		},
 	})
-
-	cache._internal_unstable.storage.resolveLayer(layer.id)
 
 	expect(
 		cache.read({

--- a/packages/houdini/src/runtime/cache/tests/storage.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/storage.test.ts
@@ -486,6 +486,33 @@ describe('in memory layers', function () {
 			expect(storage.layerCount).toEqual(1)
 		})
 
+		test('a delete and insert on the same layer correctly cancel out', function () {
+			const storage = new InMemoryStorage()
+
+			// add a linked list we will remove from in a layer
+			const baseLayerID = storage.writeLink('User:1', 'friends', ['User:3', 'User:4'])
+
+			// create an optimistic layer we will use to mutate the list
+			const layer = storage.createLayer(true)
+			// insert the same user
+			layer.remove('User:1', 'friends', 'User:2')
+			layer.insert('User:1', 'friends', 'end', 'User:2')
+
+			// make sure we removed the user from the list
+			expect(storage.get('User:1', 'friends')).toEqual({
+				value: ['User:3', 'User:4'],
+				displayLayers: [layer.id, baseLayerID],
+				kind: 'link',
+			})
+
+			// make sure we removed the user from the list
+			expect(storage.get('User:1', 'friends')).toEqual({
+				value: ['User:3', 'User:4'],
+				displayLayers: [layer.id, baseLayerID],
+				kind: 'link',
+			})
+		})
+
 		test.todo(
 			'resolving layer with deletes and fields removes old data and retains the new stuff'
 		)

--- a/packages/houdini/src/runtime/cache/tests/storage.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/storage.test.ts
@@ -346,34 +346,103 @@ describe('in memory layers', function () {
 			})
 		})
 
-		test('insert into linked list', function () {
+		test('insert into end of linked list', function () {
 			const storage = new InMemoryStorage()
 
 			// add a linked list that we will append to in an optimistic layer
 			const baseLayerID = storage.writeLink('User:1', 'friends', ['User:2'])
 
 			// create an optimistic layer and insert a new friend
-			const layer = storage.createLayer(true)
-			layer.insert('User:1', 'friends', OperationLocation.end, 'User:3')
+			const layer1 = storage.createLayer(true)
+			layer1.insert('User:1', 'friends', OperationLocation.end, 'User:3')
 
 			// insert some more records in a non-optimistic layer
 			storage.insert('User:1', 'friends', OperationLocation.end, 'User:5')
+			const layer3 = storage.topLayer
 
 			// make sure we got the full list back
 			expect(storage.get('User:1', 'friends')).toEqual({
 				value: ['User:2', 'User:3', 'User:5'],
-				displayLayers: [storage.topLayer.id, layer.id, baseLayerID],
+				displayLayers: [storage.topLayer.id, layer1.id, baseLayerID],
+				kind: 'link',
+			})
+
+			// create an optimistic layer and insert a new friend
+			const layer2 = storage.createLayer(true)
+			layer2.insert('User:1', 'friends', OperationLocation.end, 'User:6')
+
+			// make sure we got the full list back
+			expect(storage.get('User:1', 'friends')).toEqual({
+				value: ['User:2', 'User:3', 'User:5', 'User:6'],
+				displayLayers: [layer2.id, layer3.id, layer1.id, baseLayerID],
 				kind: 'link',
 			})
 
 			// simulate a mutation response with different data (clear the layer, add a new record, and resolve it)
-			layer.clear()
-			layer.insert('User:1', 'friends', OperationLocation.end, 'User:4')
-			storage.resolveLayer(layer.id)
+			layer2.clear()
+			layer2.insert('User:1', 'friends', OperationLocation.end, 'User:7')
+			storage.resolveLayer(layer2.id)
+
+			// simulate a mutation response with different data (clear the layer, add a new record, and resolve it)
+			layer1.clear()
+			layer1.insert('User:1', 'friends', OperationLocation.end, 'User:4')
+			storage.resolveLayer(layer1.id)
 
 			// look up the linked list
 			expect(storage.get('User:1', 'friends')).toEqual({
-				value: ['User:2', 'User:5', 'User:4'],
+				value: ['User:2', 'User:4', 'User:5', 'User:7'],
+				displayLayers: [baseLayerID],
+				kind: 'link',
+			})
+			// there should only be one layer
+			expect(storage.layerCount).toEqual(1)
+		})
+
+		test('insert into start of linked list', function () {
+			const storage = new InMemoryStorage()
+
+			// add a linked list that we will append to in an optimistic layer
+			const baseLayerID = storage.writeLink('User:1', 'friends', ['User:2'])
+
+			// create an optimistic layer and insert a new friend
+			const layer1 = storage.createLayer(true)
+			layer1.insert('User:1', 'friends', OperationLocation.start, 'User:3')
+
+			// insert some more records in a non-optimistic layer
+			storage.insert('User:1', 'friends', OperationLocation.start, 'User:5')
+			const layer3 = storage.topLayer
+
+			// make sure we got the full list back
+			expect(storage.get('User:1', 'friends')).toEqual({
+				value: ['User:5', 'User:3', 'User:2'],
+				displayLayers: [storage.topLayer.id, layer1.id, baseLayerID],
+				kind: 'link',
+			})
+
+			// create an optimistic layer and insert a new friend
+			const layer2 = storage.createLayer(true)
+			layer2.insert('User:1', 'friends', OperationLocation.start, 'User:6')
+
+			// make sure we got the full list back
+			expect(storage.get('User:1', 'friends')).toEqual({
+				value: ['User:6', 'User:5', 'User:3', 'User:2'],
+				displayLayers: [layer2.id, layer3.id, layer1.id, baseLayerID],
+				kind: 'link',
+			})
+
+			// simulate a mutation response with different data (clear the layer, add a new record, and resolve it)
+			layer2.clear()
+			layer2.insert('User:1', 'friends', OperationLocation.start, 'User:7')
+			storage.resolveLayer(layer2.id)
+
+			// simulate a mutation response with different data (clear the layer, add a new record, and resolve it)
+			layer1.clear()
+			layer1.insert('User:1', 'friends', OperationLocation.start, 'User:4')
+			storage.resolveLayer(layer1.id)
+
+			// look up the linked list
+			expect(storage.get('User:1', 'friends')).toEqual({
+				value: ['User:7', 'User:5', 'User:4', 'User:2'],
 				displayLayers: [baseLayerID],
 				kind: 'link',
 			})

--- a/packages/houdini/src/runtime/cache/tests/subscriptions.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/subscriptions.test.ts
@@ -3,7 +3,7 @@ import { test, expect, vi } from 'vitest'
 import { testConfigFile } from '../../../test'
 import type { SubscriptionSelection } from '../../lib'
 import { RefetchUpdateMode } from '../../lib'
-import { Cache } from '../cache'
+import { Cache, rootID } from '../cache'
 
 const config = testConfigFile()
 
@@ -1128,6 +1128,11 @@ test('deleting a node removes nested subscriptions', function () {
 				keyRaw: 'viewer',
 				selection: {
 					fields: {
+						__typename: {
+							type: 'String',
+							visible: true,
+							keyRaw: '__typename',
+						},
 						id: {
 							type: 'ID',
 							visible: true,
@@ -1144,6 +1149,11 @@ test('deleting a node removes nested subscriptions', function () {
 							},
 							selection: {
 								fields: {
+									__typename: {
+										type: 'String',
+										visible: true,
+										keyRaw: '__typename',
+									},
 									id: {
 										type: 'ID',
 										visible: true,
@@ -1168,9 +1178,11 @@ test('deleting a node removes nested subscriptions', function () {
 		selection,
 		data: {
 			viewer: {
+				__typename: 'User',
 				id: '1',
 				friends: [
 					{
+						__typename: 'User',
 						id: '2',
 						firstName: 'jane',
 					},
@@ -1197,6 +1209,369 @@ test('deleting a node removes nested subscriptions', function () {
 
 	// sanity check
 	expect(cache._internal_unstable.subscriptions.get('User:2', 'firstName')).toHaveLength(0)
+})
+
+test('find subSelection', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						__typename: {
+							type: 'String',
+							visible: true,
+							keyRaw: '__typename',
+						},
+						id: {
+							type: 'ID',
+							visible: true,
+							keyRaw: 'id',
+						},
+						friends: {
+							type: 'User',
+							visible: true,
+							keyRaw: 'friends',
+							list: {
+								name: 'All_Users',
+								connection: false,
+								type: 'User',
+							},
+							selection: {
+								fields: {
+									__typename: {
+										type: 'String',
+										visible: true,
+										keyRaw: '__typename',
+									},
+									id: {
+										type: 'ID',
+										visible: true,
+										keyRaw: 'id',
+									},
+									firstName: {
+										type: 'String',
+										visible: true,
+										keyRaw: 'firstName',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// start off associated with one object
+	cache.write({
+		selection,
+		data: {
+			viewer: {
+				__typename: 'User',
+				id: '1',
+				friends: [
+					{
+						__typename: 'User',
+						id: '2',
+						firstName: 'jane',
+					},
+				],
+			},
+		},
+	})
+
+	const subSelections = cache._internal_unstable.subscriptions.findSubSelections(
+		rootID,
+		selection,
+		{},
+		'User:1'
+	)
+
+	expect(subSelections).toEqual([
+		{
+			fields: {
+				__typename: {
+					type: 'String',
+					visible: true,
+					keyRaw: '__typename',
+				},
+				id: {
+					type: 'ID',
+					visible: true,
+					keyRaw: 'id',
+				},
+				friends: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'friends',
+					list: {
+						name: 'All_Users',
+						connection: false,
+						type: 'User',
+					},
+					selection: {
+						fields: {
+							__typename: {
+								type: 'String',
+								visible: true,
+								keyRaw: '__typename',
+							},
+							id: {
+								type: 'ID',
+								visible: true,
+								keyRaw: 'id',
+							},
+							firstName: {
+								type: 'String',
+								visible: true,
+								keyRaw: 'firstName',
+							},
+						},
+					},
+				},
+			},
+		},
+	])
+})
+
+test('find subSelection - avoid cycles', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						__typename: {
+							type: 'String',
+							visible: true,
+							keyRaw: '__typename',
+						},
+						id: {
+							type: 'ID',
+							visible: true,
+							keyRaw: 'id',
+						},
+						friends: {
+							type: 'User',
+							visible: true,
+							keyRaw: 'friends',
+							list: {
+								name: 'All_Users',
+								connection: false,
+								type: 'User',
+							},
+							selection: {
+								fields: {
+									__typename: {
+										type: 'String',
+										visible: true,
+										keyRaw: '__typename',
+									},
+									id: {
+										type: 'ID',
+										visible: true,
+										keyRaw: 'id',
+									},
+									firstName: {
+										type: 'String',
+										visible: true,
+										keyRaw: 'firstName',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// start off associated with one object
+	cache.write({
+		selection,
+		data: {
+			viewer: {
+				__typename: 'User',
+				id: '1',
+				friends: [
+					{
+						__typename: 'User',
+						id: '1',
+						firstName: 'jane',
+					},
+				],
+			},
+		},
+	})
+
+	const subSelections = cache._internal_unstable.subscriptions.findSubSelections(
+		rootID,
+		selection,
+		{},
+		'User:1'
+	)
+
+	expect(subSelections).toEqual([
+		{
+			fields: {
+				__typename: {
+					type: 'String',
+					visible: true,
+					keyRaw: '__typename',
+				},
+				id: {
+					type: 'ID',
+					visible: true,
+					keyRaw: 'id',
+				},
+				friends: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'friends',
+					list: {
+						name: 'All_Users',
+						connection: false,
+						type: 'User',
+					},
+					selection: {
+						fields: {
+							__typename: {
+								type: 'String',
+								visible: true,
+								keyRaw: '__typename',
+							},
+							id: {
+								type: 'ID',
+								visible: true,
+								keyRaw: 'id',
+							},
+							firstName: {
+								type: 'String',
+								visible: true,
+								keyRaw: 'firstName',
+							},
+						},
+					},
+				},
+			},
+		},
+	])
+})
+
+test('find subSelection - deeply nested', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						__typename: {
+							type: 'String',
+							visible: true,
+							keyRaw: '__typename',
+						},
+						id: {
+							type: 'ID',
+							visible: true,
+							keyRaw: 'id',
+						},
+						friends: {
+							type: 'User',
+							visible: true,
+							keyRaw: 'friends',
+							list: {
+								name: 'All_Users',
+								connection: false,
+								type: 'User',
+							},
+							selection: {
+								fields: {
+									__typename: {
+										type: 'String',
+										visible: true,
+										keyRaw: '__typename',
+									},
+									id: {
+										type: 'ID',
+										visible: true,
+										keyRaw: 'id',
+									},
+									firstName: {
+										type: 'String',
+										visible: true,
+										keyRaw: 'firstName',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// start off associated with one object
+	cache.write({
+		selection,
+		data: {
+			viewer: {
+				__typename: 'User',
+				id: '1',
+				friends: [
+					{
+						__typename: 'User',
+						id: '2',
+						firstName: 'jane',
+					},
+				],
+			},
+		},
+	})
+
+	const subSelections = cache._internal_unstable.subscriptions.findSubSelections(
+		rootID,
+		selection,
+		{},
+		'User:2'
+	)
+
+	expect(subSelections).toEqual([
+		{
+			fields: {
+				__typename: {
+					type: 'String',
+					visible: true,
+					keyRaw: '__typename',
+				},
+				id: {
+					type: 'ID',
+					visible: true,
+					keyRaw: 'id',
+				},
+				firstName: {
+					type: 'String',
+					visible: true,
+					keyRaw: 'firstName',
+				},
+			},
+		},
+	])
 })
 
 test('same record twice in a query survives one unsubscribe (reference counting)', function () {

--- a/packages/houdini/src/runtime/client/plugins/optimisticKeys.ts
+++ b/packages/houdini/src/runtime/client/plugins/optimisticKeys.ts
@@ -137,8 +137,9 @@ export const optimisticKeys =
 								// clean up the caches since we're done with this key
 								delete callbackCache[optimisticValue]
 							},
-							onIDChange: (optimisticValue, realValue) =>
-								cache.registerKeyMap(optimisticValue, realValue),
+							onIDChange: (optimisticValue, realValue) => {
+								cache.registerKeyMap(optimisticValue, realValue)
+							},
 						}
 					)
 				}
@@ -296,7 +297,7 @@ function extractResponseKeys(
 	mutationID: number,
 	events: {
 		onNewKey: (optimisticValue: string | number, realValue: string | number) => void
-		onIDChange: (optimisticValue: string | number, realValue: string | number) => void
+		onIDChange: (optimisticValue: string, realValue: string) => void
 	},
 	objectIDs: OptimisticObjectIDMap = objectIDMap,
 	path: string = '',


### PR DESCRIPTION
While building a trellix clone for Houdini, I ran into a few bugs related to some edge cases with our optimistic infrastructure. This PR will clean up what I run into while building the demo. So far, I have:

- fixed a bug when there are multiple pending optimistic inserts that rely on @optimisticKey
- addressed an issue when unsubscribes from a delete would be a little too aggressive
- fixed a bug when there is both a delete and create+insert that are optimistically pending

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`