### PR TITLE
Rework init script to only update the necessary fields in config files

### DIFF
--- a/.changeset/sweet-dragons-brake.md
+++ b/.changeset/sweet-dragons-brake.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Update init script to only update the necessary fields


### PR DESCRIPTION
Fixes #1432

Using recast, this now updates the necessary fields instead of naively overwriting the entire config file.
This will make it easier for people who are migrating an existing app to Houdini.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

