### PR TITLE
Fix documentation parameter type spelling error

### DIFF
--- a/site/src/routes/api/graphql-magic/+page.svx
+++ b/site/src/routes/api/graphql-magic/+page.svx
@@ -60,7 +60,7 @@ mutation UncompleteItem($id: ID!) {
 }
 ```
 
-### `@dedupe(cancelFirst: Booleam)`
+### `@dedupe(cancelFirst: Boolean)`
 
 `@dedupe` lets you control wether or not multiple copies of the same operation (query or mutation) are allowed to run at the same time.
 If you pass `true` for the `cancelFirst` argument then the first copy of the operation will be canceled (including any in-flight requests).


### PR DESCRIPTION
This is just an update to a spelling error in the docs. No tests need to run and there is no change in the API that would require generateing a changeset.

### To help everyone out, please make sure your PR does the following:

These aren't applicable in this case

~- [ ] Update the first line to point to the ticket that this PR fixes~
~- [ ] Add a message that clearly describes the fix~
~- [ ] If applicable, add a test that would fail without this fix~
~- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`~
~- [ ] Includes a changeset if your fix affects the user with `pnpm changeset`~

