### PR TITLE
Mention include: "credentials" in authentification docs

### DIFF
--- a/site/src/routes/guides/authentication/+page.svx
+++ b/site/src/routes/guides/authentication/+page.svx
@@ -40,3 +40,5 @@ export default new HoudiniClient({
     }
 })
 ```
+
+Tip: If your API uses HTTP-Only cookies, don't forget to add `include: "credentials"` to `fetchParams`' return value


### PR DESCRIPTION
Hi! I spent way too much time trying to figure out why "Houdini isn't passing cookies to the API while Svelte is", after switching to OAuth2-backed authentication with HTTP-Only cookies.

This is just a friendly reminder, not something Houdini-specific, but it'll surely prevent some tickets ^^


### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

