### PR TITLE
Don't crash dev server when a schema loading error occurs

### DIFF
--- a/.changeset/cyan-steaks-laugh.md
+++ b/.changeset/cyan-steaks-laugh.md
@@ -1,0 +1,5 @@
+---
+"houdini": patch
+---
+
+Don't crash dev server when a schema loading error occurs

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -1173,7 +1173,11 @@ export async function getConfig({
 
 			// the schema is safe to load
 			if (schemaOk && !noSchema) {
-				_config.schema = await loadSchemaFile(_config.schemaPath)
+				try {
+					_config.schema = await loadSchemaFile(_config.schemaPath)
+				} catch(e) {
+					console.error(`⚠️  Your schema file could not be loaded: ${e}`)
+				}
 			}
 		}
 

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -1175,7 +1175,7 @@ export async function getConfig({
 			if (schemaOk && !noSchema) {
 				try {
 					_config.schema = await loadSchemaFile(_config.schemaPath)
-				} catch(e) {
+				} catch (e) {
 					console.error(`⚠️  Your schema file could not be loaded: ${e}`)
 				}
 			}


### PR DESCRIPTION
Fixes #1377

By just logging the error to the console instead of letting the exception bubble all the way up, we prevent vite from dying and thus forcing a full devserver manual restart when e.g. the graphql schema temporarily becomes invalid syntax. Useful when hand-writing the schema (with schema-first server development approaches) or even in code-first setups, when the tooling is such that the generated schema temporarily becomes a blank file somehow (totally not what is happening too me)

It looks like this on my end:

```bash
# schema gets written but somehow is just empty
# houdini tries to load the schema in that state
⚠️  Your schema file could not be loaded: Syntax Error: Unexpected <EOF>.

GraphQL request:1:1
1 |
  | ^
❌ Cannot read properties of undefined (reading 'getDirectives')
# schema gets written again, this time with the actual content
# page reloads after the schema file was loaded successfully
3:55:04 AM [vite] page reload $houdini/runtime/index.js
3:55:04 AM [vite] page reload $houdini/plugins/houdini-svelte/runtime/fragments.js
```

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix: same reason as to why providing a repro is really complicated: this requires _a lot_ of setup, spinning up vite + another server that just blanks out the file, and somehow checking to see if the vite process is still running
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`: i see no reason for the tests to fail, I edited the file in node_modules to quickly patch it locally on my dev setup, and created this PR from github.dev to reflect the changes I made
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

