### PR TITLE
Cancel duplicated pagination fetches

### DIFF
--- a/.changeset/serious-penguins-unite.md
+++ b/.changeset/serious-penguins-unite.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Cancel duplicated pagination fetches if one is already in-flight

--- a/e2e/_api/graphql.mjs
+++ b/e2e/_api/graphql.mjs
@@ -122,6 +122,7 @@ export const typeDefs = /* GraphQL */ `
 			before: String
 			first: Int
 			last: Int
+			delay: Int
 			snapshot: String!
 		): UserConnection!
 		usersList(limit: Int = 4, offset: Int, snapshot: String!): [User!]!
@@ -450,7 +451,12 @@ export const resolvers = {
 			}
 			throw new GraphQLError('No authorization found', { code: 403 })
 		},
-		usersConnection(_, args) {
+		usersConnection: async (_, args) => {
+			// simulate network delay
+			if (args.delay) {
+				await sleep(args.delay)
+			}
+
 			return connectionFromArray(getUserSnapshot(args.snapshot), args)
 		},
 		user: async (_, args) => {

--- a/e2e/_api/schema.graphql
+++ b/e2e/_api/schema.graphql
@@ -110,6 +110,7 @@ type Query {
 		before: String
 		first: Int
 		last: Int
+        delay: Int
 		snapshot: String!
 	): UserConnection!
 	usersList(limit: Int = 4, offset: Int, snapshot: String!): [User!]!

--- a/e2e/kit/src/lib/utils/routes.ts
+++ b/e2e/kit/src/lib/utils/routes.ts
@@ -92,6 +92,7 @@ export const routes = {
   Pagination_query_bidirectional_cursor: '/pagination/query/bidirectional-cursor',
   Pagination_query_bidirectional_cursor_single_page:
     '/pagination/query/bidirectional-cursor-single-page',
+  Pagination_query_dedupe_pagination_fetch: 'pagination/query/dedupe-pagination-fetch',
   Pagination_query_offset: '/pagination/query/offset',
   Pagination_query_offset_single_page: '/pagination/query/offset-single-page',
   Pagination_query_offset_variable: '/pagination/query/offset-variable',

--- a/e2e/kit/src/routes/pagination/query/dedupe-pagination-fetch/+page.gql
+++ b/e2e/kit/src/routes/pagination/query/dedupe-pagination-fetch/+page.gql
@@ -1,0 +1,9 @@
+query DedupePaginationFetch {
+  usersConnection(first: 2, delay: 500, snapshot: "dedupe-pagination-fetch") @paginate {
+    edges {
+      node {
+        name
+      }
+    }
+  }
+}

--- a/e2e/kit/src/routes/pagination/query/dedupe-pagination-fetch/+page.svelte
+++ b/e2e/kit/src/routes/pagination/query/dedupe-pagination-fetch/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import type { PageData } from './$houdini';
+
+  export let data: PageData;
+  $: ({ DedupePaginationFetch } = data);
+</script>
+
+<div id="result">
+  {$DedupePaginationFetch.data?.usersConnection.edges.map(({ node }) => node?.name).join(', ')}
+</div>
+
+<div id="pageInfo">
+  {JSON.stringify($DedupePaginationFetch.pageInfo)}
+</div>
+
+<button id="next" on:click={() => DedupePaginationFetch.loadNextPage()}>next</button>

--- a/e2e/kit/src/routes/pagination/query/dedupe-pagination-fetch/spec.ts
+++ b/e2e/kit/src/routes/pagination/query/dedupe-pagination-fetch/spec.ts
@@ -1,0 +1,41 @@
+import { sleep } from '@kitql/helpers';
+import test, { expect, type Response } from '@playwright/test';
+import { routes } from '../../../../lib/utils/routes.js';
+import { expect_1_gql, expect_to_be, goto } from '../../../../lib/utils/testsHelper.js';
+
+test('pagination before previous request was finished', async ({ page }) => {
+  await goto(page, routes.Pagination_query_dedupe_pagination_fetch);
+
+  await expect_to_be(page, 'Bruce Willis, Samuel Jackson');
+
+  // Adapted from `expect_n_gql` in lib/utils/testsHelper.ts
+  let nbResponses = 0;
+  async function fnRes(response: Response) {
+    if (response.url().endsWith(routes.GraphQL)) {
+      nbResponses++;
+    }
+  }
+
+  page.on('response', fnRes);
+
+  // Click the "next page" button twice
+  await page.click('button[id=next]');
+  await page.click('button[id=next]');
+
+  // Give the query some time to execute
+  await sleep(1000);
+
+  // Check that only one gql request happened.
+  expect(nbResponses).toBe(1);
+
+  page.removeListener('response', fnRes);
+
+  await expect_to_be(page, 'Bruce Willis, Samuel Jackson, Morgan Freeman, Tom Hanks');
+
+  // Fetching the 3rd page still works ok.
+  await expect_1_gql(page, 'button[id=next]');
+  await expect_to_be(
+    page,
+    'Bruce Willis, Samuel Jackson, Morgan Freeman, Tom Hanks, Will Smith, Harrison Ford'
+  );
+});


### PR DESCRIPTION
When a pagination query takes some time to execute, it is possible to call `loadNextPage` again before the first fetch has finished. This will then give data for the same page  twice, and Houdini simply adds the data to the list.
This can cause some major problems whenever you have a keyed each-loop in svelte, causing a major crash of the application.

This PR adds a check around the `loadNextPage` and cancels the request whenever one for the same page is already in flight.

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

