### PR TITLE
Ensure session data is always returned

### DIFF
--- a/.changeset/large-lamps-complain.md
+++ b/.changeset/large-lamps-complain.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix issue with sessions if there are early returns in root layout load

--- a/package.json
+++ b/package.json
@@ -62,9 +62,5 @@
 		"overrides": {
 			"graphql": "15.5.0"
 		}
-	},
-	"engines": {
-		"node": "^20",
-		"pnpm": "^8"
 	}
 }

--- a/packages/houdini-svelte/src/plugin/transforms/kit/session.test.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/kit/session.test.ts
@@ -318,3 +318,20 @@ test('passes session from root client-side layout', async function () {
 		}
 	`)
 })
+
+
+test('augments load function in root layout load', async function () {
+	const result = await test_transform_js('src/routes/+layout.js', `
+		import { browser } from '$app/environment';
+
+		export const load = async ({ url }) => {
+			console.log('routes/+layout.js start');
+			if (!browser) return;
+
+			console.log('this should only run in the browser');
+		};
+	
+	`)
+
+	expect(result).toMatchInlineSnapshot(``)
+})

--- a/packages/houdini-svelte/src/plugin/transforms/kit/session.test.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/kit/session.test.ts
@@ -42,11 +42,9 @@ test('export const load', async function () {
 
 		export const load = loadFlash(async event => {
 		    "some random stuff that's valid javascript";
-		    const __houdini__vite__plugin__return__value__ = {};
-
 		    return {
 		        ...buildSessionObject(event),
-		        ...__houdini__vite__plugin__return__value__
+		        ...{}
 		    };
 		});
 	`)
@@ -76,11 +74,9 @@ test('adds load to +layout.server.js', async function () {
 		import { buildSessionObject } from "$houdini/plugins/houdini-svelte/runtime/session";
 
 		export async function load(event) {
-		    const __houdini__vite__plugin__return__value__ = {};
-
 		    return {
 		        ...buildSessionObject(event),
-		        ...__houdini__vite__plugin__return__value__
+		        ...{}
 		    };
 		}
 	`)
@@ -105,13 +101,12 @@ test('modifies existing load +layout.server.js', async function () {
 
 		export async function load(event) {
 		    "some random stuff that's valid javascript";
-		    const __houdini__vite__plugin__return__value__ = {
-		        hello: "world"
-		    };
-
 		    return {
 		        ...buildSessionObject(event),
-		        ...__houdini__vite__plugin__return__value__
+
+		        ...{
+		            hello: "world"
+		        }
 		    };
 		}
 	`)
@@ -132,11 +127,9 @@ test('modifies existing load +layout.server.js - no return', async function () {
 
 		export async function load(event) {
 		    "some random stuff that's valid javascript";
-		    const __houdini__vite__plugin__return__value__ = {};
-
 		    return {
 		        ...buildSessionObject(event),
-		        ...__houdini__vite__plugin__return__value__
+		        ...{}
 		    };
 		}
 	`)
@@ -157,13 +150,12 @@ test('modifies existing load +layout.server.js - satisfies operator', async func
 		import type { LayoutServerLoad } from "./$types";
 
 		export const load = (event => {
-		    const __houdini__vite__plugin__return__value__ = ({
-		        test: "Hello"
-		    });
-
 		    return {
 		        ...buildSessionObject(event),
-		        ...__houdini__vite__plugin__return__value__
+
+		        ...({
+		            test: "Hello"
+		        })
 		    };
 		}) satisfies LayoutServerLoad;
 	`)
@@ -194,13 +186,12 @@ test('modifies existing load +layout.server.js - rest params', async function ()
 
 		    console.log(foo);
 
-		    const __houdini__vite__plugin__return__value__ = {
-		        some: "value"
-		    };
-
 		    return {
 		        ...buildSessionObject(event),
-		        ...__houdini__vite__plugin__return__value__
+
+		        ...{
+		            some: "value"
+		        }
 		    };
 		}
 	`)
@@ -231,13 +222,12 @@ test('modifies existing load +layout.server.js - const arrow function', async fu
 
 		    console.log(foo);
 
-		    const __houdini__vite__plugin__return__value__ = {
-		        some: "value"
-		    };
-
 		    return {
 		        ...buildSessionObject(event),
-		        ...__houdini__vite__plugin__return__value__
+
+		        ...{
+		            some: "value"
+		        }
 		    };
 		};
 	`)
@@ -268,13 +258,12 @@ test('modifies existing load +layout.server.js - const function', async function
 
 		    console.log(foo);
 
-		    const __houdini__vite__plugin__return__value__ = {
-		        some: "value"
-		    };
-
 		    return {
 		        ...buildSessionObject(event),
-		        ...__houdini__vite__plugin__return__value__
+
+		        ...{
+		            some: "value"
+		        }
 		    };
 		};
 	`)
@@ -292,13 +281,12 @@ test('modifies existing load +layout.server.js - implicit return', async functio
 		import { buildSessionObject } from "$houdini/plugins/houdini-svelte/runtime/session";
 
 		export const load = event => {
-		    const __houdini__vite__plugin__return__value__ = ({
-		        hello: "world"
-		    });
-
 		    return {
 		        ...buildSessionObject(event),
-		        ...__houdini__vite__plugin__return__value__
+
+		        ...({
+		            hello: "world"
+		        })
 		    };
 		};
 	`)
@@ -309,19 +297,18 @@ test('passes session from root client-side layout', async function () {
 
 	expect(result).toMatchInlineSnapshot(`
 		export async function load(event) {
-		    const __houdini__vite__plugin__return__value__ = {};
-
 		    return {
 		        ...event.data,
-		        ...__houdini__vite__plugin__return__value__
+		        ...{}
 		    };
 		}
 	`)
 })
 
-
 test('augments load function in root layout load', async function () {
-	const result = await test_transform_js('src/routes/+layout.js', `
+	const result = await test_transform_js(
+		'src/routes/+layout.js',
+		`
 		import { browser } from '$app/environment';
 
 		export const load = async ({ url }) => {
@@ -330,8 +317,31 @@ test('augments load function in root layout load', async function () {
 
 			console.log('this should only run in the browser');
 		};
-	
-	`)
 
-	expect(result).toMatchInlineSnapshot(``)
+	`
+	)
+
+	expect(result).toMatchInlineSnapshot(`
+		import { browser } from "$app/environment";
+
+		export const load = async event => {
+		    let {
+		        url
+		    } = event;
+
+		    console.log("routes/+layout.js start");
+
+		    if (!browser) return {
+		        ...event.data,
+		        ...{}
+		    };
+
+		    console.log("this should only run in the browser");
+
+		    return {
+		        ...event.data,
+		        ...{}
+		    };
+		};
+	`)
 })

--- a/packages/houdini-svelte/src/plugin/transforms/kit/session.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/kit/session.ts
@@ -1,3 +1,4 @@
+import { walk } from 'estree-walker'
 import { find_exported_fn, find_insert_index, ensure_imports } from 'houdini/vite'
 import * as recast from 'recast'
 
@@ -67,29 +68,33 @@ function add_load_return(
 		else {
 			return_statement = AST.returnStatement(AST.objectExpression([]))
 			body.body.push(return_statement)
-			return_statement_index = body.body.length - 1
 		}
 
-		// replace the return statement with the variable declaration
-		const local_return_var = AST.identifier('__houdini__vite__plugin__return__value__')
-		body.body[return_statement_index] = AST.variableDeclaration('const', [
-			AST.variableDeclarator(local_return_var, return_statement.argument),
-		])
-
-		// its safe to insert a return statement after the declaration that references event
-		body.body.splice(
-			return_statement_index + 1,
-			0,
-			AST.returnStatement(
-				AST.objectExpression([...properties(event_id), AST.spreadElement(local_return_var)])
-			)
-		)
+		// now we need to walk through the body and replace any returns with one
+		// that has the additional information mixed in
+		return walk(body, {
+			enter(node) {
+				console.log(node.type)
+				if (node.type === 'ReturnStatement') {
+					// replace the return statement with a new one that includes the returned value
+					const returnedValue = (node as ReturnStatement).argument
+					this.replace(
+						AST.returnStatement(
+							AST.objectExpression([
+								...properties(event_id),
+								AST.spreadElement(returnedValue ?? AST.objectExpression([])),
+							])
+						)
+					)
+				}
+			},
+		})
 	})
 }
 
 function modify_load(
 	page: SvelteTransformPage,
-	cb: (body: BlockStatement, event_id: Identifier) => void
+	cb: (body: BlockStatement, event_id: Identifier) => BlockStatement
 ) {
 	// before we do anything, we need to find the load function
 	let load_fn = find_exported_fn(page.script.body, 'load')
@@ -156,5 +161,5 @@ function modify_load(
 	}
 
 	// modify the body
-	cb(body, event_id)
+	load_fn.body = cb(body, event_id)
 }


### PR DESCRIPTION
Fixes #1405 

This PR fixes an issue with the transformation of the root layout if it included an early return. Previously the logic would look for a single value returned but now we look for _any_ return in the function and ensure that the necessary values are included


### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

