### PR TITLE
fix import path resolution issue

### DIFF
--- a/.changeset/tender-sloths-shave.md
+++ b/.changeset/tender-sloths-shave.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix bug preventing vite6 from importing the generated root layout

--- a/packages/houdini-svelte/src/plugin/fsPatch.ts
+++ b/packages/houdini-svelte/src/plugin/fsPatch.ts
@@ -24,8 +24,11 @@ export default (getFramework: () => Framework) =>
 				if (match) {
 					return path.join(config.projectRoot, filepath.substring(match[1].length))
 				}
+
 				// if there is no deep relative import, do the default thing
-				return
+				return filepath.startsWith('/src')
+					? { id: path.join(config.projectRoot, filepath) }
+					: null
 			}
 
 			// everything internal to houdini should assume posix paths


### PR DESCRIPTION
Fixes #1401 

This PR fixes an issue with the svelte plugin that was breaking imports in vite 6. I'm still unsure if this is the right approach so i'm waiting to hear back from someone who knows better but I wanted to open this up for others to test.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

