### PR TITLE
wip: how to publish go to npm

### DIFF
--- a/packages/_scripts/typedefs.js
+++ b/packages/_scripts/typedefs.js
@@ -1,8 +1,8 @@
-import fsSync from 'fs'
 import fs_extra from 'fs-extra'
-import fs from 'fs/promises'
 import { glob } from 'glob'
-import path from 'path'
+import fsSync from 'node:fs'
+import fs from 'node:fs/promises'
+import path from 'node:path'
 import ts from 'typescript'
 
 const { ModuleResolutionKind } = ts

--- a/packages/houdini-go/_scripts/build.ts
+++ b/packages/houdini-go/_scripts/build.ts
@@ -1,0 +1,90 @@
+import { join as joinPath } from 'jsr:@std/path'
+import parentPkg from "../package.json" with { type: "json" }
+
+const PACKAGE_NAME = parentPkg.name
+const BUILD_DIR = 'build'
+
+// Major platforms on arm64 and amd64, more can be added later
+const platforms = [
+	{ GOOS: 'darwin', GOARCH: 'amd64', NODEOS: 'darwin', NODECPU: 'x64' },
+	{ GOOS: 'darwin', GOARCH: 'arm64', NODEOS: 'darwin', NODECPU: 'arm64' },
+	{ GOOS: 'linux', GOARCH: 'amd64', NODEOS: 'linux', NODECPU: 'x64' },
+	{ GOOS: 'linux', GOARCH: 'arm64', NODEOS: 'linux', NODECPU: 'arm64' },
+	{ GOOS: 'windows', GOARCH: 'amd64', NODEOS: 'win32', NODECPU: 'x64' },
+	{ GOOS: 'windows', GOARCH: 'arm64', NODEOS: 'win32', NODECPU: 'arm64' },
+] as const
+
+
+platforms.forEach(async ({ GOOS, GOARCH, NODEOS, NODECPU }) => {
+	const pkg_name = `${PACKAGE_NAME}-${NODEOS}-${NODECPU}`
+	const pkg_dir = joinPath(BUILD_DIR, pkg_name, 'bin')
+	Deno.mkdirSync(pkg_dir, { recursive: true })
+
+	console.log(`Building ${pkg_name}...`)
+
+	// Build the go binary for the current platform
+	const command = new Deno.Command('go', {
+		args: [
+			'build',
+			'-o',
+			joinPath(pkg_dir, `${PACKAGE_NAME}${GOOS === 'windows' ? '.exe' : ''}`),
+			'.',
+		],
+		env: {
+			GOOS,
+			GOARCH,
+		},
+		stdin: 'null',
+		stdout: 'piped',
+	})
+
+	const child = command.spawn()
+	const status = await child.status
+
+	if (!status.success) {
+		console.error(`Error building for ${GOOS}/${GOARCH}`)
+		return
+	}
+
+	// Create package.json
+	const pkg = {
+		name: pkg_name,
+		version: parentPkg.version,
+		authors: parentPkg.authors,
+		description: parentPkg.description,
+		os: [NODEOS],
+		cpu: [NODECPU],
+	}
+
+	const encoder = new TextEncoder()
+	const data = encoder.encode(JSON.stringify(pkg, null, 2))
+	const pkg_json_path = joinPath(pkg_dir, 'package.json')
+	await Deno.writeFile(pkg_json_path, data)
+})
+
+console.log('Building meta-package...')
+
+const meta_pkg_dir = joinPath(BUILD_DIR, PACKAGE_NAME)
+
+// Create the meta-package
+Deno.mkdirSync(meta_pkg_dir, { recursive: true })
+
+const meta_pkg = {
+	name: PACKAGE_NAME,
+	version: parentPkg.version,
+	authors: parentPkg.authors,
+	description: parentPkg.description,
+	optionalDependencies: {} as Record<string, string>,
+}
+
+for (const { NODEOS, NODECPU } of platforms) {
+	const pkg_name = `${PACKAGE_NAME}-${NODEOS}-${NODECPU}`
+	const version = parentPkg.version
+
+	meta_pkg.optionalDependencies[pkg_name] = version
+}
+
+const encoder = new TextEncoder()
+const data = encoder.encode(JSON.stringify(meta_pkg, null, 2))
+const meta_pkg_json_path = joinPath(meta_pkg_dir, 'package.json')
+await Deno.writeFile(meta_pkg_json_path, data)

--- a/packages/houdini-go/_scripts/deno.json
+++ b/packages/houdini-go/_scripts/deno.json
@@ -1,0 +1,5 @@
+{
+	"imports": {
+		"@std/path": "jsr:@std/path@^1.0.8"
+	}
+}

--- a/packages/houdini-go/_scripts/deno.lock
+++ b/packages/houdini-go/_scripts/deno.lock
@@ -1,0 +1,17 @@
+{
+  "version": "4",
+  "specifiers": {
+    "jsr:@std/path@*": "1.0.8",
+    "jsr:@std/path@^1.0.8": "1.0.8"
+  },
+  "jsr": {
+    "@std/path@1.0.8": {
+      "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/path@^1.0.8"
+    ]
+  }
+}

--- a/packages/houdini-go/go.mod
+++ b/packages/houdini-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/HoudiniGraphql/houdini/packages/houdini-go
+
+go 1.23.2

--- a/packages/houdini-go/install.js
+++ b/packages/houdini-go/install.js
@@ -1,0 +1,118 @@
+import * as fs from 'node:fs'
+import * as https from 'node:https'
+import * as path from 'node:path'
+import * as zlib from 'node:zlib'
+
+// Lookup table for all platforms and binary distribution packages
+const BINARY_DISTRIBUTION_PACKAGES = {
+	'linux-x64': 'my-package-linux-x64',
+	'linux-arm': 'my-package-linux-arm',
+	'win32-x64': 'my-package-windows-x64',
+}
+
+// Adjust the version you want to install. You can also make this dynamic.
+const BINARY_DISTRIBUTION_VERSION = '1.0.0'
+
+// Windows binaries end with .exe so we need to special case them.
+const binaryName = process.platform === 'win32' ? 'my-binary.exe' : 'my-binary'
+
+// Determine package name for this platform
+const platformSpecificPackageName =
+	BINARY_DISTRIBUTION_PACKAGES[`${process.platform}-${process.arch}`]
+
+// Compute the path we want to emit the fallback binary to
+const fallbackBinaryPath = path.join(__dirname, binaryName)
+
+function makeRequest(url) {
+	return new Promise((resolve, reject) => {
+		https
+			.get(url, (response) => {
+				if (response.statusCode >= 200 && response.statusCode < 300) {
+					const chunks = []
+					response.on('data', (chunk) => chunks.push(chunk))
+					response.on('end', () => {
+						resolve(Buffer.concat(chunks))
+					})
+				} else if (
+					response.statusCode >= 300 &&
+					response.statusCode < 400 &&
+					response.headers.location
+				) {
+					// Follow redirects
+					makeRequest(response.headers.location).then(resolve, reject)
+				} else {
+					reject(
+						new Error(
+							`npm responded with status code ${response.statusCode} when downloading the package!`
+						)
+					)
+				}
+			})
+			.on('error', (error) => {
+				reject(error)
+			})
+	})
+}
+
+function extractFileFromTarball(tarballBuffer, filepath) {
+	// Tar archives are organized in 512 byte blocks.
+	// Blocks can either be header blocks or data blocks.
+	// Header blocks contain file names of the archive in the first 100 bytes, terminated by a null byte.
+	// The size of a file is contained in bytes 124-135 of a header block and in octal format.
+	// The following blocks will be data blocks containing the file.
+	let offset = 0
+	while (offset < tarballBuffer.length) {
+		const header = tarballBuffer.subarray(offset, offset + 512)
+		offset += 512
+
+		const fileName = header.toString('utf-8', 0, 100).replace(/\0.*/g, '')
+		const fileSize = parseInt(header.toString('utf-8', 124, 136).replace(/\0.*/g, ''), 8)
+
+		if (fileName === filepath) {
+			return tarballBuffer.subarray(offset, offset + fileSize)
+		}
+
+		// Clamp offset to the uppoer multiple of 512
+		offset = (offset + fileSize + 511) & ~511
+	}
+}
+
+async function downloadBinaryFromNpm() {
+	// Download the tarball of the right binary distribution package
+	const tarballDownloadBuffer = await makeRequest(
+		`https://registry.npmjs.org/${platformSpecificPackageName}/-/${platformSpecificPackageName}-${BINARY_DISTRIBUTION_VERSION}.tgz`
+	)
+
+	const tarballBuffer = zlib.unzipSync(tarballDownloadBuffer)
+
+	// Extract binary from package and write to disk
+	fs.writeFileSync(
+		fallbackBinaryPath,
+		extractFileFromTarball(tarballBuffer, `package/bin/${binaryName}`),
+		{ mode: 0o755 } // Make binary file executable
+	)
+}
+
+function isPlatformSpecificPackageInstalled() {
+	try {
+		// Resolving will fail if the optionalDependency was not installed
+		require.resolve(`${platformSpecificPackageName}/bin/${binaryName}`)
+		return true
+	} catch (e) {
+		return false
+	}
+}
+
+if (!platformSpecificPackageName) {
+	throw new Error('Platform not supported!')
+}
+
+// Skip downloading the binary if it was already installed via optionalDependencies
+if (!isPlatformSpecificPackageInstalled()) {
+	console.log('Platform specific package not found. Will manually download binary.')
+	downloadBinaryFromNpm()
+} else {
+	console.log(
+		'Platform specific package already installed. Will fall back to manually downloading binary.'
+	)
+}

--- a/packages/houdini-go/main.go
+++ b/packages/houdini-go/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/packages/houdini-go/package.json
+++ b/packages/houdini-go/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "houdini-go",
+	"description": "description",
+	"authors": "author",
+	"version": "1.0.0",
+	"dependencies": {},
+	"scripts": {
+		"build": "deno run --allow-read --allow-write --allow-env --allow-run _scripts/build.ts"
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,13 +53,13 @@ importers:
         version: 1.6.0(vitest@1.6.0)
       eslint-plugin-unused-imports:
         specifier: ^3.0.0
-        version: 3.2.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.4))(eslint@8.57.0)(typescript@4.9.4))(eslint@8.57.0)
+        version: 3.2.0(eslint@8.57.0)
       graphql:
         specifier: 15.5.0
         version: 15.5.0
       lint-staged:
         specifier: ^12.3.4
-        version: 12.5.0(enquirer@2.3.6)
+        version: 12.5.0
       prettier:
         specifier: ^2.8.3
         version: 2.8.3
@@ -71,10 +71,10 @@ importers:
         version: 4.9.4
       vite:
         specifier: ^6.0.3
-        version: 6.0.7(@types/node@18.11.15)(terser@5.16.1)
+        version: 6.0.11(@types/node@18.19.64)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@18.11.15)(@vitest/ui@1.6.0)(terser@5.16.1)
+        version: 1.6.0(@types/node@18.19.64)(@vitest/ui@1.6.0)
 
   e2e/_api:
     dependencies:
@@ -83,7 +83,7 @@ importers:
         version: 3.0.6
       '@graphql-yoga/plugin-persisted-operations':
         specifier: ^1.9.1
-        version: 1.9.1(@graphql-tools/utils@10.0.6(graphql@15.5.0))(graphql-yoga@4.0.4(graphql@15.5.0))(graphql@15.5.0)
+        version: 1.9.1(@graphql-tools/utils@9.2.1)(graphql-yoga@4.0.4)(graphql@15.5.0)
       '@kitql/helpers':
         specifier: ^0.8.2
         version: 0.8.2
@@ -110,10 +110,10 @@ importers:
     dependencies:
       '@sveltejs/adapter-node':
         specifier: ^5.0.1
-        version: 5.0.1(@sveltejs/kit@2.16.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))
+        version: 5.0.1(@sveltejs/kit@2.16.1)
       '@sveltejs/adapter-static':
         specifier: ^3.0.2
-        version: 3.0.2(@sveltejs/kit@2.16.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))
+        version: 3.0.2(@sveltejs/kit@2.16.1)
       graphql-ws:
         specifier: ^5.8.2
         version: 5.11.2(graphql@15.5.0)
@@ -126,16 +126,16 @@ importers:
         version: 1.48.0
       '@sveltejs/adapter-auto':
         specifier: ^3.2.1
-        version: 3.2.4(@sveltejs/kit@2.16.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))
+        version: 3.2.4(@sveltejs/kit@2.16.1)
       '@sveltejs/kit':
         specifier: ^2.9.0
-        version: 2.16.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
+        version: 2.16.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.19.2)(vite@6.0.11)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
-        version: 5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
+        version: 5.0.3(svelte@5.19.2)(vite@6.0.11)
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.11.0
-        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)(typescript@5.4.2)
+        version: 7.18.0(@typescript-eslint/parser@7.18.0)(eslint@8.57.0)(typescript@5.4.2)
       '@typescript-eslint/parser':
         specifier: ^7.11.0
         version: 7.18.0(eslint@8.57.0)(typescript@5.4.2)
@@ -156,7 +156,7 @@ importers:
         version: 9.1.0(eslint@8.57.0)
       eslint-plugin-svelte:
         specifier: ^2.39.0
-        version: 2.43.0(eslint@8.57.0)(svelte@5.19.0)
+        version: 2.43.0(eslint@8.57.0)(svelte@5.19.2)
       houdini:
         specifier: workspace:^
         version: link:../../packages/houdini
@@ -171,19 +171,19 @@ importers:
         version: 3.3.3
       prettier-plugin-svelte:
         specifier: ^3.2.3
-        version: 3.2.6(prettier@3.3.3)(svelte@5.19.0)
+        version: 3.2.6(prettier@3.3.3)(svelte@5.19.2)
       svelte:
         specifier: ^5.3.1
-        version: 5.19.0
+        version: 5.19.2
       svelte-check:
         specifier: ^3.8.0
-        version: 3.8.0(@babel/core@7.21.4)(postcss-load-config@4.0.1(postcss@8.4.39))(postcss@8.4.39)(svelte@5.19.0)
+        version: 3.8.0(@babel/core@7.20.7)(postcss@8.4.39)(svelte@5.19.2)
       svelte-eslint-parser:
         specifier: ^0.41.1
-        version: 0.41.1(svelte@5.19.0)
+        version: 0.41.1(svelte@5.19.2)
       svelte-preprocess:
         specifier: ^5.1.4
-        version: 5.1.4(@babel/core@7.21.4)(postcss-load-config@4.0.1(postcss@8.4.39))(postcss@8.4.39)(svelte@5.19.0)(typescript@5.4.2)
+        version: 5.1.4(@babel/core@7.20.7)(postcss@8.4.39)(svelte@5.19.2)(typescript@5.4.2)
       tslib:
         specifier: ^2.3.1
         version: 2.4.1
@@ -192,7 +192,7 @@ importers:
         version: 5.4.2
       vite:
         specifier: ^6.0.3
-        version: 6.0.7(@types/node@18.11.15)(terser@5.16.1)
+        version: 6.0.11(@types/node@18.19.64)
       vite-plugin-lib-reporter:
         specifier: ^0.1.0
         version: 0.1.0
@@ -210,10 +210,10 @@ importers:
         version: 3.38.0(graphql@15.5.0)
       '@pothos/plugin-relay':
         specifier: ^3.44.0
-        version: 3.44.0(@pothos/core@3.38.0(graphql@15.5.0))(graphql@15.5.0)
+        version: 3.44.0(@pothos/core@3.38.0)(graphql@15.5.0)
       '@pothos/plugin-simple-objects':
         specifier: ^3.7.0
-        version: 3.7.0(@pothos/core@3.38.0(graphql@15.5.0))(graphql@15.5.0)
+        version: 3.7.0(@pothos/core@3.38.0)(graphql@15.5.0)
       '@whatwg-node/server':
         specifier: ^0.9.14
         version: 0.9.14
@@ -240,7 +240,7 @@ importers:
         version: 19.0.0(react@19.0.0)
       react-streaming-compat:
         specifier: ^0.3.18
-        version: 0.3.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 0.3.18(react-dom@19.0.0)(react@19.0.0)
     devDependencies:
       '@playwright/test':
         specifier: 1.48.0
@@ -253,7 +253,7 @@ importers:
         version: 19.0.3(@types/react@19.0.7)
       '@vitejs/plugin-react':
         specifier: ^3.1.0
-        version: 3.1.0(vite@4.1.4(@types/node@18.11.15)(terser@5.16.1))
+        version: 3.1.0(vite@4.1.4)
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.16(postcss@8.4.31)
@@ -286,10 +286,10 @@ importers:
         version: 4.9.4
       vite:
         specifier: ^4.1.0
-        version: 4.1.4(@types/node@18.11.15)(terser@5.16.1)
+        version: 4.1.4
       wrangler:
         specifier: ^3.91.0
-        version: 3.103.2(@cloudflare/workers-types@4.20230904.0)
+        version: 3.105.0(@cloudflare/workers-types@4.20230904.0)
 
   e2e/svelte:
     devDependencies:
@@ -301,7 +301,7 @@ importers:
         version: 1.48.0
       '@sveltejs/vite-plugin-svelte':
         specifier: ^2.0.2
-        version: 2.0.2(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1))
+        version: 2.0.2(svelte@3.57.0)(vite@4.1.4)
       '@tsconfig/svelte':
         specifier: ^3.0.0
         version: 3.0.0
@@ -325,7 +325,7 @@ importers:
         version: 3.57.0
       svelte-check:
         specifier: ^2.10.3
-        version: 2.10.3(@babel/core@7.21.4)(postcss-load-config@4.0.1(postcss@8.5.1))(postcss@8.5.1)(svelte@3.57.0)
+        version: 2.10.3(@babel/core@7.20.7)(svelte@3.57.0)
       tslib:
         specifier: ^2.5.0
         version: 2.5.0
@@ -334,7 +334,7 @@ importers:
         version: 4.9.4
       vite:
         specifier: ^4.1.1
-        version: 4.1.1(@types/node@18.11.15)(terser@5.16.1)
+        version: 4.1.4
 
   packages/_scripts:
     dependencies:
@@ -355,10 +355,10 @@ importers:
         version: 11.0.1
       rollup:
         specifier: ^4.28.1
-        version: 4.30.1
+        version: 4.31.0
       rollup-plugin-typescript2:
         specifier: ^0.34.0
-        version: 0.34.1(rollup@4.30.1)(typescript@4.9.4)
+        version: 0.34.1(rollup@4.31.0)(typescript@4.9.4)
       typescript:
         specifier: ^4.9
         version: 4.9.4
@@ -377,7 +377,7 @@ importers:
         version: link:../_scripts
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(postcss@8.5.1)(typescript@5.5.4)
+        version: 7.2.0(typescript@4.9.4)
 
   packages/adapter-cloudflare:
     dependencies:
@@ -393,7 +393,7 @@ importers:
         version: link:../_scripts
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(postcss@8.5.1)(typescript@5.5.4)
+        version: 7.2.0(typescript@4.9.4)
 
   packages/adapter-node:
     dependencies:
@@ -406,7 +406,7 @@ importers:
         version: link:../_scripts
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(postcss@8.5.1)(typescript@5.5.4)
+        version: 7.2.0(typescript@4.9.4)
 
   packages/adapter-static:
     dependencies:
@@ -421,7 +421,7 @@ importers:
         version: 19.0.0(react@19.0.0)
       vite:
         specifier: ^5.3.3
-        version: 5.3.3(@types/node@18.11.15)(terser@5.16.1)
+        version: 5.3.3(@types/node@18.11.15)
     devDependencies:
       '@types/node':
         specifier: ^18.7.23
@@ -437,7 +437,7 @@ importers:
         version: link:../_scripts
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(postcss@8.5.1)(typescript@5.5.4)
+        version: 7.2.0(typescript@5.5.4)
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
@@ -468,19 +468,19 @@ importers:
     dependencies:
       '@babel/parser':
         specifier: ^7.24.6
-        version: 7.24.6
+        version: 7.26.2
       '@clack/prompts':
         specifier: ^0.6.3
         version: 0.6.3
       '@graphql-tools/merge':
         specifier: ^9.0.0
-        version: 9.0.0(graphql@15.5.0)
+        version: 9.0.9(graphql@15.5.0)
       '@graphql-tools/schema':
         specifier: ^9.0.4
         version: 9.0.12(graphql@15.5.0)
       '@kitql/helpers':
         specifier: ^0.8.2
-        version: 0.8.2
+        version: 0.8.10
       '@types/estree':
         specifier: ^1.0.0
         version: 1.0.0
@@ -507,7 +507,7 @@ importers:
         version: 4.2.2
       estree-walker:
         specifier: ^3.0.1
-        version: 3.0.1
+        version: 3.0.3
       fs-extra:
         specifier: ^10.1.0
         version: 10.1.0
@@ -525,7 +525,7 @@ importers:
         version: 3.4.12
       micromatch:
         specifier: ^4.0.5
-        version: 4.0.5
+        version: 4.0.8
       minimatch:
         specifier: ^5.1.0
         version: 5.1.2
@@ -544,7 +544,7 @@ importers:
     devDependencies:
       '@babel/types':
         specifier: ^7.24.6
-        version: 7.24.6
+        version: 7.26.0
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^4.0.0
         version: 4.0.0(@vue/compiler-sfc@3.2.47)(prettier@2.8.3)
@@ -556,7 +556,7 @@ importers:
         version: 5.1.2
       '@types/node':
         specifier: ^18.7.23
-        version: 18.11.15
+        version: 18.19.64
       '@types/ungap__structured-clone':
         specifier: ^0.3.0
         version: 0.3.0
@@ -568,25 +568,25 @@ importers:
         version: 2.8.3
       rollup:
         specifier: ^4.28.1
-        version: 4.30.1
+        version: 4.31.0
       scripts:
         specifier: workspace:^
         version: link:../_scripts
       vite:
         specifier: ^6.0.3
-        version: 6.0.7(@types/node@18.11.15)(terser@5.16.1)
+        version: 6.0.11(@types/node@18.19.64)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@18.11.15)(@vitest/ui@1.6.0)(terser@5.16.1)
+        version: 1.6.0(@types/node@18.19.64)(@vitest/ui@1.6.0)
 
   packages/houdini-react:
     dependencies:
       '@babel/parser':
         specifier: ^7.24.6
-        version: 7.24.6
+        version: 7.26.2
       '@babel/types':
         specifier: ^7.24.6
-        version: 7.24.6
+        version: 7.26.0
       '@whatwg-node/server':
         specifier: ^0.9.14
         version: 0.9.14
@@ -622,13 +622,13 @@ importers:
         version: 19.0.0(react@19.0.0)
       react-streaming-compat:
         specifier: ^0.3.18
-        version: 0.3.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 0.3.18(react-dom@19.0.0)(react@19.0.0)
       recast:
         specifier: ^0.23.1
         version: 0.23.1
       rollup:
         specifier: ^4.28.1
-        version: 4.30.1
+        version: 4.31.0
       use-deep-compare-effect:
         specifier: ^1.8.1
         version: 1.8.1(react@19.0.0)
@@ -665,7 +665,7 @@ importers:
         version: 0.8.2
       '@sveltejs/kit':
         specifier: ^2.9.0
-        version: 2.16.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.0.2)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.0.2)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
+        version: 2.16.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.0.2)(vite@6.0.11)
       ast-types:
         specifier: ^0.16.1
         version: 0.16.1
@@ -683,13 +683,13 @@ importers:
         version: 0.23.1
       rollup:
         specifier: ^4.28.1
-        version: 4.30.1
+        version: 4.31.0
       svelte:
         specifier: ^5.0.0
         version: 5.0.2
       vite:
         specifier: ^6.0.3
-        version: 6.0.7(@types/node@18.11.15)(terser@5.16.1)
+        version: 6.0.11(@types/node@18.19.64)
     devDependencies:
       '@types/minimatch':
         specifier: ^5.1.2
@@ -702,13 +702,13 @@ importers:
         version: link:../_scripts
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@18.11.15)(@vitest/ui@1.6.0)(terser@5.16.1)
+        version: 1.6.0(@types/node@18.19.64)(@vitest/ui@1.6.0)
 
   packages/plugin-svelte-global-stores:
     dependencies:
       '@sveltejs/kit':
         specifier: ^2.5.3
-        version: 2.5.24(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.0.2)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.0.2)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
+        version: 2.5.24(@sveltejs/vite-plugin-svelte@4.0.0)(svelte@5.0.2)(vite@5.3.3)
       houdini:
         specifier: workspace:^
         version: link:../houdini
@@ -727,16 +727,16 @@ importers:
         version: link:../_scripts
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@18.11.15)(@vitest/ui@1.6.0)(terser@5.16.1)
+        version: 1.6.0(@types/node@18.19.64)(@vitest/ui@1.6.0)
 
   site:
     dependencies:
       '@sveltejs/adapter-auto':
         specifier: 2.0.0
-        version: 2.0.0(@sveltejs/kit@1.9.3(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1)))
+        version: 2.0.0(@sveltejs/kit@1.9.3)
       '@sveltejs/adapter-netlify':
         specifier: ^2.0.5
-        version: 2.0.5(@sveltejs/kit@1.9.3(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1)))
+        version: 2.0.5(@sveltejs/kit@1.9.3)
       feather-icons:
         specifier: ^4.29.0
         version: 4.29.0
@@ -778,13 +778,13 @@ importers:
         version: 3.57.0
       svelte-preprocess:
         specifier: ^5.0.0
-        version: 5.0.0(@babel/core@7.21.4)(postcss-load-config@4.0.1(postcss@8.5.1))(postcss@8.5.1)(svelte@3.57.0)(typescript@4.9.4)
+        version: 5.0.0(@babel/core@7.20.7)(svelte@3.57.0)(typescript@4.9.4)
       unist-util-visit:
         specifier: ^4.1.1
         version: 4.1.1
       vite:
         specifier: ^4.1.1
-        version: 4.1.1(@types/node@18.11.15)(terser@5.16.1)
+        version: 4.1.4
     devDependencies:
       '@babel/parser':
         specifier: ^7.20.7
@@ -794,10 +794,10 @@ importers:
         version: 1.30.0
       '@sveltejs/kit':
         specifier: 1.9.3
-        version: 1.9.3(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1))
+        version: 1.9.3(svelte@3.57.0)(vite@4.1.4)
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.50.0
-        version: 5.50.0(@typescript-eslint/parser@5.50.0(eslint@8.33.0)(typescript@4.9.4))(eslint@8.33.0)(typescript@4.9.4)
+        version: 5.50.0(@typescript-eslint/parser@5.50.0)(eslint@8.33.0)(typescript@4.9.4)
       '@typescript-eslint/parser':
         specifier: ^5.50.0
         version: 5.50.0(eslint@8.33.0)(typescript@4.9.4)
@@ -821,10 +821,10 @@ importers:
         version: 7.0.4
       lint-staged:
         specifier: ^12.3.4
-        version: 12.5.0(enquirer@2.3.6)
+        version: 12.5.0
       mermaid:
         specifier: ^10.1.0
-        version: 10.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 10.1.0(react-dom@16.14.0)(react@16.14.0)
       prettier:
         specifier: ^2.8.3
         version: 2.8.3
@@ -839,7 +839,7 @@ importers:
         version: 0.2.0(mermaid.cli@0.3.6)
       svelte-check:
         specifier: ^3.0.1
-        version: 3.0.1(@babel/core@7.21.4)(postcss-load-config@4.0.1(postcss@8.5.1))(postcss@8.5.1)(svelte@3.57.0)
+        version: 3.0.1(@babel/core@7.20.7)(svelte@3.57.0)
       svelte-kit-cookie-session:
         specifier: 3.0.6
         version: 3.0.6
@@ -934,16 +934,16 @@ packages:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.24.6':
-    resolution: {integrity: sha512-WdJjwMEkmBicq5T9fm/cHND3+UlFa2Yj8ALLgmoSQAJZysYbBjw+azChSGPN4DSPLXOcooGRvDwZWMcF/mLO2Q==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.19.1':
-    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
+  '@babel/helper-string-parser@7.25.9':
+    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.24.6':
     resolution: {integrity: sha512-4yA7s865JHaqUdRbnaxarZREuPTHrjpDT+pXoAZ1yhyo6uFnIEpS8VMu16siFOHDpZNKYv5BObhsB//ycbICyw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.25.9':
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.21.0':
@@ -968,8 +968,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@7.24.6':
-    resolution: {integrity: sha512-eNZXdfU35nJC2h24RznROuOpO94h6x8sg9ju0tT9biNtLZ2vuP8SduLqqV+/8+cebSLV9SJEAN5Z3zQbJG/M+Q==}
+  '@babel/parser@7.26.2':
+    resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1086,8 +1086,8 @@ packages:
     resolution: {integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.24.6':
-    resolution: {integrity: sha512-WaMsgi6Q8zMgMth93GvWPXkhAIEobfsIkLTacoVZoK1J0CevIPGYY2Vo5YvJGqyHqXM6P4ppOYGsIRU8MM9pFQ==}
+  '@babel/types@7.26.0':
+    resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -1966,8 +1966,8 @@ packages:
     peerDependencies:
       graphql: 15.5.0
 
-  '@graphql-tools/merge@9.0.0':
-    resolution: {integrity: sha512-J7/xqjkGTTwOJmaJQJ2C+VDBDOWJL3lKrHJN4yMaRLAJH3PosB7GiPRaSDZdErs0+F77sH2MKs2haMMkywzx7Q==}
+  '@graphql-tools/merge@9.0.9':
+    resolution: {integrity: sha512-w9yaU7UMRQvtkTYZHo+c7cS7LO7rqc2H6g3k0aUs8VE9YlFYG1bYdxvEPM5bloaoVqr5TmbqIZqzl1CHeJKilQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: 15.5.0
@@ -1989,8 +1989,19 @@ packages:
     peerDependencies:
       graphql: 15.5.0
 
+  '@graphql-tools/utils@10.5.6':
+    resolution: {integrity: sha512-JAC44rhbLzXUHiltceyEpWkxmX4e45Dfg19wRFoA9EbDxQVbOzVNF76eEECdg0J1owFsJwfLqCwz7/6xzrovOw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: 15.5.0
+
   '@graphql-tools/utils@9.1.3':
     resolution: {integrity: sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==}
+    peerDependencies:
+      graphql: 15.5.0
+
+  '@graphql-tools/utils@9.2.1':
+    resolution: {integrity: sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==}
     peerDependencies:
       graphql: 15.5.0
 
@@ -2120,6 +2131,10 @@ packages:
       react: 16.14.0
       react-dom: 16.14.0
 
+  '@kitql/helpers@0.8.10':
+    resolution: {integrity: sha512-r9m0eQyjy3Z2sdeXA8wRGl2tgKtZ9puPuZ3vm9Cv3WMMWVmbKVzUJvF+4UucsHzT9xECFbO9lcQu7lIb774PPQ==}
+    engines: {node: ^16.14 || >=18}
+
   '@kitql/helpers@0.8.2':
     resolution: {integrity: sha512-+fny1XOuOWOEp8K3GqQqCSOCki+Kr5gMnl7Majzjs1iFlyvIvwYRv8x3sqNyP77yrUTQbiY5q/BTNav1Yl4LKg==}
 
@@ -2247,8 +2262,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm-eabi@4.30.1':
-    resolution: {integrity: sha512-pSWY+EVt3rJ9fQ3IqlrEUtXh3cGqGtPDH1FQlNZehO2yYxCHEX1SPsz1M//NXwYfbTlcKr9WObLnJX9FsS9K1Q==}
+  '@rollup/rollup-android-arm-eabi@4.31.0':
+    resolution: {integrity: sha512-9NrR4033uCbUBRgvLcBrJofa2KY9DzxL2UKZ1/4xA/mnTNyhZCWBuD8X3tPm1n4KxcgaraOYgrFKSgwjASfmlA==}
     cpu: [arm]
     os: [android]
 
@@ -2257,8 +2272,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.30.1':
-    resolution: {integrity: sha512-/NA2qXxE3D/BRjOJM8wQblmArQq1YoBVJjrjoTSBS09jgUisq7bqxNHJ8kjCHeV21W/9WDGwJEWSN0KQ2mtD/w==}
+  '@rollup/rollup-android-arm64@4.31.0':
+    resolution: {integrity: sha512-iBbODqT86YBFHajxxF8ebj2hwKm1k8PTBQSojSt3d1FFt1gN+xf4CowE47iN0vOSdnd+5ierMHBbu/rHc7nq5g==}
     cpu: [arm64]
     os: [android]
 
@@ -2267,8 +2282,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-arm64@4.30.1':
-    resolution: {integrity: sha512-r7FQIXD7gB0WJ5mokTUgUWPl0eYIH0wnxqeSAhuIwvnnpjdVB8cRRClyKLQr7lgzjctkbp5KmswWszlwYln03Q==}
+  '@rollup/rollup-darwin-arm64@4.31.0':
+    resolution: {integrity: sha512-WHIZfXgVBX30SWuTMhlHPXTyN20AXrLH4TEeH/D0Bolvx9PjgZnn4H677PlSGvU6MKNsjCQJYczkpvBbrBnG6g==}
     cpu: [arm64]
     os: [darwin]
 
@@ -2277,18 +2292,18 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.30.1':
-    resolution: {integrity: sha512-x78BavIwSH6sqfP2xeI1hd1GpHL8J4W2BXcVM/5KYKoAD3nNsfitQhvWSw+TFtQTLZ9OmlF+FEInEHyubut2OA==}
+  '@rollup/rollup-darwin-x64@4.31.0':
+    resolution: {integrity: sha512-hrWL7uQacTEF8gdrQAqcDy9xllQ0w0zuL1wk1HV8wKGSGbKPVjVUv/DEwT2+Asabf8Dh/As+IvfdU+H8hhzrQQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.30.1':
-    resolution: {integrity: sha512-HYTlUAjbO1z8ywxsDFWADfTRfTIIy/oUlfIDmlHYmjUP2QRDTzBuWXc9O4CXM+bo9qfiCclmHk1x4ogBjOUpUQ==}
+  '@rollup/rollup-freebsd-arm64@4.31.0':
+    resolution: {integrity: sha512-S2oCsZ4hJviG1QjPY1h6sVJLBI6ekBeAEssYKad1soRFv3SocsQCzX6cwnk6fID6UQQACTjeIMB+hyYrFacRew==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.30.1':
-    resolution: {integrity: sha512-1MEdGqogQLccphhX5myCJqeGNYTNcmTyaic9S7CG3JhwuIByJ7J05vGbZxsizQthP1xpVx7kd3o31eOogfEirw==}
+  '@rollup/rollup-freebsd-x64@4.31.0':
+    resolution: {integrity: sha512-pCANqpynRS4Jirn4IKZH4tnm2+2CqCNLKD7gAdEjzdLGbH1iO0zouHz4mxqg0uEMpO030ejJ0aA6e1PJo2xrPA==}
     cpu: [x64]
     os: [freebsd]
 
@@ -2297,8 +2312,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.30.1':
-    resolution: {integrity: sha512-PaMRNBSqCx7K3Wc9QZkFx5+CX27WFpAMxJNiYGAXfmMIKC7jstlr32UhTgK6T07OtqR+wYlWm9IxzennjnvdJg==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.31.0':
+    resolution: {integrity: sha512-0O8ViX+QcBd3ZmGlcFTnYXZKGbFu09EhgD27tgTdGnkcYXLat4KIsBBQeKLR2xZDCXdIBAlWLkiXE1+rJpCxFw==}
     cpu: [arm]
     os: [linux]
 
@@ -2307,8 +2322,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.30.1':
-    resolution: {integrity: sha512-B8Rcyj9AV7ZlEFqvB5BubG5iO6ANDsRKlhIxySXcF1axXYUyqwBok+XZPgIYGBgs7LDXfWfifxhw0Ik57T0Yug==}
+  '@rollup/rollup-linux-arm-musleabihf@4.31.0':
+    resolution: {integrity: sha512-w5IzG0wTVv7B0/SwDnMYmbr2uERQp999q8FMkKG1I+j8hpPX2BYFjWe69xbhbP6J9h2gId/7ogesl9hwblFwwg==}
     cpu: [arm]
     os: [linux]
 
@@ -2317,8 +2332,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.30.1':
-    resolution: {integrity: sha512-hqVyueGxAj3cBKrAI4aFHLV+h0Lv5VgWZs9CUGqr1z0fZtlADVV1YPOij6AhcK5An33EXaxnDLmJdQikcn5NEw==}
+  '@rollup/rollup-linux-arm64-gnu@4.31.0':
+    resolution: {integrity: sha512-JyFFshbN5xwy6fulZ8B/8qOqENRmDdEkcIMF0Zz+RsfamEW+Zabl5jAb0IozP/8UKnJ7g2FtZZPEUIAlUSX8cA==}
     cpu: [arm64]
     os: [linux]
 
@@ -2327,13 +2342,13 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.30.1':
-    resolution: {integrity: sha512-i4Ab2vnvS1AE1PyOIGp2kXni69gU2DAUVt6FSXeIqUCPIR3ZlheMW3oP2JkukDfu3PsexYRbOiJrY+yVNSk9oA==}
+  '@rollup/rollup-linux-arm64-musl@4.31.0':
+    resolution: {integrity: sha512-kpQXQ0UPFeMPmPYksiBL9WS/BDiQEjRGMfklVIsA0Sng347H8W2iexch+IEwaR7OVSKtr2ZFxggt11zVIlZ25g==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.30.1':
-    resolution: {integrity: sha512-fARcF5g296snX0oLGkVxPmysetwUk2zmHcca+e9ObOovBR++9ZPOhqFUM61UUZ2EYpXVPN1redgqVoBB34nTpQ==}
+  '@rollup/rollup-linux-loongarch64-gnu@4.31.0':
+    resolution: {integrity: sha512-pMlxLjt60iQTzt9iBb3jZphFIl55a70wexvo8p+vVFK+7ifTRookdoXX3bOsRdmfD+OKnMozKO6XM4zR0sHRrQ==}
     cpu: [loong64]
     os: [linux]
 
@@ -2342,8 +2357,8 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.30.1':
-    resolution: {integrity: sha512-GLrZraoO3wVT4uFXh67ElpwQY0DIygxdv0BNW9Hkm3X34wu+BkqrDrkcsIapAY+N2ATEbvak0XQ9gxZtCIA5Rw==}
+  '@rollup/rollup-linux-powerpc64le-gnu@4.31.0':
+    resolution: {integrity: sha512-D7TXT7I/uKEuWiRkEFbed1UUYZwcJDU4vZQdPTcepK7ecPhzKOYk4Er2YR4uHKme4qDeIh6N3XrLfpuM7vzRWQ==}
     cpu: [ppc64]
     os: [linux]
 
@@ -2352,8 +2367,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.30.1':
-    resolution: {integrity: sha512-0WKLaAUUHKBtll0wvOmh6yh3S0wSU9+yas923JIChfxOaaBarmb/lBKPF0w/+jTVozFnOXJeRGZ8NvOxvk/jcw==}
+  '@rollup/rollup-linux-riscv64-gnu@4.31.0':
+    resolution: {integrity: sha512-wal2Tc8O5lMBtoePLBYRKj2CImUCJ4UNGJlLwspx7QApYny7K1cUYlzQ/4IGQBLmm+y0RS7dwc3TDO/pmcneTw==}
     cpu: [riscv64]
     os: [linux]
 
@@ -2362,8 +2377,8 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.30.1':
-    resolution: {integrity: sha512-GWFs97Ruxo5Bt+cvVTQkOJ6TIx0xJDD/bMAOXWJg8TCSTEK8RnFeOeiFTxKniTc4vMIaWvCplMAFBt9miGxgkA==}
+  '@rollup/rollup-linux-s390x-gnu@4.31.0':
+    resolution: {integrity: sha512-O1o5EUI0+RRMkK9wiTVpk2tyzXdXefHtRTIjBbmFREmNMy7pFeYXCFGbhKFwISA3UOExlo5GGUuuj3oMKdK6JQ==}
     cpu: [s390x]
     os: [linux]
 
@@ -2372,8 +2387,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.30.1':
-    resolution: {integrity: sha512-UtgGb7QGgXDIO+tqqJ5oZRGHsDLO8SlpE4MhqpY9Llpzi5rJMvrK6ZGhsRCST2abZdBqIBeXW6WPD5fGK5SDwg==}
+  '@rollup/rollup-linux-x64-gnu@4.31.0':
+    resolution: {integrity: sha512-zSoHl356vKnNxwOWnLd60ixHNPRBglxpv2g7q0Cd3Pmr561gf0HiAcUBRL3S1vPqRC17Zo2CX/9cPkqTIiai1g==}
     cpu: [x64]
     os: [linux]
 
@@ -2382,8 +2397,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.30.1':
-    resolution: {integrity: sha512-V9U8Ey2UqmQsBT+xTOeMzPzwDzyXmnAoO4edZhL7INkwQcaW1Ckv3WJX3qrrp/VHaDkEWIBWhRwP47r8cdrOow==}
+  '@rollup/rollup-linux-x64-musl@4.31.0':
+    resolution: {integrity: sha512-ypB/HMtcSGhKUQNiFwqgdclWNRrAYDH8iMYH4etw/ZlGwiTVxBz2tDrGRrPlfZu6QjXwtd+C3Zib5pFqID97ZA==}
     cpu: [x64]
     os: [linux]
 
@@ -2392,8 +2407,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-arm64-msvc@4.30.1':
-    resolution: {integrity: sha512-WabtHWiPaFF47W3PkHnjbmWawnX/aE57K47ZDT1BXTS5GgrBUEpvOzq0FI0V/UYzQJgdb8XlhVNH8/fwV8xDjw==}
+  '@rollup/rollup-win32-arm64-msvc@4.31.0':
+    resolution: {integrity: sha512-JuhN2xdI/m8Hr+aVO3vspO7OQfUFO6bKLIRTAy0U15vmWjnZDLrEgCZ2s6+scAYaQVpYSh9tZtRijApw9IXyMw==}
     cpu: [arm64]
     os: [win32]
 
@@ -2402,8 +2417,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.30.1':
-    resolution: {integrity: sha512-pxHAU+Zv39hLUTdQQHUVHf4P+0C47y/ZloorHpzs2SXMRqeAWmGghzAhfOlzFHHwjvgokdFAhC4V+6kC1lRRfw==}
+  '@rollup/rollup-win32-ia32-msvc@4.31.0':
+    resolution: {integrity: sha512-U1xZZXYkvdf5MIWmftU8wrM5PPXzyaY1nGCI4KI4BFfoZxHamsIe+BtnPLIvvPykvQWlVbqUXdLa4aJUuilwLQ==}
     cpu: [ia32]
     os: [win32]
 
@@ -2412,8 +2427,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.30.1':
-    resolution: {integrity: sha512-D6qjsXGcvhTjv0kI4fU8tUuBDF/Ueee4SVX79VfNDXZa64TfCW1Slkb6Z7O1p7vflqZjcmOVdZlqf8gvJxc6og==}
+  '@rollup/rollup-win32-x64-msvc@4.31.0':
+    resolution: {integrity: sha512-ul8rnCsUumNln5YWwz0ted2ZHFhzhRRnkpBZ+YRuHoRAlUji9KChpOUOndY7uykrPEPXVbHLlsdo6v5yXo/TXw==}
     cpu: [x64]
     os: [win32]
 
@@ -2459,8 +2474,8 @@ packages:
       svelte: ^3.54.0
       vite: ^4.0.0
 
-  '@sveltejs/kit@2.16.0':
-    resolution: {integrity: sha512-S9i1ZWKqluzoaJ6riYnEdbe+xJluMTMkhABouBa66GaWcAyCjW/jAc0NdJQJ/DXyK1CnP5quBW25e99MNyvLxA==}
+  '@sveltejs/kit@2.16.1':
+    resolution: {integrity: sha512-2pF5sgGJx9brYZ/9nNDYnh5KX0JguPF14dnvvtf/MqrvlWrDj/e7Rk3LBJPecFLLK1GRs6ZniD24gFPqZm/NFw==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
@@ -2485,6 +2500,14 @@ packages:
       svelte: ^3.54.0 || ^4.0.0
       vite: ^4.0.0
 
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.0':
+    resolution: {integrity: sha512-hBxSYW/66989cq9dN248omD/ziskSdIV1NqfuueuAI1z6jGcg14k9Zd98pDIEnoA6wC9kWUGuQ6adzBbWwQyRg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^4.0.0-next.0||^4.0.0
+      svelte: ^5.0.0-next.96 || ^5.0.0
+      vite: ^5.0.0
+
   '@sveltejs/vite-plugin-svelte-inspector@4.0.1':
     resolution: {integrity: sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22}
@@ -2506,6 +2529,13 @@ packages:
     peerDependencies:
       svelte: ^3.54.0 || ^4.0.0 || ^5.0.0-next.0
       vite: ^4.0.0
+
+  '@sveltejs/vite-plugin-svelte@4.0.0':
+    resolution: {integrity: sha512-kpVJwF+gNiMEsoHaw+FJL76IYiwBikkxYU83+BpqQLdVMff19KeRKLd2wisS8niNBMJ2omv5gG+iGDDwd8jzag==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      svelte: ^5.0.0-next.96 || ^5.0.0
+      vite: ^5.0.0
 
   '@sveltejs/vite-plugin-svelte@5.0.3':
     resolution: {integrity: sha512-MCFS6CrQDu1yGwspm4qtli0e63vaPCehf6V7pIMP15AsWgMKrqDGCPFF/0kn4SP0ii4aySu4Pa62+fIRGFMjgw==}
@@ -2650,6 +2680,9 @@ packages:
 
   '@types/node@18.11.15':
     resolution: {integrity: sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw==}
+
+  '@types/node@18.19.64':
+    resolution: {integrity: sha512-955mDqvO2vFf/oL7V3WiUtiz+BugyX8uVbaT2H8oj3+8dRyH2FLiNdowe7eNqRM7IOIZvzDH76EoAT+gwm6aIQ==}
 
   '@types/normalize-package-data@2.4.1':
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -3206,6 +3239,10 @@ packages:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
     engines: {node: '>=8'}
 
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   breakword@1.0.5:
     resolution: {integrity: sha512-ex5W9DoOQ/LUEU3PMdLs9ua/CYZl1678NUkKOdUSi8Aw5F1idieaiRURCBFJCwVcrD1J8Iy3vfWSloaMwO2qFg==}
 
@@ -3490,6 +3527,10 @@ packages:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
     engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
     hasBin: true
+
+  cross-inspect@1.0.1:
+    resolution: {integrity: sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==}
+    engines: {node: '>=16.0.0'}
 
   cross-spawn@5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
@@ -4531,6 +4572,10 @@ packages:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
     engines: {node: '>=8'}
 
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
   filter-obj@5.1.0:
     resolution: {integrity: sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==}
     engines: {node: '>=14.16'}
@@ -4713,8 +4758,8 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
 
-  glob@8.0.3:
-    resolution: {integrity: sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==}
+  glob@8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
     deprecated: Glob versions prior to v9 are no longer supported
 
@@ -5676,6 +5721,10 @@ packages:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
     engines: {node: '>=8.6'}
 
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -6216,10 +6265,6 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.4.28:
-    resolution: {integrity: sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -6351,6 +6396,11 @@ packages:
     resolution: {integrity: sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==}
     engines: {node: '>= 0.8'}
 
+  react-dom@16.14.0:
+    resolution: {integrity: sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==}
+    peerDependencies:
+      react: ^16.14.0
+
   react-dom@19.0.0:
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
@@ -6371,6 +6421,10 @@ packages:
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
+
+  react@16.14.0:
+    resolution: {integrity: sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==}
+    engines: {node: '>=0.10.0'}
 
   react@19.0.0:
     resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
@@ -6533,11 +6587,6 @@ packages:
   rollup-pluginutils@2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
 
-  rollup@3.14.0:
-    resolution: {integrity: sha512-o23sdgCLcLSe3zIplT9nQ1+r97okuaiR+vmAPZPTDYB7/f3tgWIYNyiQveMsZwshBT0is4eGax/HH83Q7CG+/Q==}
-    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rollup@3.27.1:
     resolution: {integrity: sha512-tXNDFwOkN6C2w5Blj1g6ForKeFw6c1mDu5jxoeDO3/pmYjgt+8yvIFjKzH5FQUq70OKZBkOt0zzv0THXL7vwzQ==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
@@ -6548,8 +6597,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rollup@4.30.1:
-    resolution: {integrity: sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==}
+  rollup@4.31.0:
+    resolution: {integrity: sha512-9cCE8P4rZLx9+PjoyqHLs31V9a9Vpvfo4qNcs6JCiGWYhw2gijSetFbH6SSy1whnkgcefnUwr8sad7tgqsGvnw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -6599,6 +6648,9 @@ packages:
 
   sander@0.5.1:
     resolution: {integrity: sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA==}
+
+  scheduler@0.19.1:
+    resolution: {integrity: sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==}
 
   scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
@@ -6912,6 +6964,11 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  sucrase@3.35.0:
+    resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -7096,8 +7153,8 @@ packages:
     resolution: {integrity: sha512-TIqp5kjyTMa45L0McUvVfjuvlF/hyxVolyAc9APY3/FeF5aqYpt+Y1PckPQ7DlsDkthxNeq2+ystop8GlIV3kw==}
     engines: {node: '>=18'}
 
-  svelte@5.19.0:
-    resolution: {integrity: sha512-qvd2GvvYnJxS/MteQKFSMyq8cQrAAut28QZ39ySv9k3ggmhw4Au4Rfcsqva74i0xMys//OhbhVCNfXPrDzL/Bg==}
+  svelte@5.19.2:
+    resolution: {integrity: sha512-Ww1uLgdX5MdQrAO5zfU1dWUh6zqiPR6uIbwqm8a+4eQ+tNEYHRPgypvKKfHh9lmTkmJ30PWZ2O5qX8aS+PblRQ==}
     engines: {node: '>=18'}
 
   synckit@0.6.2:
@@ -7374,11 +7431,17 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  ufo@1.5.3:
+    resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
+
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
 
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici@5.20.0:
     resolution: {integrity: sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==}
@@ -7388,8 +7451,8 @@ packages:
     resolution: {integrity: sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==}
     engines: {node: '>=14.0'}
 
-  unenv-nightly@2.0.0-20250109-100802-88ad671:
-    resolution: {integrity: sha512-Uij6gODNNNNsNBoDlnaMvZI99I6YlVJLRfYH8AOLMlbFrW7k2w872v9VLuIdch2vF8QBeSC4EftIh5sG4ibzdA==}
+  unenv@2.0.0-rc.0:
+    resolution: {integrity: sha512-H0kl2w8jFL/FAk0xvjVing4bS3jd//mbg1QChDnn58l9Sc5RtduaKmLAL8n+eBw5jJo8ZjYV7CrEGage5LAOZQ==}
 
   unified-engine@10.1.0:
     resolution: {integrity: sha512-5+JDIs4hqKfHnJcVCxTid1yBoI/++FfF/1PFdSMpaftZZZY+qg2JFruRbf7PaIwa9KgLotXQV3gSjtY0IdcFGQ==}
@@ -7538,31 +7601,6 @@ packages:
     resolution: {integrity: sha512-f6TUUxDvOeFPMJ1/NDK8N1y/65w8h4jPZGsuOOYVnaK4lkutN95rTNAunsr0fcgTVo1BRUMxDTY7iFlsGuiCig==}
     engines: {node: ^16.14 || >=18}
 
-  vite@4.1.1:
-    resolution: {integrity: sha512-LM9WWea8vsxhr782r9ntg+bhSFS06FJgCvvB0+8hf8UWtvaiDagKYWXndjfX6kGl74keHJUcpzrQliDXZlF5yg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-
   vite@4.1.4:
     resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -7616,8 +7654,8 @@ packages:
       terser:
         optional: true
 
-  vite@6.0.7:
-    resolution: {integrity: sha512-RDt8r/7qx9940f8FcOIAH9PTViRrghKaK2K1jY3RaAURrEUbm9Du1mJ72G+jlhtG3WwodnfzY8ORQZbBavZEAQ==}
+  vite@6.0.11:
+    resolution: {integrity: sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -7668,6 +7706,14 @@ packages:
     resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
+  vitefu@1.0.3:
+    resolution: {integrity: sha512-iKKfOMBHob2WxEJbqbJjHAkmYgvFDPhuqrO82om83S8RLk+17FtyMBfcyeH8GqD0ihShtkMW/zzJgiA51hCNCQ==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0-beta.0
     peerDependenciesMeta:
       vite:
         optional: true
@@ -7786,8 +7832,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@3.103.2:
-    resolution: {integrity: sha512-eYcnubPhPBU1QMZYTam+vfCLpaQx+x1EWA6nFbLhid1eqNDAk1dNwNlbo+ZryrOHDEX3XlOxn2Z3Fx8vVv3hKw==}
+  wrangler@3.105.0:
+    resolution: {integrity: sha512-NX10iuUXtgiVRG9YJ7dwwEUuhQ38hu4stcxMWq4dbKCnfcOj7fLFh+HwaWudqOr1jDCPrnSOQVkgfAfG3ZH9Lw==}
     engines: {node: '>=16.17.0'}
     hasBin: true
     peerDependencies:
@@ -7956,12 +8002,12 @@ snapshots:
       '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.17.8)
       '@babel/helper-module-transforms': 7.21.2
       '@babel/helpers': 7.21.0
-      '@babel/parser': 7.24.6
+      '@babel/parser': 7.26.2
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.4
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.7
       gensync: 1.0.0-beta.2
       json5: 2.2.2
       semver: 6.3.0
@@ -7976,10 +8022,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.20.7)
       '@babel/helper-module-transforms': 7.21.2
       '@babel/helpers': 7.21.0
-      '@babel/parser': 7.24.6
+      '@babel/parser': 7.26.2
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.4
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
       convert-source-map: 1.9.0
       debug: 4.3.7
       gensync: 1.0.0-beta.2
@@ -7996,10 +8042,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.21.4)
       '@babel/helper-module-transforms': 7.21.2
       '@babel/helpers': 7.21.0
-      '@babel/parser': 7.24.6
+      '@babel/parser': 7.26.2
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.4
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
       convert-source-map: 1.9.0
       debug: 4.3.4(supports-color@9.3.1)
       gensync: 1.0.0-beta.2
@@ -8010,19 +8056,19 @@ snapshots:
 
   '@babel/generator@7.17.7':
     dependencies:
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
       jsesc: 2.5.2
       source-map: 0.5.7
 
   '@babel/generator@7.20.7':
     dependencies:
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
 
   '@babel/generator@7.21.4':
     dependencies:
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
@@ -8059,15 +8105,15 @@ snapshots:
   '@babel/helper-function-name@7.21.0':
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
 
   '@babel/helper-hoist-variables@7.18.6':
     dependencies:
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
 
   '@babel/helper-module-imports@7.18.6':
     dependencies:
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
 
   '@babel/helper-module-transforms@7.21.2':
     dependencies:
@@ -8075,10 +8121,10 @@ snapshots:
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-simple-access': 7.20.2
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/helper-validator-identifier': 7.24.6
+      '@babel/helper-validator-identifier': 7.25.9
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.4
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8086,17 +8132,17 @@ snapshots:
 
   '@babel/helper-simple-access@7.20.2':
     dependencies:
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
 
   '@babel/helper-split-export-declaration@7.18.6':
     dependencies:
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
 
-  '@babel/helper-string-parser@7.24.6': {}
-
-  '@babel/helper-validator-identifier@7.19.1': {}
+  '@babel/helper-string-parser@7.25.9': {}
 
   '@babel/helper-validator-identifier@7.24.6': {}
+
+  '@babel/helper-validator-identifier@7.25.9': {}
 
   '@babel/helper-validator-option@7.21.0': {}
 
@@ -8104,7 +8150,7 @@ snapshots:
     dependencies:
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.4
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8116,15 +8162,15 @@ snapshots:
 
   '@babel/parser@7.18.9':
     dependencies:
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
 
   '@babel/parser@7.20.7':
     dependencies:
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
 
-  '@babel/parser@7.24.6':
+  '@babel/parser@7.26.2':
     dependencies:
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.20.7)':
     dependencies:
@@ -8217,8 +8263,8 @@ snapshots:
   '@babel/template@7.20.7':
     dependencies:
       '@babel/code-frame': 7.21.4
-      '@babel/parser': 7.24.6
-      '@babel/types': 7.24.6
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
 
   '@babel/traverse@7.17.3':
     dependencies:
@@ -8228,9 +8274,9 @@ snapshots:
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.24.6
-      '@babel/types': 7.24.6
-      debug: 4.3.4(supports-color@9.3.1)
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
+      debug: 4.3.7
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -8243,8 +8289,8 @@ snapshots:
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.24.6
-      '@babel/types': 7.24.6
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
       debug: 4.3.7
       globals: 11.12.0
     transitivePeerDependencies:
@@ -8258,8 +8304,8 @@ snapshots:
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.24.6
-      '@babel/types': 7.24.6
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
       debug: 4.3.7
       globals: 11.12.0
     transitivePeerDependencies:
@@ -8267,14 +8313,13 @@ snapshots:
 
   '@babel/types@7.17.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.25.9
       to-fast-properties: 2.0.0
 
-  '@babel/types@7.24.6':
+  '@babel/types@7.26.0':
     dependencies:
-      '@babel/helper-string-parser': 7.24.6
-      '@babel/helper-validator-identifier': 7.24.6
-      to-fast-properties: 2.0.0
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -8365,7 +8410,7 @@ snapshots:
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
-      micromatch: 4.0.5
+      micromatch: 4.0.8
 
   '@changesets/errors@0.1.4':
     dependencies:
@@ -8405,7 +8450,7 @@ snapshots:
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
       is-subdir: 1.2.0
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       spawndamnit: 2.0.0
 
   '@changesets/logger@0.0.5':
@@ -8870,7 +8915,7 @@ snapshots:
   '@eslint/eslintrc@1.4.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7
+      debug: 4.3.4(supports-color@9.3.1)
       espree: 9.6.1
       globals: 13.20.0
       ignore: 5.3.1
@@ -8914,15 +8959,15 @@ snapshots:
       graphql: 15.5.0
       tslib: 2.6.2
 
-  '@graphql-tools/merge@9.0.0(graphql@15.5.0)':
+  '@graphql-tools/merge@9.0.9(graphql@15.5.0)':
     dependencies:
-      '@graphql-tools/utils': 10.0.6(graphql@15.5.0)
+      '@graphql-tools/utils': 10.5.6(graphql@15.5.0)
       graphql: 15.5.0
       tslib: 2.6.2
 
   '@graphql-tools/schema@10.0.0(graphql@15.5.0)':
     dependencies:
-      '@graphql-tools/merge': 9.0.0(graphql@15.5.0)
+      '@graphql-tools/merge': 9.0.9(graphql@15.5.0)
       '@graphql-tools/utils': 10.0.6(graphql@15.5.0)
       graphql: 15.5.0
       tslib: 2.6.2
@@ -8943,8 +8988,22 @@ snapshots:
       graphql: 15.5.0
       tslib: 2.6.2
 
+  '@graphql-tools/utils@10.5.6(graphql@15.5.0)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@15.5.0)
+      cross-inspect: 1.0.1
+      dset: 3.1.2
+      graphql: 15.5.0
+      tslib: 2.6.2
+
   '@graphql-tools/utils@9.1.3(graphql@15.5.0)':
     dependencies:
+      graphql: 15.5.0
+      tslib: 2.6.2
+
+  '@graphql-tools/utils@9.2.1(graphql@15.5.0)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@15.5.0)
       graphql: 15.5.0
       tslib: 2.6.2
 
@@ -8956,9 +9015,9 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
-  '@graphql-yoga/plugin-persisted-operations@1.9.1(@graphql-tools/utils@10.0.6(graphql@15.5.0))(graphql-yoga@4.0.4(graphql@15.5.0))(graphql@15.5.0)':
+  '@graphql-yoga/plugin-persisted-operations@1.9.1(@graphql-tools/utils@9.2.1)(graphql-yoga@4.0.4)(graphql@15.5.0)':
     dependencies:
-      '@graphql-tools/utils': 10.0.6(graphql@15.5.0)
+      '@graphql-tools/utils': 9.2.1(graphql@15.5.0)
       graphql: 15.5.0
       graphql-yoga: 4.0.4(graphql@15.5.0)
 
@@ -8985,7 +9044,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.8':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.7
+      debug: 4.3.4(supports-color@9.3.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -9042,7 +9101,7 @@ snapshots:
       jest-haste-map: 29.4.1
       jest-regex-util: 29.2.0
       jest-util: 29.4.1
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       pirates: 4.0.5
       slash: 3.0.0
       write-file-atomic: 5.0.0
@@ -9054,7 +9113,7 @@ snapshots:
       '@jest/schemas': 29.4.0
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.11.15
+      '@types/node': 18.19.64
       '@types/yargs': 17.0.17
       chalk: 4.1.2
 
@@ -9102,11 +9161,15 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@khanacademy/simple-markdown@0.8.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@khanacademy/simple-markdown@0.8.6(react-dom@16.14.0)(react@16.14.0)':
     dependencies:
       '@types/react': 19.0.7
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
+      react: 16.14.0
+      react-dom: 16.14.0(react@16.14.0)
+
+  '@kitql/helpers@0.8.10':
+    dependencies:
+      esm-env: 1.0.0
 
   '@kitql/helpers@0.8.2':
     dependencies:
@@ -9171,7 +9234,7 @@ snapshots:
 
   '@playwright/test@1.30.0':
     dependencies:
-      '@types/node': 18.11.15
+      '@types/node': 18.19.64
       playwright-core: 1.30.0
 
   '@playwright/test@1.48.0':
@@ -9186,12 +9249,12 @@ snapshots:
     dependencies:
       graphql: 15.5.0
 
-  '@pothos/plugin-relay@3.44.0(@pothos/core@3.38.0(graphql@15.5.0))(graphql@15.5.0)':
+  '@pothos/plugin-relay@3.44.0(@pothos/core@3.38.0)(graphql@15.5.0)':
     dependencies:
       '@pothos/core': 3.38.0(graphql@15.5.0)
       graphql: 15.5.0
 
-  '@pothos/plugin-simple-objects@3.7.0(@pothos/core@3.38.0(graphql@15.5.0))(graphql@15.5.0)':
+  '@pothos/plugin-simple-objects@3.7.0(@pothos/core@3.38.0)(graphql@15.5.0)':
     dependencies:
       '@pothos/core': 3.38.0(graphql@15.5.0)
       graphql: 15.5.0
@@ -9203,16 +9266,14 @@ snapshots:
       '@rollup/pluginutils': 5.1.0(rollup@4.16.4)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      glob: 8.0.3
+      glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.30.11
-    optionalDependencies:
       rollup: 4.16.4
 
   '@rollup/plugin-json@6.1.0(rollup@4.16.4)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.16.4)
-    optionalDependencies:
       rollup: 4.16.4
 
   '@rollup/plugin-node-resolve@15.2.3(rollup@4.16.4)':
@@ -9223,7 +9284,6 @@ snapshots:
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.8
-    optionalDependencies:
       rollup: 4.16.4
 
   '@rollup/pluginutils@4.2.1':
@@ -9236,112 +9296,111 @@ snapshots:
       '@types/estree': 1.0.6
       estree-walker: 2.0.2
       picomatch: 2.3.1
-    optionalDependencies:
       rollup: 4.16.4
 
   '@rollup/rollup-android-arm-eabi@4.16.4':
     optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.30.1':
+  '@rollup/rollup-android-arm-eabi@4.31.0':
     optional: true
 
   '@rollup/rollup-android-arm64@4.16.4':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.30.1':
+  '@rollup/rollup-android-arm64@4.31.0':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.16.4':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.30.1':
+  '@rollup/rollup-darwin-arm64@4.31.0':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.16.4':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.30.1':
+  '@rollup/rollup-darwin-x64@4.31.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.30.1':
+  '@rollup/rollup-freebsd-arm64@4.31.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.30.1':
+  '@rollup/rollup-freebsd-x64@4.31.0':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.16.4':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.30.1':
+  '@rollup/rollup-linux-arm-gnueabihf@4.31.0':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.16.4':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.30.1':
+  '@rollup/rollup-linux-arm-musleabihf@4.31.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.16.4':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.30.1':
+  '@rollup/rollup-linux-arm64-gnu@4.31.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.16.4':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.30.1':
+  '@rollup/rollup-linux-arm64-musl@4.31.0':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.30.1':
+  '@rollup/rollup-linux-loongarch64-gnu@4.31.0':
     optional: true
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.16.4':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.30.1':
+  '@rollup/rollup-linux-powerpc64le-gnu@4.31.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.16.4':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.30.1':
+  '@rollup/rollup-linux-riscv64-gnu@4.31.0':
     optional: true
 
   '@rollup/rollup-linux-s390x-gnu@4.16.4':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.30.1':
+  '@rollup/rollup-linux-s390x-gnu@4.31.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.16.4':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.30.1':
+  '@rollup/rollup-linux-x64-gnu@4.31.0':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.16.4':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.30.1':
+  '@rollup/rollup-linux-x64-musl@4.31.0':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.16.4':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.30.1':
+  '@rollup/rollup-win32-arm64-msvc@4.31.0':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.16.4':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.30.1':
+  '@rollup/rollup-win32-ia32-msvc@4.31.0':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.16.4':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.30.1':
+  '@rollup/rollup-win32-x64-msvc@4.31.0':
     optional: true
 
   '@rushstack/eslint-patch@1.10.3': {}
@@ -9350,38 +9409,38 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
-  '@sveltejs/adapter-auto@2.0.0(@sveltejs/kit@1.9.3(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1)))':
+  '@sveltejs/adapter-auto@2.0.0(@sveltejs/kit@1.9.3)':
     dependencies:
-      '@sveltejs/kit': 1.9.3(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1))
+      '@sveltejs/kit': 1.9.3(svelte@3.57.0)(vite@4.1.4)
       import-meta-resolve: 2.2.0
 
-  '@sveltejs/adapter-auto@3.2.4(@sveltejs/kit@2.16.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))':
+  '@sveltejs/adapter-auto@3.2.4(@sveltejs/kit@2.16.1)':
     dependencies:
-      '@sveltejs/kit': 2.16.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
+      '@sveltejs/kit': 2.16.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.19.2)(vite@6.0.11)
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/adapter-netlify@2.0.5(@sveltejs/kit@1.9.3(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1)))':
+  '@sveltejs/adapter-netlify@2.0.5(@sveltejs/kit@1.9.3)':
     dependencies:
       '@iarna/toml': 2.2.5
-      '@sveltejs/kit': 1.9.3(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1))
+      '@sveltejs/kit': 1.9.3(svelte@3.57.0)(vite@4.1.4)
       esbuild: 0.16.17
       set-cookie-parser: 2.5.1
 
-  '@sveltejs/adapter-node@5.0.1(@sveltejs/kit@2.16.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))':
+  '@sveltejs/adapter-node@5.0.1(@sveltejs/kit@2.16.1)':
     dependencies:
       '@rollup/plugin-commonjs': 25.0.7(rollup@4.16.4)
       '@rollup/plugin-json': 6.1.0(rollup@4.16.4)
       '@rollup/plugin-node-resolve': 15.2.3(rollup@4.16.4)
-      '@sveltejs/kit': 2.16.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
+      '@sveltejs/kit': 2.16.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.19.2)(vite@6.0.11)
       rollup: 4.16.4
 
-  '@sveltejs/adapter-static@3.0.2(@sveltejs/kit@2.16.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))':
+  '@sveltejs/adapter-static@3.0.2(@sveltejs/kit@2.16.1)':
     dependencies:
-      '@sveltejs/kit': 2.16.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
+      '@sveltejs/kit': 2.16.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.19.2)(vite@6.0.11)
 
-  '@sveltejs/kit@1.9.3(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1))':
+  '@sveltejs/kit@1.9.3(svelte@3.57.0)(vite@4.1.4)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.5.3(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1))
+      '@sveltejs/vite-plugin-svelte': 2.5.3(svelte@3.57.0)(vite@4.1.4)
       '@types/cookie': 0.5.2
       cookie: 0.5.0
       devalue: 4.3.0
@@ -9395,13 +9454,13 @@ snapshots:
       svelte: 3.57.0
       tiny-glob: 0.2.9
       undici: 5.20.0
-      vite: 4.1.1(@types/node@18.11.15)(terser@5.16.1)
+      vite: 4.1.4
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/kit@2.16.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.0.2)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.0.2)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))':
+  '@sveltejs/kit@2.16.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.0.2)(vite@6.0.11)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.0.2)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.0.2)(vite@6.0.11)
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -9414,11 +9473,11 @@ snapshots:
       set-cookie-parser: 2.6.0
       sirv: 3.0.0
       svelte: 5.0.2
-      vite: 6.0.7(@types/node@18.11.15)(terser@5.16.1)
+      vite: 6.0.11(@types/node@18.19.64)
 
-  '@sveltejs/kit@2.16.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))':
+  '@sveltejs/kit@2.16.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.19.2)(vite@6.0.11)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.2)(vite@6.0.11)
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -9430,12 +9489,12 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 3.0.0
-      svelte: 5.19.0
-      vite: 6.0.7(@types/node@18.11.15)(terser@5.16.1)
+      svelte: 5.19.2
+      vite: 6.0.11(@types/node@18.19.64)
 
-  '@sveltejs/kit@2.5.24(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.0.2)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.0.2)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))':
+  '@sveltejs/kit@2.5.24(@sveltejs/vite-plugin-svelte@4.0.0)(svelte@5.0.2)(vite@5.3.3)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.0.2)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
+      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.0.2)(vite@5.3.3)
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.0.0
@@ -9449,36 +9508,45 @@ snapshots:
       sirv: 2.0.4
       svelte: 5.0.2
       tiny-glob: 0.2.9
-      vite: 6.0.7(@types/node@18.11.15)(terser@5.16.1)
+      vite: 5.3.3(@types/node@18.19.64)
 
-  '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.5.3(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1)))(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.5.3)(svelte@3.57.0)(vite@4.1.4)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.5.3(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1))
+      '@sveltejs/vite-plugin-svelte': 2.5.3(svelte@3.57.0)(vite@4.1.4)
       debug: 4.3.7
       svelte: 3.57.0
-      vite: 4.1.1(@types/node@18.11.15)(terser@5.16.1)
+      vite: 4.1.4
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.0.2)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.0.2)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.0(@sveltejs/vite-plugin-svelte@4.0.0)(svelte@5.0.2)(vite@5.3.3)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.0.2)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
+      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.0.2)(vite@5.3.3)
+      debug: 4.3.7
+      svelte: 5.0.2
+      vite: 5.3.3(@types/node@18.19.64)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.0.2)(vite@6.0.11)':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.0.2)(vite@6.0.11)
       debug: 4.4.0
       svelte: 5.0.2
-      vite: 6.0.7(@types/node@18.11.15)(terser@5.16.1)
+      vite: 6.0.11(@types/node@18.19.64)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.19.2)(vite@6.0.11)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.2)(vite@6.0.11)
       debug: 4.4.0
-      svelte: 5.19.0
-      vite: 6.0.7(@types/node@18.11.15)(terser@5.16.1)
+      svelte: 5.19.2
+      vite: 6.0.11(@types/node@18.19.64)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@2.0.2(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1))':
+  '@sveltejs/vite-plugin-svelte@2.0.2(svelte@3.57.0)(vite@4.1.4)':
     dependencies:
       debug: 4.3.4(supports-color@9.3.1)
       deepmerge: 4.2.2
@@ -9486,60 +9554,73 @@ snapshots:
       magic-string: 0.27.0
       svelte: 3.57.0
       svelte-hmr: 0.15.1(svelte@3.57.0)
-      vite: 4.1.1(@types/node@18.11.15)(terser@5.16.1)
-      vitefu: 0.2.3(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1))
+      vite: 4.1.4
+      vitefu: 0.2.3(vite@4.1.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@2.5.3(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1))':
+  '@sveltejs/vite-plugin-svelte@2.5.3(svelte@3.57.0)(vite@4.1.4)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.5.3(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1)))(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.5.3)(svelte@3.57.0)(vite@4.1.4)
       debug: 4.3.7
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.12
       svelte: 3.57.0
       svelte-hmr: 0.15.3(svelte@3.57.0)
-      vite: 4.1.1(@types/node@18.11.15)(terser@5.16.1)
-      vitefu: 0.2.5(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1))
+      vite: 4.1.4
+      vitefu: 0.2.5(vite@4.1.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.0.2)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))':
+  '@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.0.2)(vite@5.3.3)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.0.2)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.0.2)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.0(@sveltejs/vite-plugin-svelte@4.0.0)(svelte@5.0.2)(vite@5.3.3)
+      debug: 4.3.7
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.12
+      svelte: 5.0.2
+      vite: 5.3.3(@types/node@18.19.64)
+      vitefu: 1.0.3(vite@5.3.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.0.2)(vite@6.0.11)':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.0.2)(vite@6.0.11)
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 5.0.2
-      vite: 6.0.7(@types/node@18.11.15)(terser@5.16.1)
-      vitefu: 1.0.5(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
+      vite: 6.0.11(@types/node@18.19.64)
+      vitefu: 1.0.5(vite@6.0.11)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.2)(vite@6.0.11)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)))(svelte@5.19.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.19.2)(vite@6.0.11)
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
-      svelte: 5.19.0
-      vite: 6.0.7(@types/node@18.11.15)(terser@5.16.1)
-      vitefu: 1.0.5(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
+      svelte: 5.19.2
+      vite: 6.0.11(@types/node@18.19.64)
+      vitefu: 1.0.5(vite@6.0.11)
     transitivePeerDependencies:
       - supports-color
 
   '@theguild/eslint-config@0.8.1(eslint@8.57.0)(typescript@4.9.4)':
     dependencies:
       '@rushstack/eslint-patch': 1.10.3
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.4))(eslint@8.57.0)(typescript@4.9.4)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@4.9.4)
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@4.9.4)
       eslint: 8.57.0
       eslint-config-prettier: 8.6.0(eslint@8.57.0)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-jsonc: 2.16.0(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-mdx: 2.3.4(eslint@8.57.0)
@@ -9574,26 +9655,26 @@ snapshots:
 
   '@types/acorn@4.0.6':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.5
 
   '@types/babel__traverse@7.18.3':
     dependencies:
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
 
   '@types/body-parser@1.19.2':
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 18.11.15
+      '@types/node': 18.19.64
 
   '@types/braces@3.0.1': {}
 
   '@types/concat-stream@2.0.3':
     dependencies:
-      '@types/node': 18.11.15
+      '@types/node': 18.19.64
 
   '@types/connect@3.4.35':
     dependencies:
-      '@types/node': 18.11.15
+      '@types/node': 18.19.64
 
   '@types/cookie-parser@1.4.3':
     dependencies:
@@ -9613,7 +9694,7 @@ snapshots:
       '@types/connect': 3.4.35
       '@types/express': 4.17.17
       '@types/keygrip': 1.0.2
-      '@types/node': 18.11.15
+      '@types/node': 18.19.64
 
   '@types/debug@4.1.7':
     dependencies:
@@ -9625,7 +9706,7 @@ snapshots:
 
   '@types/estree-jsx@1.0.0':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.5
 
   '@types/estree@1.0.0': {}
 
@@ -9635,7 +9716,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.17.35':
     dependencies:
-      '@types/node': 18.11.15
+      '@types/node': 18.19.64
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
@@ -9649,16 +9730,16 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 18.11.15
+      '@types/node': 18.19.64
 
   '@types/glob@8.0.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.11.15
+      '@types/node': 18.19.64
 
   '@types/graceful-fs@4.1.5':
     dependencies:
-      '@types/node': 18.11.15
+      '@types/node': 18.19.64
 
   '@types/hast@2.3.4':
     dependencies:
@@ -9710,6 +9791,10 @@ snapshots:
 
   '@types/node@18.11.15': {}
 
+  '@types/node@18.19.64':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/normalize-package-data@2.4.1': {}
 
   '@types/prettier@2.7.2': {}
@@ -9732,7 +9817,7 @@ snapshots:
 
   '@types/sass@1.43.1':
     dependencies:
-      '@types/node': 18.11.15
+      '@types/node': 18.19.64
 
   '@types/semver@6.2.3': {}
 
@@ -9741,13 +9826,13 @@ snapshots:
   '@types/send@0.17.1':
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 18.11.15
+      '@types/node': 18.19.64
 
   '@types/serve-static@1.15.2':
     dependencies:
       '@types/http-errors': 2.0.1
       '@types/mime': 3.0.1
-      '@types/node': 18.11.15
+      '@types/node': 18.19.64
 
   '@types/stack-utils@2.0.1': {}
 
@@ -9765,7 +9850,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
-  '@typescript-eslint/eslint-plugin@5.50.0(@typescript-eslint/parser@5.50.0(eslint@8.33.0)(typescript@4.9.4))(eslint@8.33.0)(typescript@4.9.4)':
+  '@typescript-eslint/eslint-plugin@5.50.0(@typescript-eslint/parser@5.50.0)(eslint@8.33.0)(typescript@4.9.4)':
     dependencies:
       '@typescript-eslint/parser': 5.50.0(eslint@8.33.0)(typescript@4.9.4)
       '@typescript-eslint/scope-manager': 5.50.0
@@ -9779,50 +9864,29 @@ snapshots:
       regexpp: 3.2.0
       semver: 7.6.0
       tsutils: 3.21.0(typescript@4.9.4)
-    optionalDependencies:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.4))(eslint@8.57.0)(typescript@4.9.4)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@4.9.4)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@4.9.4)
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.0)(typescript@4.9.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@4.9.4)
-      debug: 4.3.7
+      debug: 4.3.4(supports-color@9.3.1)
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare-lite: 1.4.0
       semver: 7.6.3
       tsutils: 3.21.0(typescript@4.9.4)
-    optionalDependencies:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.4))(eslint@8.57.0)(typescript@4.9.4)':
-    dependencies:
-      '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@4.9.4)
-      '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/type-utils': 7.18.0(eslint@8.57.0)(typescript@4.9.4)
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@4.9.4)
-      '@typescript-eslint/visitor-keys': 7.18.0
-      eslint: 8.57.0
-      graphemer: 1.4.0
-      ignore: 5.3.1
-      natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@4.9.4)
-    optionalDependencies:
-      typescript: 4.9.4
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.4.2))(eslint@8.57.0)(typescript@5.4.2)':
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0)(eslint@8.57.0)(typescript@5.4.2)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.0)(typescript@5.4.2)
@@ -9835,7 +9899,6 @@ snapshots:
       ignore: 5.3.1
       natural-compare: 1.4.0
       ts-api-utils: 1.3.0(typescript@5.4.2)
-    optionalDependencies:
       typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
@@ -9847,7 +9910,6 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.50.0(typescript@4.9.4)
       debug: 4.3.4(supports-color@9.3.1)
       eslint: 8.33.0
-    optionalDependencies:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
@@ -9857,9 +9919,8 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.4)
-      debug: 4.3.7
+      debug: 4.3.4(supports-color@9.3.1)
       eslint: 8.57.0
-    optionalDependencies:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
@@ -9872,7 +9933,6 @@ snapshots:
       '@typescript-eslint/visitor-keys': 7.18.0
       debug: 4.3.4(supports-color@9.3.1)
       eslint: 8.57.0
-    optionalDependencies:
       typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
@@ -9896,10 +9956,9 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.50.0(typescript@4.9.4)
       '@typescript-eslint/utils': 5.50.0(eslint@8.33.0)(typescript@4.9.4)
-      debug: 4.3.7
+      debug: 4.3.4(supports-color@9.3.1)
       eslint: 8.33.0
       tsutils: 3.21.0(typescript@4.9.4)
-    optionalDependencies:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
@@ -9911,23 +9970,9 @@ snapshots:
       debug: 4.3.7
       eslint: 8.57.0
       tsutils: 3.21.0(typescript@4.9.4)
-    optionalDependencies:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/type-utils@7.18.0(eslint@8.57.0)(typescript@4.9.4)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@4.9.4)
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@4.9.4)
-      debug: 4.3.4(supports-color@9.3.1)
-      eslint: 8.57.0
-      ts-api-utils: 1.3.0(typescript@4.9.4)
-    optionalDependencies:
-      typescript: 4.9.4
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@typescript-eslint/type-utils@7.18.0(eslint@8.57.0)(typescript@5.4.2)':
     dependencies:
@@ -9936,7 +9981,6 @@ snapshots:
       debug: 4.3.4(supports-color@9.3.1)
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.4.2)
-    optionalDependencies:
       typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
@@ -9951,12 +9995,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.50.0
       '@typescript-eslint/visitor-keys': 5.50.0
-      debug: 4.3.7
+      debug: 4.3.4(supports-color@9.3.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.0
       tsutils: 3.21.0(typescript@4.9.4)
-    optionalDependencies:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
@@ -9970,26 +10013,9 @@ snapshots:
       is-glob: 4.0.3
       semver: 7.6.3
       tsutils: 3.21.0(typescript@4.9.4)
-    optionalDependencies:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@4.9.4)':
-    dependencies:
-      '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.4(supports-color@9.3.1)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      minimatch: 9.0.4
-      semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@4.9.4)
-    optionalDependencies:
-      typescript: 4.9.4
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@typescript-eslint/typescript-estree@7.18.0(typescript@5.4.2)':
     dependencies:
@@ -10001,7 +10027,6 @@ snapshots:
       minimatch: 9.0.4
       semver: 7.6.3
       ts-api-utils: 1.3.0(typescript@5.4.2)
-    optionalDependencies:
       typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
@@ -10036,18 +10061,6 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.18.0(eslint@8.57.0)(typescript@4.9.4)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
-      '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@4.9.4)
-      eslint: 8.57.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    optional: true
-
   '@typescript-eslint/utils@7.18.0(eslint@8.57.0)(typescript@5.4.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
@@ -10078,14 +10091,14 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitejs/plugin-react@3.1.0(vite@4.1.4(@types/node@18.11.15)(terser@5.16.1))':
+  '@vitejs/plugin-react@3.1.0(vite@4.1.4)':
     dependencies:
       '@babel/core': 7.21.4
       '@babel/plugin-transform-react-jsx-self': 7.21.0(@babel/core@7.21.4)
       '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.21.4)
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.1.4(@types/node@18.11.15)(terser@5.16.1)
+      vite: 4.1.4
     transitivePeerDependencies:
       - supports-color
 
@@ -10104,7 +10117,7 @@ snapshots:
       std-env: 3.7.0
       strip-literal: 2.1.0
       test-exclude: 6.0.0
-      vitest: 1.6.0(@types/node@18.11.15)(@vitest/ui@1.6.0)(terser@5.16.1)
+      vitest: 1.6.0(@types/node@18.19.64)(@vitest/ui@1.6.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10122,7 +10135,7 @@ snapshots:
 
   '@vitest/snapshot@1.6.0':
     dependencies:
-      magic-string: 0.30.17
+      magic-string: 0.30.12
       pathe: 1.1.2
       pretty-format: 29.7.0
 
@@ -10139,7 +10152,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.0.0
       sirv: 2.0.4
-      vitest: 1.6.0(@types/node@18.11.15)(@vitest/ui@1.6.0)(terser@5.16.1)
+      vitest: 1.6.0(@types/node@18.19.64)(@vitest/ui@1.6.0)
 
   '@vitest/utils@1.6.0':
     dependencies:
@@ -10150,7 +10163,7 @@ snapshots:
 
   '@vue/compiler-core@3.2.47':
     dependencies:
-      '@babel/parser': 7.24.6
+      '@babel/parser': 7.26.2
       '@vue/shared': 3.2.47
       estree-walker: 2.0.2
       source-map: 0.6.1
@@ -10162,7 +10175,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.2.47':
     dependencies:
-      '@babel/parser': 7.24.6
+      '@babel/parser': 7.26.2
       '@vue/compiler-core': 3.2.47
       '@vue/compiler-dom': 3.2.47
       '@vue/compiler-ssr': 3.2.47
@@ -10170,7 +10183,7 @@ snapshots:
       '@vue/shared': 3.2.47
       estree-walker: 2.0.2
       magic-string: 0.25.9
-      postcss: 8.5.1
+      postcss: 8.4.39
       source-map: 0.6.1
 
   '@vue/compiler-ssr@3.2.47':
@@ -10180,7 +10193,7 @@ snapshots:
 
   '@vue/reactivity-transform@3.2.47':
     dependencies:
-      '@babel/parser': 7.24.6
+      '@babel/parser': 7.26.2
       '@vue/compiler-core': 3.2.47
       '@vue/shared': 3.2.47
       estree-walker: 2.0.2
@@ -10215,13 +10228,13 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  acorn-jsx@5.3.2(acorn@8.11.3):
+    dependencies:
+      acorn: 8.11.3
+
   acorn-jsx@5.3.2(acorn@8.12.1):
     dependencies:
       acorn: 8.12.1
-
-  acorn-jsx@5.3.2(acorn@8.14.0):
-    dependencies:
-      acorn: 8.14.0
 
   acorn-typescript@1.4.13(acorn@8.12.1):
     dependencies:
@@ -10507,6 +10520,10 @@ snapshots:
     dependencies:
       fill-range: 7.0.1
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   breakword@1.0.5:
     dependencies:
       wcwidth: 1.0.1
@@ -10583,7 +10600,7 @@ snapshots:
 
   capnp-ts@0.7.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.3.7
       tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
@@ -10796,6 +10813,10 @@ snapshots:
   cross-env@7.0.3:
     dependencies:
       cross-spawn: 7.0.3
+
+  cross-inspect@1.0.1:
+    dependencies:
+      tslib: 2.6.2
 
   cross-spawn@5.1.0:
     dependencies:
@@ -11049,7 +11070,6 @@ snapshots:
   debug@4.3.4(supports-color@9.3.1):
     dependencies:
       ms: 2.1.2
-    optionalDependencies:
       supports-color: 9.3.1
 
   debug@4.3.7:
@@ -11641,13 +11661,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0)(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.4(supports-color@9.3.1)
       enhanced-resolve: 5.16.1
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.13.1
@@ -11660,8 +11680,8 @@ snapshots:
 
   eslint-mdx@2.3.4(eslint@8.57.0):
     dependencies:
-      acorn: 8.14.0
-      acorn-jsx: 5.3.2(acorn@8.14.0)
+      acorn: 8.12.1
+      acorn-jsx: 5.3.2(acorn@8.12.1)
       eslint: 8.57.0
       espree: 9.6.1
       estree-util-visit: 1.2.1
@@ -11678,14 +11698,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
-      debug: 3.2.7
-    optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@4.9.4)
+      debug: 3.2.7
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11695,8 +11714,9 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@4.9.4)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
@@ -11705,7 +11725,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -11715,8 +11735,6 @@ snapshots:
       object.values: 1.2.0
       semver: 6.3.1
       tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@4.9.4)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -11825,7 +11843,7 @@ snapshots:
       eslint: 8.33.0
       svelte: 3.57.0
 
-  eslint-plugin-svelte@2.43.0(eslint@8.57.0)(svelte@5.19.0):
+  eslint-plugin-svelte@2.43.0(eslint@8.57.0)(svelte@5.19.2):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -11838,9 +11856,8 @@ snapshots:
       postcss-safe-parser: 6.0.0(postcss@8.4.39)
       postcss-selector-parser: 6.1.2
       semver: 7.6.3
-      svelte-eslint-parser: 0.41.1(svelte@5.19.0)
-    optionalDependencies:
-      svelte: 5.19.0
+      svelte: 5.19.2
+      svelte-eslint-parser: 0.41.1(svelte@5.19.2)
     transitivePeerDependencies:
       - ts-node
 
@@ -11864,16 +11881,14 @@ snapshots:
       semver: 7.6.3
       strip-indent: 3.0.0
 
-  eslint-plugin-unused-imports@3.2.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.4))(eslint@8.57.0)(typescript@4.9.4))(eslint@8.57.0):
+  eslint-plugin-unused-imports@3.2.0(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
       eslint-rule-composer: 0.3.0
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.4))(eslint@8.57.0)(typescript@4.9.4)
 
   eslint-plugin-yml@1.14.0(eslint@8.57.0):
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.4(supports-color@9.3.1)
       eslint: 8.57.0
       eslint-compat-utils: 0.5.1(eslint@8.57.0)
       lodash: 4.17.21
@@ -12014,14 +12029,14 @@ snapshots:
 
   espree@9.4.1:
     dependencies:
-      acorn: 8.12.1
-      acorn-jsx: 5.3.2(acorn@8.12.1)
+      acorn: 8.11.3
+      acorn-jsx: 5.3.2(acorn@8.11.3)
       eslint-visitor-keys: 3.4.3
 
   espree@9.6.1:
     dependencies:
-      acorn: 8.12.1
-      acorn-jsx: 5.3.2(acorn@8.12.1)
+      acorn: 8.11.3
+      acorn-jsx: 5.3.2(acorn@8.11.3)
       eslint-visitor-keys: 3.4.3
 
   esprima@4.0.1: {}
@@ -12183,7 +12198,7 @@ snapshots:
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
-      micromatch: 4.0.5
+      micromatch: 4.0.8
 
   fast-glob@3.3.2:
     dependencies:
@@ -12191,7 +12206,7 @@ snapshots:
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
-      micromatch: 4.0.5
+      micromatch: 4.0.8
 
   fast-json-stable-stringify@2.1.0: {}
 
@@ -12241,6 +12256,10 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
   filter-obj@5.1.0: {}
 
   finalhandler@1.2.0:
@@ -12273,7 +12292,7 @@ snapshots:
 
   find-yarn-workspace-root2@1.2.16:
     dependencies:
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       pkg-dir: 4.2.0
 
   flat-cache@3.0.4:
@@ -12452,7 +12471,7 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
-  glob@8.0.3:
+  glob@8.1.0:
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -12875,7 +12894,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.21.4
-      '@babel/parser': 7.24.6
+      '@babel/parser': 7.26.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.1
@@ -12891,7 +12910,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.3.7
+      debug: 4.3.4(supports-color@9.3.1)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -12934,14 +12953,14 @@ snapshots:
     dependencies:
       '@jest/types': 29.4.1
       '@types/graceful-fs': 4.1.5
-      '@types/node': 18.11.15
+      '@types/node': 18.19.64
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.10
       jest-regex-util: 29.2.0
       jest-util: 29.4.1
       jest-worker: 29.4.1
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
@@ -12960,7 +12979,7 @@ snapshots:
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
       graceful-fs: 4.2.10
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       pretty-format: 29.4.1
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -12974,7 +12993,7 @@ snapshots:
       '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.20.7)
       '@babel/plugin-syntax-typescript': 7.20.0(@babel/core@7.20.7)
       '@babel/traverse': 7.20.10
-      '@babel/types': 7.24.6
+      '@babel/types': 7.26.0
       '@jest/expect-utils': 29.4.1
       '@jest/transform': 29.4.1
       '@jest/types': 29.4.1
@@ -12999,7 +13018,7 @@ snapshots:
   jest-util@29.4.1:
     dependencies:
       '@jest/types': 29.4.1
-      '@types/node': 18.11.15
+      '@types/node': 18.19.64
       chalk: 4.1.2
       ci-info: 3.7.0
       graceful-fs: 4.2.10
@@ -13007,7 +13026,7 @@ snapshots:
 
   jest-worker@29.4.1:
     dependencies:
-      '@types/node': 18.11.15
+      '@types/node': 18.19.64
       jest-util: 29.4.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -13053,7 +13072,7 @@ snapshots:
 
   jsonc-eslint-parser@2.1.0:
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.12.1
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       semver: 7.6.3
@@ -13112,7 +13131,7 @@ snapshots:
 
   lines-and-columns@2.0.4: {}
 
-  lint-staged@12.5.0(enquirer@2.3.6):
+  lint-staged@12.5.0:
     dependencies:
       cli-truncate: 3.1.0
       colorette: 2.0.19
@@ -13120,8 +13139,8 @@ snapshots:
       debug: 4.3.4(supports-color@9.3.1)
       execa: 5.1.1
       lilconfig: 2.0.5
-      listr2: 4.0.5(enquirer@2.3.6)
-      micromatch: 4.0.5
+      listr2: 4.0.5
+      micromatch: 4.0.8
       normalize-path: 3.0.0
       object-inspect: 1.12.2
       pidtree: 0.5.0
@@ -13131,7 +13150,7 @@ snapshots:
     transitivePeerDependencies:
       - enquirer
 
-  listr2@4.0.5(enquirer@2.3.6):
+  listr2@4.0.5:
     dependencies:
       cli-truncate: 2.1.0
       colorette: 2.0.19
@@ -13141,8 +13160,6 @@ snapshots:
       rxjs: 7.6.0
       through: 2.3.8
       wrap-ansi: 7.0.0
-    optionalDependencies:
-      enquirer: 2.3.6
 
   load-plugin@5.1.0:
     dependencies:
@@ -13229,7 +13246,7 @@ snapshots:
 
   magic-string@0.30.0:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   magic-string@0.30.10:
     dependencies:
@@ -13249,8 +13266,8 @@ snapshots:
 
   magicast@0.3.4:
     dependencies:
-      '@babel/parser': 7.24.6
-      '@babel/types': 7.24.6
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
       source-map-js: 1.2.0
 
   make-dir@3.1.0:
@@ -13409,10 +13426,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  mermaid@10.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  mermaid@10.1.0(react-dom@16.14.0)(react@16.14.0):
     dependencies:
       '@braintree/sanitize-url': 6.0.2
-      '@khanacademy/simple-markdown': 0.8.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@khanacademy/simple-markdown': 0.8.6(react-dom@16.14.0)(react@16.14.0)
       cytoscape: 3.24.0
       cytoscape-cose-bilkent: 4.1.0(cytoscape@3.24.0)
       cytoscape-fcose: 2.2.0(cytoscape@3.24.0)
@@ -13455,7 +13472,7 @@ snapshots:
 
   micromark-extension-mdx-expression@1.0.8:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.5
       micromark-factory-mdx-expression: 1.0.9
       micromark-factory-space: 1.1.0
       micromark-util-character: 1.2.0
@@ -13467,7 +13484,7 @@ snapshots:
   micromark-extension-mdx-jsx@1.0.5:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.5
       estree-util-is-identifier-name: 2.1.0
       micromark-factory-mdx-expression: 1.0.9
       micromark-factory-space: 1.1.0
@@ -13483,7 +13500,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@1.0.5:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.5
       micromark-core-commonmark: 1.1.0
       micromark-util-character: 1.2.0
       micromark-util-events-to-acorn: 1.2.3
@@ -13495,8 +13512,8 @@ snapshots:
 
   micromark-extension-mdxjs@1.0.1:
     dependencies:
-      acorn: 8.14.0
-      acorn-jsx: 5.3.2(acorn@8.14.0)
+      acorn: 8.12.1
+      acorn-jsx: 5.3.2(acorn@8.12.1)
       micromark-extension-mdx-expression: 1.0.8
       micromark-extension-mdx-jsx: 1.0.5
       micromark-extension-mdx-md: 1.0.1
@@ -13519,7 +13536,7 @@ snapshots:
 
   micromark-factory-mdx-expression@1.0.9:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.5
       micromark-util-character: 1.2.0
       micromark-util-events-to-acorn: 1.2.3
       micromark-util-symbol: 1.1.0
@@ -13583,7 +13600,7 @@ snapshots:
   micromark-util-events-to-acorn@1.2.3:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.5
       '@types/unist': 2.0.6
       estree-util-visit: 1.2.1
       micromark-util-symbol: 1.1.0
@@ -13650,6 +13667,11 @@ snapshots:
   micromatch@4.0.5:
     dependencies:
       braces: 3.0.2
+      picomatch: 2.3.1
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
       picomatch: 2.3.1
 
   mime-db@1.52.0: {}
@@ -13726,7 +13748,7 @@ snapshots:
       acorn: 8.12.1
       pathe: 1.1.2
       pkg-types: 1.0.3
-      ufo: 1.5.4
+      ufo: 1.5.3
 
   mlly@1.7.4:
     dependencies:
@@ -14075,7 +14097,7 @@ snapshots:
   pkg-types@1.0.3:
     dependencies:
       jsonc-parser: 3.2.0
-      mlly: 1.7.4
+      mlly: 1.6.1
       pathe: 1.1.2
 
   pkg-types@1.3.1:
@@ -14113,31 +14135,14 @@ snapshots:
   postcss-load-config@3.1.4(postcss@8.4.39):
     dependencies:
       lilconfig: 2.1.0
-      yaml: 1.10.2
-    optionalDependencies:
       postcss: 8.4.39
+      yaml: 1.10.2
 
   postcss-load-config@4.0.1(postcss@8.4.31):
     dependencies:
       lilconfig: 2.1.0
-      yaml: 2.2.1
-    optionalDependencies:
       postcss: 8.4.31
-
-  postcss-load-config@4.0.1(postcss@8.4.39):
-    dependencies:
-      lilconfig: 2.1.0
       yaml: 2.2.1
-    optionalDependencies:
-      postcss: 8.4.39
-    optional: true
-
-  postcss-load-config@4.0.1(postcss@8.5.1):
-    dependencies:
-      lilconfig: 2.1.0
-      yaml: 2.2.1
-    optionalDependencies:
-      postcss: 8.5.1
 
   postcss-nested@6.0.1(postcss@8.4.31):
     dependencies:
@@ -14163,12 +14168,6 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss-value-parser@4.2.0: {}
-
-  postcss@8.4.28:
-    dependencies:
-      nanoid: 3.3.6
-      picocolors: 1.0.0
-      source-map-js: 1.0.2
 
   postcss@8.4.31:
     dependencies:
@@ -14207,10 +14206,10 @@ snapshots:
       prettier: 3.3.3
       svelte: 5.0.2
 
-  prettier-plugin-svelte@3.2.6(prettier@3.3.3)(svelte@5.19.0):
+  prettier-plugin-svelte@3.2.6(prettier@3.3.3)(svelte@5.19.2):
     dependencies:
       prettier: 3.3.3
-      svelte: 5.19.0
+      svelte: 5.19.2
 
   prettier@2.8.3: {}
 
@@ -14265,7 +14264,7 @@ snapshots:
 
   puppeteer@1.20.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.3.7
       extract-zip: 1.7.0
       https-proxy-agent: 2.2.4
       mime: 2.6.0
@@ -14306,6 +14305,14 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
+  react-dom@16.14.0(react@16.14.0):
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      prop-types: 15.8.1
+      react: 16.14.0
+      scheduler: 0.19.1
+
   react-dom@19.0.0(react@19.0.0):
     dependencies:
       react: 19.0.0
@@ -14317,13 +14324,19 @@ snapshots:
 
   react-refresh@0.14.0: {}
 
-  react-streaming-compat@0.3.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  react-streaming-compat@0.3.18(react-dom@19.0.0)(react@19.0.0):
     dependencies:
       '@brillout/import': 0.2.3
       '@brillout/json-serializer': 0.5.6
       isbot-fast: 1.2.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
+
+  react@16.14.0:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      prop-types: 15.8.1
 
   react@19.0.0: {}
 
@@ -14529,12 +14542,12 @@ snapshots:
     dependencies:
       rollup-plugin-inject: 3.0.2
 
-  rollup-plugin-typescript2@0.34.1(rollup@4.30.1)(typescript@4.9.4):
+  rollup-plugin-typescript2@0.34.1(rollup@4.31.0)(typescript@4.9.4):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       find-cache-dir: 3.3.2
       fs-extra: 10.1.0
-      rollup: 4.30.1
+      rollup: 4.31.0
       semver: 7.3.8
       tslib: 2.4.1
       typescript: 4.9.4
@@ -14542,10 +14555,6 @@ snapshots:
   rollup-pluginutils@2.8.2:
     dependencies:
       estree-walker: 0.6.1
-
-  rollup@3.14.0:
-    optionalDependencies:
-      fsevents: 2.3.3
 
   rollup@3.27.1:
     optionalDependencies:
@@ -14573,29 +14582,29 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.16.4
       fsevents: 2.3.3
 
-  rollup@4.30.1:
+  rollup@4.31.0:
     dependencies:
       '@types/estree': 1.0.6
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.30.1
-      '@rollup/rollup-android-arm64': 4.30.1
-      '@rollup/rollup-darwin-arm64': 4.30.1
-      '@rollup/rollup-darwin-x64': 4.30.1
-      '@rollup/rollup-freebsd-arm64': 4.30.1
-      '@rollup/rollup-freebsd-x64': 4.30.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.30.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.30.1
-      '@rollup/rollup-linux-arm64-gnu': 4.30.1
-      '@rollup/rollup-linux-arm64-musl': 4.30.1
-      '@rollup/rollup-linux-loongarch64-gnu': 4.30.1
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.30.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.30.1
-      '@rollup/rollup-linux-s390x-gnu': 4.30.1
-      '@rollup/rollup-linux-x64-gnu': 4.30.1
-      '@rollup/rollup-linux-x64-musl': 4.30.1
-      '@rollup/rollup-win32-arm64-msvc': 4.30.1
-      '@rollup/rollup-win32-ia32-msvc': 4.30.1
-      '@rollup/rollup-win32-x64-msvc': 4.30.1
+      '@rollup/rollup-android-arm-eabi': 4.31.0
+      '@rollup/rollup-android-arm64': 4.31.0
+      '@rollup/rollup-darwin-arm64': 4.31.0
+      '@rollup/rollup-darwin-x64': 4.31.0
+      '@rollup/rollup-freebsd-arm64': 4.31.0
+      '@rollup/rollup-freebsd-x64': 4.31.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.31.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.31.0
+      '@rollup/rollup-linux-arm64-gnu': 4.31.0
+      '@rollup/rollup-linux-arm64-musl': 4.31.0
+      '@rollup/rollup-linux-loongarch64-gnu': 4.31.0
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.31.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.31.0
+      '@rollup/rollup-linux-s390x-gnu': 4.31.0
+      '@rollup/rollup-linux-x64-gnu': 4.31.0
+      '@rollup/rollup-linux-x64-musl': 4.31.0
+      '@rollup/rollup-win32-arm64-msvc': 4.31.0
+      '@rollup/rollup-win32-ia32-msvc': 4.31.0
+      '@rollup/rollup-win32-x64-msvc': 4.31.0
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
@@ -14658,6 +14667,11 @@ snapshots:
       graceful-fs: 4.2.10
       mkdirp: 0.5.6
       rimraf: 2.7.1
+
+  scheduler@0.19.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
 
   scheduler@0.25.0: {}
 
@@ -15013,6 +15027,16 @@ snapshots:
       pirates: 4.0.5
       ts-interface-checker: 0.1.13
 
+  sucrase@3.35.0:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.5
+      commander: 4.1.1
+      glob: 10.4.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.5
+      ts-interface-checker: 0.1.13
+
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -15029,7 +15053,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@2.10.3(@babel/core@7.21.4)(postcss-load-config@4.0.1(postcss@8.5.1))(postcss@8.5.1)(svelte@3.57.0):
+  svelte-check@2.10.3(@babel/core@7.20.7)(svelte@3.57.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.17
       chokidar: 3.5.3
@@ -15038,7 +15062,7 @@ snapshots:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 3.57.0
-      svelte-preprocess: 4.10.7(@babel/core@7.21.4)(postcss-load-config@4.0.1(postcss@8.5.1))(postcss@8.5.1)(svelte@3.57.0)(typescript@4.9.4)
+      svelte-preprocess: 4.10.7(@babel/core@7.20.7)(svelte@3.57.0)(typescript@4.9.4)
       typescript: 4.9.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -15052,7 +15076,7 @@ snapshots:
       - stylus
       - sugarss
 
-  svelte-check@3.0.1(@babel/core@7.21.4)(postcss-load-config@4.0.1(postcss@8.5.1))(postcss@8.5.1)(svelte@3.57.0):
+  svelte-check@3.0.1(@babel/core@7.20.7)(svelte@3.57.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.17
       chokidar: 3.5.3
@@ -15061,7 +15085,7 @@ snapshots:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 3.57.0
-      svelte-preprocess: 5.1.4(@babel/core@7.21.4)(postcss-load-config@4.0.1(postcss@8.5.1))(postcss@8.5.1)(svelte@3.57.0)(typescript@4.9.4)
+      svelte-preprocess: 5.1.4(@babel/core@7.20.7)(svelte@3.57.0)(typescript@4.9.4)
       typescript: 4.9.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -15074,7 +15098,7 @@ snapshots:
       - stylus
       - sugarss
 
-  svelte-check@3.8.0(@babel/core@7.21.4)(postcss-load-config@4.0.1(postcss@8.4.39))(postcss@8.4.39)(svelte@5.19.0):
+  svelte-check@3.8.0(@babel/core@7.20.7)(postcss@8.4.39)(svelte@5.19.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.5.3
@@ -15082,8 +15106,8 @@ snapshots:
       import-fresh: 3.3.0
       picocolors: 1.0.1
       sade: 1.8.1
-      svelte: 5.19.0
-      svelte-preprocess: 5.1.4(@babel/core@7.21.4)(postcss-load-config@4.0.1(postcss@8.4.39))(postcss@8.4.39)(svelte@5.19.0)(typescript@5.5.4)
+      svelte: 5.19.2
+      svelte-preprocess: 5.1.4(@babel/core@7.20.7)(postcss@8.4.39)(svelte@5.19.2)(typescript@5.5.4)
       typescript: 5.5.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -15096,15 +15120,14 @@ snapshots:
       - stylus
       - sugarss
 
-  svelte-eslint-parser@0.41.1(svelte@5.19.0):
+  svelte-eslint-parser@0.41.1(svelte@5.19.2):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       postcss: 8.4.39
       postcss-scss: 4.0.9(postcss@8.4.39)
-    optionalDependencies:
-      svelte: 5.19.0
+      svelte: 5.19.2
 
   svelte-hmr@0.15.1(svelte@3.57.0):
     dependencies:
@@ -15118,8 +15141,9 @@ snapshots:
     dependencies:
       zencrypt: 0.0.7
 
-  svelte-preprocess@4.10.7(@babel/core@7.21.4)(postcss-load-config@4.0.1(postcss@8.5.1))(postcss@8.5.1)(svelte@3.57.0)(typescript@4.9.4):
+  svelte-preprocess@4.10.7(@babel/core@7.20.7)(svelte@3.57.0)(typescript@4.9.4):
     dependencies:
+      '@babel/core': 7.20.7
       '@types/pug': 2.0.6
       '@types/sass': 1.43.1
       detect-indent: 6.1.0
@@ -15127,14 +15151,11 @@ snapshots:
       sorcery: 0.10.0
       strip-indent: 3.0.0
       svelte: 3.57.0
-    optionalDependencies:
-      '@babel/core': 7.21.4
-      postcss: 8.5.1
-      postcss-load-config: 4.0.1(postcss@8.5.1)
       typescript: 4.9.4
 
-  svelte-preprocess@5.0.0(@babel/core@7.21.4)(postcss-load-config@4.0.1(postcss@8.5.1))(postcss@8.5.1)(svelte@3.57.0)(typescript@4.9.4):
+  svelte-preprocess@5.0.0(@babel/core@7.20.7)(svelte@3.57.0)(typescript@4.9.4):
     dependencies:
+      '@babel/core': 7.20.7
       '@types/pug': 2.0.6
       '@types/sass': 1.43.1
       detect-indent: 6.1.0
@@ -15142,52 +15163,41 @@ snapshots:
       sorcery: 0.10.0
       strip-indent: 3.0.0
       svelte: 3.57.0
-    optionalDependencies:
-      '@babel/core': 7.21.4
-      postcss: 8.5.1
-      postcss-load-config: 4.0.1(postcss@8.5.1)
       typescript: 4.9.4
 
-  svelte-preprocess@5.1.4(@babel/core@7.21.4)(postcss-load-config@4.0.1(postcss@8.4.39))(postcss@8.4.39)(svelte@5.19.0)(typescript@5.4.2):
+  svelte-preprocess@5.1.4(@babel/core@7.20.7)(postcss@8.4.39)(svelte@5.19.2)(typescript@5.4.2):
     dependencies:
+      '@babel/core': 7.20.7
       '@types/pug': 2.0.6
       detect-indent: 6.1.0
       magic-string: 0.30.10
+      postcss: 8.4.39
       sorcery: 0.11.0
       strip-indent: 3.0.0
-      svelte: 5.19.0
-    optionalDependencies:
-      '@babel/core': 7.21.4
-      postcss: 8.4.39
-      postcss-load-config: 4.0.1(postcss@8.4.39)
+      svelte: 5.19.2
       typescript: 5.4.2
 
-  svelte-preprocess@5.1.4(@babel/core@7.21.4)(postcss-load-config@4.0.1(postcss@8.4.39))(postcss@8.4.39)(svelte@5.19.0)(typescript@5.5.4):
+  svelte-preprocess@5.1.4(@babel/core@7.20.7)(postcss@8.4.39)(svelte@5.19.2)(typescript@5.5.4):
     dependencies:
+      '@babel/core': 7.20.7
       '@types/pug': 2.0.6
       detect-indent: 6.1.0
       magic-string: 0.30.10
+      postcss: 8.4.39
       sorcery: 0.11.0
       strip-indent: 3.0.0
-      svelte: 5.19.0
-    optionalDependencies:
-      '@babel/core': 7.21.4
-      postcss: 8.4.39
-      postcss-load-config: 4.0.1(postcss@8.4.39)
+      svelte: 5.19.2
       typescript: 5.5.4
 
-  svelte-preprocess@5.1.4(@babel/core@7.21.4)(postcss-load-config@4.0.1(postcss@8.5.1))(postcss@8.5.1)(svelte@3.57.0)(typescript@4.9.4):
+  svelte-preprocess@5.1.4(@babel/core@7.20.7)(svelte@3.57.0)(typescript@4.9.4):
     dependencies:
+      '@babel/core': 7.20.7
       '@types/pug': 2.0.6
       detect-indent: 6.1.0
       magic-string: 0.30.10
       sorcery: 0.11.0
       strip-indent: 3.0.0
       svelte: 3.57.0
-    optionalDependencies:
-      '@babel/core': 7.21.4
-      postcss: 8.5.1
-      postcss-load-config: 4.0.1(postcss@8.5.1)
       typescript: 4.9.4
 
   svelte@3.57.0: {}
@@ -15208,7 +15218,7 @@ snapshots:
       magic-string: 0.30.11
       zimmerframe: 1.1.2
 
-  svelte@5.19.0:
+  svelte@5.19.2:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -15222,7 +15232,7 @@ snapshots:
       esrap: 1.4.3
       is-reference: 3.0.3
       locate-character: 3.0.0
-      magic-string: 0.30.17
+      magic-string: 0.30.12
       zimmerframe: 1.1.2
 
   synckit@0.6.2:
@@ -15334,11 +15344,6 @@ snapshots:
 
   trough@2.1.0: {}
 
-  ts-api-utils@1.3.0(typescript@4.9.4):
-    dependencies:
-      typescript: 4.9.4
-    optional: true
-
   ts-api-utils@1.3.0(typescript@5.4.2):
     dependencies:
       typescript: 5.4.2
@@ -15364,7 +15369,7 @@ snapshots:
 
   tsscmp@1.0.6: {}
 
-  tsup@7.2.0(postcss@8.5.1)(typescript@5.5.4):
+  tsup@7.2.0(typescript@4.9.4):
     dependencies:
       bundle-require: 4.0.1(esbuild@0.18.17)
       cac: 6.7.14
@@ -15374,14 +15379,33 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.1(postcss@8.5.1)
+      postcss-load-config: 4.0.1(postcss@8.4.31)
       resolve-from: 5.0.0
       rollup: 3.27.1
       source-map: 0.8.0-beta.0
       sucrase: 3.34.0
       tree-kill: 1.2.2
-    optionalDependencies:
-      postcss: 8.5.1
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+
+  tsup@7.2.0(typescript@5.5.4):
+    dependencies:
+      bundle-require: 4.0.1(esbuild@0.18.17)
+      cac: 6.7.14
+      chokidar: 3.5.3
+      debug: 4.3.7
+      esbuild: 0.18.17
+      execa: 5.1.1
+      globby: 11.1.0
+      joycon: 3.1.1
+      postcss-load-config: 4.0.1(postcss@8.4.31)
+      resolve-from: 5.0.0
+      rollup: 3.27.1
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tree-kill: 1.2.2
       typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
@@ -15517,6 +15541,8 @@ snapshots:
 
   typescript@5.5.4: {}
 
+  ufo@1.5.3: {}
+
   ufo@1.5.4: {}
 
   unbox-primitive@1.0.2:
@@ -15526,6 +15552,8 @@ snapshots:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
 
+  undici-types@5.26.5: {}
+
   undici@5.20.0:
     dependencies:
       busboy: 1.6.0
@@ -15534,7 +15562,7 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.1
 
-  unenv-nightly@2.0.0-20250109-100802-88ad671:
+  unenv@2.0.0-rc.0:
     dependencies:
       defu: 6.1.4
       mlly: 1.7.4
@@ -15547,12 +15575,12 @@ snapshots:
       '@types/concat-stream': 2.0.3
       '@types/debug': 4.1.7
       '@types/is-empty': 1.2.3
-      '@types/node': 18.11.15
+      '@types/node': 18.19.64
       '@types/unist': 2.0.6
       concat-stream: 2.0.0
       debug: 4.3.7
       fault: 2.0.1
-      glob: 8.0.3
+      glob: 8.1.0
       ignore: 5.3.1
       is-buffer: 2.0.5
       is-empty: 1.2.0
@@ -15736,13 +15764,13 @@ snapshots:
       unist-util-stringify-position: 3.0.2
       vfile-message: 3.1.3
 
-  vite-node@1.6.0(@types/node@18.11.15)(terser@5.16.1):
+  vite-node@1.6.0(@types/node@18.19.64):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7
       pathe: 1.1.2
       picocolors: 1.0.1
-      vite: 5.3.3(@types/node@18.11.15)(terser@5.16.1)
+      vite: 5.3.3(@types/node@18.19.64)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -15763,66 +15791,66 @@ snapshots:
       '@kitql/helpers': 0.8.9
       micromatch: 4.0.5
 
-  vite@4.1.1(@types/node@18.11.15)(terser@5.16.1):
-    dependencies:
-      esbuild: 0.16.17
-      postcss: 8.4.28
-      resolve: 1.22.1
-      rollup: 3.14.0
-    optionalDependencies:
-      '@types/node': 18.11.15
-      fsevents: 2.3.3
-      terser: 5.16.1
-
-  vite@4.1.4(@types/node@18.11.15)(terser@5.16.1):
+  vite@4.1.4:
     dependencies:
       esbuild: 0.16.17
       postcss: 8.4.39
       resolve: 1.22.8
       rollup: 3.27.1
     optionalDependencies:
-      '@types/node': 18.11.15
       fsevents: 2.3.3
-      terser: 5.16.1
 
-  vite@5.3.3(@types/node@18.11.15)(terser@5.16.1):
+  vite@5.3.3(@types/node@18.11.15):
     dependencies:
+      '@types/node': 18.11.15
       esbuild: 0.21.5
-      postcss: 8.5.1
-      rollup: 4.30.1
+      postcss: 8.4.39
+      rollup: 4.31.0
     optionalDependencies:
-      '@types/node': 18.11.15
       fsevents: 2.3.3
-      terser: 5.16.1
 
-  vite@6.0.7(@types/node@18.11.15)(terser@5.16.1):
+  vite@5.3.3(@types/node@18.19.64):
     dependencies:
+      '@types/node': 18.19.64
+      esbuild: 0.21.5
+      postcss: 8.4.39
+      rollup: 4.31.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vite@6.0.11(@types/node@18.19.64):
+    dependencies:
+      '@types/node': 18.19.64
       esbuild: 0.24.2
       postcss: 8.5.1
-      rollup: 4.30.1
+      rollup: 4.31.0
     optionalDependencies:
-      '@types/node': 18.11.15
       fsevents: 2.3.3
-      terser: 5.16.1
 
-  vitefu@0.2.3(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1)):
-    optionalDependencies:
-      vite: 4.1.1(@types/node@18.11.15)(terser@5.16.1)
-
-  vitefu@0.2.5(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1)):
-    optionalDependencies:
-      vite: 4.1.1(@types/node@18.11.15)(terser@5.16.1)
-
-  vitefu@1.0.5(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)):
-    optionalDependencies:
-      vite: 6.0.7(@types/node@18.11.15)(terser@5.16.1)
-
-  vitest@1.6.0(@types/node@18.11.15)(@vitest/ui@1.6.0)(terser@5.16.1):
+  vitefu@0.2.3(vite@4.1.4):
     dependencies:
+      vite: 4.1.4
+
+  vitefu@0.2.5(vite@4.1.4):
+    dependencies:
+      vite: 4.1.4
+
+  vitefu@1.0.3(vite@5.3.3):
+    dependencies:
+      vite: 5.3.3(@types/node@18.19.64)
+
+  vitefu@1.0.5(vite@6.0.11):
+    dependencies:
+      vite: 6.0.11(@types/node@18.19.64)
+
+  vitest@1.6.0(@types/node@18.19.64)(@vitest/ui@1.6.0):
+    dependencies:
+      '@types/node': 18.19.64
       '@vitest/expect': 1.6.0
       '@vitest/runner': 1.6.0
       '@vitest/snapshot': 1.6.0
       '@vitest/spy': 1.6.0
+      '@vitest/ui': 1.6.0(vitest@1.6.0)
       '@vitest/utils': 1.6.0
       acorn-walk: 8.3.2
       chai: 4.4.1
@@ -15836,12 +15864,9 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.8.0
       tinypool: 0.8.4
-      vite: 5.3.3(@types/node@18.11.15)(terser@5.16.1)
-      vite-node: 1.6.0(@types/node@18.11.15)(terser@5.16.1)
+      vite: 5.3.3(@types/node@18.19.64)
+      vite-node: 1.6.0(@types/node@18.19.64)
       why-is-node-running: 2.2.2
-    optionalDependencies:
-      '@types/node': 18.11.15
-      '@vitest/ui': 1.6.0(vitest@1.6.0)
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -15958,19 +15983,19 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20241230.0
       '@cloudflare/workerd-windows-64': 1.20241230.0
 
-  wrangler@3.103.2(@cloudflare/workers-types@4.20230904.0):
+  wrangler@3.105.0(@cloudflare/workers-types@4.20230904.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
+      '@cloudflare/workers-types': 4.20230904.0
       '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
       '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
       blake3-wasm: 2.1.5
       esbuild: 0.17.19
       miniflare: 3.20241230.2
       path-to-regexp: 6.3.0
-      unenv: unenv-nightly@2.0.0-20250109-100802-88ad671
+      unenv: 2.0.0-rc.0
       workerd: 1.20241230.0
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20230904.0
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
# experimental PR

This branch has preliminary work for a process to deploy Go binaries alongside the main NPM packages, colocated within the monorepo.

Currently, it introduces `houdini-go`, a stub Go project that does nothing, and some build scripts written in Deno-flavoured TypeScript to build the Go module for all desired os/arch combinations and generate NPM packages to contain them. It also generates a meta-package that will contain what `houdini` would once this is all working properly, to avoid prematurely getting caught up in modifying the more complex `package.json` at build time.

If everything works with the Deno/separate meta-package setup, it can be ported to Node-flavour ESM and be merged into the main `houdini` package's build scripts.

Heavily WIP
