### PR TITLE
Give better error when receiving non-JSON response

### DIFF
--- a/.changeset/fluffy-lamps-provide.md
+++ b/.changeset/fluffy-lamps-provide.md
@@ -2,4 +2,4 @@
 'houdini': patch
 ---
 
-Throw the semantic HTML error code and message when receiving a non-JSON error response from the server
+Throw the semantic HTTP error code and message when receiving a non-JSON error response from the server

--- a/.changeset/fluffy-lamps-provide.md
+++ b/.changeset/fluffy-lamps-provide.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Throw the semantic HTML error code and message when receiving a non-JSON error response from the server

--- a/packages/houdini/src/runtime/client/plugins/fetch.ts
+++ b/packages/houdini/src/runtime/client/plugins/fetch.ts
@@ -100,7 +100,9 @@ const defaultFetch = (
 			result.headers.get('content-type') !== 'application/json' &&
 			result.headers.get('content-type') !== 'application/graphql+json'
 		) {
-			throw new Error(`${result.status}": ${result.statusText}`)
+			throw new Error(
+				`Failed to fetch: server returned invalid response with error ${result.status}": ${result.statusText}`
+			)
 		}
 
 		return await result.json()

--- a/packages/houdini/src/runtime/client/plugins/fetch.ts
+++ b/packages/houdini/src/runtime/client/plugins/fetch.ts
@@ -94,6 +94,15 @@ const defaultFetch = (
 			},
 		})
 
+		// Avoid parsing the response if it's not JSON, as that will throw a SyntaxError
+		if (
+			!result.ok &&
+			result.headers.get('content-type') !== 'application/json' &&
+			result.headers.get('content-type') !== 'application/graphql+json'
+		) {
+			throw new Error(`${result.status}": ${result.statusText}`)
+		}
+
 		return await result.json()
 	}
 }

--- a/packages/houdini/src/runtime/client/plugins/fetch.ts
+++ b/packages/houdini/src/runtime/client/plugins/fetch.ts
@@ -101,7 +101,7 @@ const defaultFetch = (
 			result.headers.get('content-type') !== 'application/graphql+json'
 		) {
 			throw new Error(
-				`Failed to fetch: server returned invalid response with error ${result.status}": ${result.statusText}`
+				`Failed to fetch: server returned invalid response with error ${result.status}: ${result.statusText}`
 			)
 		}
 


### PR DESCRIPTION
Fixes # N/A : https://discord.com/channels/1024421016405016718/1301635915663278131

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

Without this, if the server returns a non-JSON error response such as an NGINX error page, `defaultFetch` will still attempt to parse the response as JSON, which will throw a syntax error. Instead, this PR changes it to throw the semantic HTTP error which is easier to understand than a SyntaxError from parsing HTML as JSON.