### PR TITLE
Fix bug where JSON error response might get treated as non-JSON error response

### DIFF
--- a/.changeset/fluffy-lamps-provide.md
+++ b/.changeset/fluffy-lamps-provide.md
@@ -2,4 +2,4 @@
 'houdini': patch
 ---
 
-Throw the semantic HTML error code and message when receiving a non-JSON error response from the server
+Throw the semantic HTTP error code and message when receiving a non-JSON error response from the server

--- a/.changeset/fluffy-lamps-provide.md
+++ b/.changeset/fluffy-lamps-provide.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Throw the semantic HTML error code and message when receiving a non-JSON error response from the server

--- a/.changeset/fluffy-lamps-provide.md
+++ b/.changeset/fluffy-lamps-provide.md
@@ -1,5 +1,0 @@
----
-'houdini': patch
----
-
-Throw the semantic HTTP error code and message when receiving a non-JSON error response from the server

--- a/.changeset/tough-insects-joke.md
+++ b/.changeset/tough-insects-joke.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix error bug JSON response might get treated as non-JSON if it includes `charset` or `boundary`

--- a/packages/houdini/src/runtime/client/plugins/fetch.ts
+++ b/packages/houdini/src/runtime/client/plugins/fetch.ts
@@ -100,7 +100,9 @@ const defaultFetch = (
 			result.headers.get('content-type') !== 'application/json' &&
 			result.headers.get('content-type') !== 'application/graphql+json'
 		) {
-			throw new Error(`${result.status}": ${result.statusText}`)
+			throw new Error(
+				`Failed to fetch: server returned invalid response with error ${result.status}": ${result.statusText}`
+			)
 		}
 
 		return await result.json()

--- a/packages/houdini/src/runtime/client/plugins/fetch.ts
+++ b/packages/houdini/src/runtime/client/plugins/fetch.ts
@@ -97,8 +97,8 @@ const defaultFetch = (
 		// Avoid parsing the response if it's not JSON, as that will throw a SyntaxError
 		if (
 			!result.ok &&
-			result.headers.get('content-type')?.startsWith('application/json') &&
-			result.headers.get('content-type')?.startsWith('application/graphql+json')
+			!result.headers.get('content-type')?.startsWith('application/json') &&
+			!result.headers.get('content-type')?.startsWith('application/graphql+json')
 		) {
 			throw new Error(
 				`Failed to fetch: server returned invalid response with error ${result.status}: ${result.statusText}`

--- a/packages/houdini/src/runtime/client/plugins/fetch.ts
+++ b/packages/houdini/src/runtime/client/plugins/fetch.ts
@@ -94,6 +94,15 @@ const defaultFetch = (
 			},
 		})
 
+		// Avoid parsing the response if it's not JSON, as that will throw a SyntaxError
+		if (
+			!result.ok &&
+			result.headers.get('content-type') !== 'application/json' &&
+			result.headers.get('content-type') !== 'application/graphql+json'
+		) {
+			throw new Error(`${result.status}": ${result.statusText}`)
+		}
+
 		return await result.json()
 	}
 }

--- a/packages/houdini/src/runtime/client/plugins/fetch.ts
+++ b/packages/houdini/src/runtime/client/plugins/fetch.ts
@@ -101,7 +101,7 @@ const defaultFetch = (
 			result.headers.get('content-type') !== 'application/graphql+json'
 		) {
 			throw new Error(
-				`Failed to fetch: server returned invalid response with error ${result.status}": ${result.statusText}`
+				`Failed to fetch: server returned invalid response with error ${result.status}: ${result.statusText}`
 			)
 		}
 

--- a/packages/houdini/src/runtime/client/plugins/fetch.ts
+++ b/packages/houdini/src/runtime/client/plugins/fetch.ts
@@ -97,8 +97,8 @@ const defaultFetch = (
 		// Avoid parsing the response if it's not JSON, as that will throw a SyntaxError
 		if (
 			!result.ok &&
-			result.headers.get('content-type') !== 'application/json' &&
-			result.headers.get('content-type') !== 'application/graphql+json'
+			result.headers.get('content-type')?.startsWith('application/json') &&
+			result.headers.get('content-type')?.startsWith('application/graphql+json')
 		) {
 			throw new Error(
 				`Failed to fetch: server returned invalid response with error ${result.status}: ${result.statusText}`


### PR DESCRIPTION
Fixes # N/A

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

This PR fixes a bug from https://github.com/HoudiniGraphql/houdini/pull/1404 where valid `content-type`s would be treated as invalid because it checked that the `content-type` was strictly equal to one of the valid values. However, the `content-type` header can have other stuff in it after the content type, (e.g. `application/json; charset=utf-8`) so just check that it starts with the right thing instead of checking equality.

