### PR TITLE
Fix init script using incorrect houdini-svelte version

### DIFF
--- a/.changeset/thirty-melons-hug.md
+++ b/.changeset/thirty-melons-hug.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix init script using incorrect version for houdini-svelte plugin

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,14 +131,8 @@ jobs:
             - name: Build packages
               run: cd houdini && pnpm run compile
 
-            - name: Checkout template
-              uses: actions/checkout@v4
-              with:
-                repository: sveltejs/kit
-                path: kit
-
-            - name: Extract Template
-              run: mv kit/packages/create-svelte/templates/default project
+            - name: Create template project
+              run: pnpm dlx sv create project --check-types none --template demo --no-integrations --no-install
 
             - name: Run init
               run: cd project && node ../houdini/packages/houdini/build/cmd-esm/index.js init -y

--- a/packages/houdini/src/cmd/init.ts
+++ b/packages/houdini/src/cmd/init.ts
@@ -588,13 +588,13 @@ async function packageJSON(targetPath: string, frameworkInfo: HoudiniFrameworkIn
 	// houdini should be a dev dependencies
 	packageJSON.devDependencies = {
 		...packageJSON.devDependencies,
-		houdini: '^PACKAGE_VERSION',
+		houdini: '^HOUDINI_PACKAGE_VERSION',
 	}
 
 	if (frameworkInfo.framework === 'svelte' || frameworkInfo.framework === 'kit') {
 		packageJSON.devDependencies = {
 			...packageJSON.devDependencies,
-			'houdini-svelte': '^PACKAGE_VERSION',
+			'houdini-svelte': '^HOUDINI_SVELTE_PACKAGE_VERSION',
 		}
 	} else {
 		throw new Error(`Unmanaged framework: "${JSON.stringify(frameworkInfo)}"`)


### PR DESCRIPTION
When running `npx houdini init` on a brand new svelte project, the init script would incorrectly assume the version for the `houdini` package is the same as the version for the `houdini-svelte` package.
This PR fixes it by altering the build script to fetch the package.json files for all the packages, and then either use `houdini`'s version, or `houdini-svelte`'s version 

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

