### PR TITLE
Fix credentials key, value order

### DIFF
--- a/site/src/routes/guides/authentication/+page.svx
+++ b/site/src/routes/guides/authentication/+page.svx
@@ -41,4 +41,4 @@ export default new HoudiniClient({
 })
 ```
 
-Tip: If your API uses HTTP-Only cookies, don't forget to add `include: "credentials"` to `fetchParams`' return value
+Tip: If your API uses HTTP-Only cookies, don't forget to add `credentials: "include"` to `fetchParams`' return value


### PR DESCRIPTION
The property is called `credentials` and the value `include`. This only touches documentation so no tests have been changed.

Fixes #TICKET

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

