### PR TITLE
Fix: make sure TS transforms to JSdoc 💱

### DIFF
--- a/site/plugins/docs-lang.js
+++ b/site/plugins/docs-lang.js
@@ -190,7 +190,7 @@ function transformVariable(statement, parent, importPaths) {
 		// remove the type annotation
 		declaration.id.typeAnnotation = null
 
-		parent.comments = [...(parent.comments ?? []), AST.commentBlock(` @type { ${targetType} } `)]
+		parent.comments = [...(parent.comments ?? []), AST.commentBlock(`* @type { ${targetType} } `)]
 	}
 }
 

--- a/site/plugins/docs-lang.test.js
+++ b/site/plugins/docs-lang.test.js
@@ -24,7 +24,7 @@ test('strip type declarations from variable declarations', async function () {
         \`\`\``)
 	).resolves.toMatchInlineSnapshot(`
 		"\`\`\`javascript
-		/* @type { import('./source').Type } */
+		/** @type { import('./source').Type } */
 		const Foo = () => {
 		    console.log('hello')
 		}
@@ -43,7 +43,7 @@ test('strip type declarations from exported variable declarations', async functi
         \`\`\``)
 	).resolves.toMatchInlineSnapshot(`
 		"\`\`\`javascript
-		/* @type { import('./source').Type } */
+		/** @type { import('./source').Type } */
 		export const Foo = () => {
 		    console.log('hello')
 		}


### PR DESCRIPTION
Fixes #1438  

This PR fixes the JSDoc generation in the typescript transform funtion for all code examples on the website.


![image](https://github.com/user-attachments/assets/20a40339-f834-4295-b2c7-b1698df4d42c)
