### PR TITLE
add abortController to query and mutation args

### DIFF
--- a/.changeset/tender-cows-unite.md
+++ b/.changeset/tender-cows-unite.md
@@ -1,0 +1,7 @@
+---
+'houdini-svelte': patch
+'houdini-react': patch
+'houdini': patch
+---
+
+Add abortController argument to query and mutation handles

--- a/packages/houdini-react/src/runtime/hooks/useMutation.ts
+++ b/packages/houdini-react/src/runtime/hooks/useMutation.ts
@@ -14,6 +14,7 @@ export type MutationHandler<_Result, _Input, _Optimistic extends GraphQLObject> 
 	metadata?: App.Metadata
 	fetch?: typeof globalThis.fetch
 	optimisticResponse?: _Optimistic
+	abortController?: AbortController
 }) => Promise<QueryResult<_Result, _Input>>
 
 export function useMutation<
@@ -39,12 +40,14 @@ export function useMutation<
 		metadata,
 		fetch,
 		variables,
+		abortController,
 		...mutationConfig
 	}) =>
 		observer.send({
 			variables,
 			metadata,
 			session,
+			abortController,
 			stuff: {
 				...mutationConfig,
 			},

--- a/packages/houdini-svelte/src/runtime/stores/mutation.ts
+++ b/packages/houdini-svelte/src/runtime/stores/mutation.ts
@@ -23,6 +23,7 @@ export class MutationStore<
 			metadata,
 			fetch,
 			event,
+			abortController: abort,
 			...mutationConfig
 		}: {
 			// @ts-ignore
@@ -44,6 +45,7 @@ export class MutationStore<
 			fetch: context.fetch,
 			metadata,
 			session: context.session,
+			abortController: abort,
 			stuff: {
 				...mutationConfig,
 			},
@@ -53,4 +55,5 @@ export class MutationStore<
 
 export type MutationConfig<_Result, _Input, _Optimistic> = {
 	optimisticResponse?: _Optimistic
+	abortController?: AbortController
 }

--- a/packages/houdini-svelte/src/runtime/stores/mutation.ts
+++ b/packages/houdini-svelte/src/runtime/stores/mutation.ts
@@ -23,7 +23,7 @@ export class MutationStore<
 			metadata,
 			fetch,
 			event,
-			abortController: abort,
+			abortController,
 			...mutationConfig
 		}: {
 			// @ts-ignore
@@ -45,7 +45,7 @@ export class MutationStore<
 			fetch: context.fetch,
 			metadata,
 			session: context.session,
-			abortController: abort,
+			abortController,
 			stuff: {
 				...mutationConfig,
 			},

--- a/packages/houdini-svelte/src/runtime/stores/query.ts
+++ b/packages/houdini-svelte/src/runtime/stores/query.ts
@@ -182,6 +182,7 @@ This will result in duplicate queries. If you are trying to ensure there is alwa
 				// if the CacheOnly request doesn't give us anything,
 				// don't update the store
 				silenceEcho: true,
+				abortController: params.abortController,
 			})
 		}
 

--- a/packages/houdini-svelte/src/runtime/types.ts
+++ b/packages/houdini-svelte/src/runtime/types.ts
@@ -83,11 +83,6 @@ type FetchGlobalParams<_Data extends GraphQLObject, _Input> = FetchParams<_Input
 	 * A function to call after the fetch happens (whether fake or not)
 	 */
 	then?: (val: _Data | null) => void | Promise<void>
-
-	/**
-	 * An abort controller to abort the request
-	 */
-	abortController?: AbortController
 }
 
 export type LoadEventFetchParams<_Data extends GraphQLObject, _Input> = FetchGlobalParams<

--- a/packages/houdini-svelte/src/runtime/types.ts
+++ b/packages/houdini-svelte/src/runtime/types.ts
@@ -83,6 +83,11 @@ type FetchGlobalParams<_Data extends GraphQLObject, _Input> = FetchParams<_Input
 	 * A function to call after the fetch happens (whether fake or not)
 	 */
 	then?: (val: _Data | null) => void | Promise<void>
+
+	/**
+	 * An abort controller to abort the request
+	 */
+	abortController?: AbortController
 }
 
 export type LoadEventFetchParams<_Data extends GraphQLObject, _Input> = FetchGlobalParams<

--- a/packages/houdini/src/runtime/lib/types.ts
+++ b/packages/houdini/src/runtime/lib/types.ts
@@ -317,6 +317,11 @@ export type FetchParams<_Input> = {
 	 */
 	// @ts-ignore
 	metadata?: App.Metadata
+
+	/**
+	 * An abort controller to abort the operation
+	 */
+	abortController?: AbortController
 }
 
 export type FetchFn<_Data extends GraphQLObject, _Input = any> = (


### PR DESCRIPTION
This PR adds an `abortController` argument to query and mutation stores in svelte in order to abort the operation

### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

