### PR TITLE
Fix return types for pagination handlers

### DIFF
--- a/.changeset/kind-suns-clap.md
+++ b/.changeset/kind-suns-clap.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix return types for pagination loadNextPage and loadPreviousPage

--- a/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
+++ b/packages/houdini-svelte/src/runtime/stores/pagination/query.ts
@@ -86,7 +86,7 @@ export class QueryStoreCursor<
 
 	async loadPreviousPage(
 		args?: Parameters<Required<CursorHandlers<_Data, _Input>>['loadPreviousPage']>[0]
-	) {
+	): Promise<ReturnType<CursorHandlers<_Data, _Input>['loadPreviousPage']>> {
 		const handlers = await this.#handlers()
 		try {
 			return await handlers.loadPreviousPage(args)
@@ -94,13 +94,16 @@ export class QueryStoreCursor<
 			const err = e as Error
 			// if the error is an abort error then we don't want to throw
 			if (err.name === 'AbortError') {
+				return get(this.observer)
 			} else {
 				throw err
 			}
 		}
 	}
 
-	async loadNextPage(args?: Parameters<CursorHandlers<_Data, _Input>['loadNextPage']>[0]) {
+	async loadNextPage(
+		args?: Parameters<CursorHandlers<_Data, _Input>['loadNextPage']>[0]
+	): Promise<ReturnType<CursorHandlers<_Data, _Input>['loadNextPage']>> {
 		const handlers = await this.#handlers()
 		try {
 			return await handlers.loadNextPage(args)
@@ -108,6 +111,7 @@ export class QueryStoreCursor<
 			const err = e as Error
 			// if the error is an abort error then we don't want to throw
 			if (err.name === 'AbortError') {
+				return get(this.observer)
 			} else {
 				throw err
 			}


### PR DESCRIPTION
This fixes a subtle bug that crept in with #1352, where the return types for `loadNextPage` and `loadPreviousPage` became `Promise<QueryResult<_Data, _Input> | undefined>` instead of the `Promise<QueryResult<_Data, _Input>>` as defined by the `CursorHandlers` type.

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [ ] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [ ] Includes a changeset if your fix affects the user with `pnpm changeset`

