### PR TITLE
Take LoadingType object union into account for FragmentStore

### DIFF
--- a/.changeset/sour-starfishes-push.md
+++ b/.changeset/sour-starfishes-push.md
@@ -1,6 +1,7 @@
 ---
 'houdini': minor
 'houdini-svelte': patch
+'houdini-react': patch
 ---
 
 Add new types GraphQLLoadedValue and GraphQLLoadedObject, and include LoadingType in GraphQLValue

--- a/.changeset/sour-starfishes-push.md
+++ b/.changeset/sour-starfishes-push.md
@@ -1,0 +1,6 @@
+---
+'houdini': minor
+'houdini-svelte': patch
+---
+
+Add new types GraphQLLoadedValue and GraphQLLoadedObject, and include LoadingType in GraphQLValue

--- a/packages/houdini-react/src/runtime/componentFields.ts
+++ b/packages/houdini-react/src/runtime/componentFields.ts
@@ -1,6 +1,6 @@
 import { defaultComponentField, type Cache } from '$houdini/runtime/cache/cache'
 import { getFieldsForType } from '$houdini/runtime/lib/selection'
-import type { DocumentArtifact, GraphQLValue } from 'houdini'
+import type { DocumentArtifact, GraphQLLoadedValue, GraphQLValue } from 'houdini'
 
 export function injectComponents({
 	cache,
@@ -12,7 +12,7 @@ export function injectComponents({
 	cache: Cache
 	selection: DocumentArtifact['selection']
 	data: GraphQLValue | null
-	variables: Record<string, GraphQLValue> | undefined | null
+	variables: Record<string, GraphQLLoadedValue> | undefined | null
 	parentType?: string
 }) {
 	// if the value is null, we're done

--- a/packages/houdini-react/src/runtime/hooks/useDocumentStore.ts
+++ b/packages/houdini-react/src/runtime/hooks/useDocumentStore.ts
@@ -1,6 +1,10 @@
-import type { DocumentArtifact, GraphQLVariables, QueryResult } from '$houdini/lib/types'
+import type {
+	DocumentArtifact,
+	GraphQLVariables,
+	QueryResult,
+	GraphQLObject,
+} from '$houdini/lib/types'
 import type { DocumentStore, ObserveParams } from '$houdini/runtime/client'
-import type { GraphQLObject } from 'houdini'
 import * as React from 'react'
 
 import { useClient } from '../routing'

--- a/packages/houdini-react/src/runtime/hooks/useDocumentSubscription.ts
+++ b/packages/houdini-react/src/runtime/hooks/useDocumentSubscription.ts
@@ -1,6 +1,10 @@
-import type { DocumentArtifact, GraphQLVariables, QueryResult } from '$houdini/lib/types'
+import type {
+	DocumentArtifact,
+	GraphQLObject,
+	GraphQLVariables,
+	QueryResult,
+} from '$houdini/lib/types'
 import type { DocumentStore, SendParams } from '$houdini/runtime/client'
-import type { GraphQLObject } from 'houdini'
 
 import { useSession } from '../routing/Router'
 import useDeepCompareEffect from './useDeepCompareEffect'

--- a/packages/houdini-svelte/src/runtime/stores/subscription.ts
+++ b/packages/houdini-svelte/src/runtime/stores/subscription.ts
@@ -1,10 +1,10 @@
 import type {
+	GraphQLLoadedObject,
 	GraphQLVariables,
 	QueryResult,
 	SubscriptionArtifact,
 } from '$houdini/runtime/lib/types'
 import { CompiledSubscriptionKind } from '$houdini/runtime/lib/types'
-import type { GraphQLObject } from 'houdini'
 import { derived, writable, type Subscriber, type Writable } from 'svelte/store'
 
 import { initClient } from '../client'
@@ -12,7 +12,7 @@ import { getSession } from '../session'
 import { BaseStore } from './base'
 
 export class SubscriptionStore<
-	_Data extends GraphQLObject,
+	_Data extends GraphQLLoadedObject,
 	_Input extends GraphQLVariables
 > extends BaseStore<_Data, _Input, SubscriptionArtifact> {
 	kind = CompiledSubscriptionKind

--- a/packages/houdini/src/runtime/cache/cache.ts
+++ b/packages/houdini/src/runtime/cache/cache.ts
@@ -1,10 +1,12 @@
 import { computeKey, PendingValue } from '../lib'
 import type { ConfigFile } from '../lib/config'
-import { computeID, defaultConfigValues, keyFieldsForType, getCurrentConfig } from '../lib/config'
+import { computeID, defaultConfigValues, getCurrentConfig, keyFieldsForType } from '../lib/config'
 import { deepEquals } from '../lib/deepEquals'
 import { flatten } from '../lib/flatten'
 import { getFieldsForType } from '../lib/selection'
 import type {
+	GraphQLLoadedObject,
+	GraphQLLoadedValue,
 	GraphQLObject,
 	GraphQLValue,
 	NestedList,
@@ -1535,7 +1537,7 @@ class CacheInternal {
 	}
 }
 
-export function evaluateVariables(variables: ValueMap, args: GraphQLObject) {
+export function evaluateVariables(variables: ValueMap, args: GraphQLLoadedObject) {
 	return Object.fromEntries(
 		Object.entries(variables).map(([key, value]) => [key, variableValue(value, args)])
 	)
@@ -1548,7 +1550,7 @@ function wrapInLists<T>(target: T, count: number = 0): T | NestedList<T> {
 	return wrapInLists([target], count - 1)
 }
 
-export function variableValue(value: ValueNode, args: GraphQLObject): GraphQLValue {
+export function variableValue(value: ValueNode, args: GraphQLLoadedObject): GraphQLLoadedValue {
 	if (value.kind === 'StringValue') {
 		return value.value
 	}
@@ -1607,7 +1609,7 @@ export function defaultComponentField({
 	cache: Cache
 	component: Required<Required<SubscriptionSelection>['fields'][string]>['component']
 	loading?: boolean
-	variables: Record<string, GraphQLValue> | undefined | null
+	variables: Record<string, GraphQLLoadedValue> | undefined | null
 	parent: string
 }) {
 	return (props: any) => {

--- a/packages/houdini/src/runtime/lib/types.ts
+++ b/packages/houdini/src/runtime/lib/types.ts
@@ -173,9 +173,26 @@ export type MutationOperation = {
 
 export type GraphQLObject = { [key: string]: GraphQLValue }
 
+export type GraphQLLoadedObject = {
+	[key: string]: GraphQLLoadedValue
+}
+
 export type GraphQLDefaultScalar = string | number | boolean
 
-export type GraphQLValue = GraphQLDefaultScalar | null | GraphQLObject | GraphQLValue[] | undefined
+export type GraphQLLoadedValue =
+	| GraphQLDefaultScalar
+	| null
+	| GraphQLLoadedObject
+	| GraphQLLoadedValue[]
+	| undefined
+
+export type GraphQLValue =
+	| LoadingType
+	| GraphQLDefaultScalar
+	| null
+	| GraphQLObject
+	| GraphQLValue[]
+	| undefined
 
 export type GraphQLVariables = { [key: string]: any } | null
 


### PR DESCRIPTION
Fixes #1388

By defining new GraphQLLoadedValue & GraphQLLoadedObject types and including LoadingType in GraphQLValue's definition, every type in the library take could accept a loading value reflects this fact in its types. This allows typescript to infer things correctly

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

