### PR TITLE
Update verify_init script to support changed sv CLI options

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,7 +132,7 @@ jobs:
               run: cd houdini && pnpm run compile
 
             - name: Create template project
-              run: pnpm dlx sv create project --check-types none --template demo --no-integrations --no-install
+              run: pnpm dlx sv@0.6 create project --types ts --template demo --no-add-ons --no-install
 
             - name: Run init
               run: cd project && node ../houdini/packages/houdini/build/cmd-esm/index.js init -y


### PR DESCRIPTION
This fixes currently broken builds, because of the deprecated CLI options in the svelte cli.
I also pinned the version of the cli to the current latest, 0.6, so that we don't have to do this again every time they push a non-backwards compatible change.

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [ ] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [ ] Includes a changeset if your fix affects the user with `pnpm changeset`

