### PR TITLE
Subscription client types

### DIFF
--- a/.changeset/forty-pandas-notice.md
+++ b/.changeset/forty-pandas-notice.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Loosen typing requirements for SubscriptionClient to fix compatibility with graphql-sse

--- a/packages/houdini/src/runtime/client/plugins/subscription.ts
+++ b/packages/houdini/src/runtime/client/plugins/subscription.ts
@@ -105,8 +105,8 @@ export type SubscriptionClient = {
 		payload: {
 			operationName?: string
 			query: string
-			variables?: Record<string, unknown> | null
-			extensions?: Record<'persistedQuery', string> | Record<string, unknown> | null
+			variables?: Record<string, unknown>
+			extensions?: Record<'persistedQuery', string> | Record<string, unknown>
 		},
 		handlers: {
 			next: (payload: { data?: {} | null; errors?: readonly { message: string }[] }) => void


### PR DESCRIPTION
Fixes typescript errors when using `graphql-sse` for the subscriptions client, as the types between `graphql-ws` and `graphql-sse` don't quite match 100%:

https://github.com/enisdenjo/graphql-ws/blob/5161bd91388677893badb8dbaca5c6587095199b/src/common.ts#L130-L135

https://github.com/enisdenjo/graphql-sse/blob/b8c6beb00dcd5ffc83c4bc64d50c73dd3869cf8e/src/common.ts#L37-L42