### PR TITLE
Fix config exclude not matching absolute paths

### DIFF
--- a/.changeset/shiny-dogs-swim.md
+++ b/.changeset/shiny-dogs-swim.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix config exclude not excluding absolute paths correctly

--- a/packages/houdini/src/lib/config.test.ts
+++ b/packages/houdini/src/lib/config.test.ts
@@ -107,6 +107,25 @@ test(`Files that should not be included`, async () => {
 	expect(config.includeFile(path.join(process.cwd(), 'src/rou?tes/page.nop?s?e'))).toBe(false)
 })
 
+test('Include with absolute paths to project root', () => {
+	const config = testConfig()
+	config.projectRoot = '/path/to/project'
+
+	expect(config.includeFile('/path/to/project/src/lib/test.gql')).toBe(true)
+	expect(config.includeFile('/path/to/project/src/lib/test.ts')).toBe(true)
+	expect(config.includeFile('/path/to/project/src/lib/test.nope')).toBe(false)
+})
+
+test('Exclude with absolute paths to project root', () => {
+	const config = testConfig()
+	config.projectRoot = '/path/to/project'
+	config.exclude = ['src/lib/paraglide/**']
+
+	expect(config.includeFile('/path/to/project/src/lib/paraglide/messages.js')).toBe(false)
+	expect(config.includeFile('/path/to/project/src/lib/paraglide/registry.js')).toBe(false)
+	expect(config.includeFile('/path/to/project/src/lib/paraglide/messages/_index.js')).toBe(false)
+})
+
 test('Config.include includes plugin runtimes', () => {
 	const config = testConfig()
 

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -545,11 +545,11 @@ export class Config {
 		)
 	}
 
-	excludeFile(filepath: string) {
+	excludeFile(filepath: string, { root = this.projectRoot }: { root?: string }) {
 		// if the configured exclude does not allow this file, we're done
 		if (
 			this.exclude.length > 0 &&
-			this.exclude.some((pattern) => minimatch(filepath, pattern))
+			this.exclude.some((pattern) => minimatch(filepath, path.join(root, pattern)))
 		) {
 			return true
 		}
@@ -597,7 +597,7 @@ export class Config {
 		}
 
 		// if there is an exclude, make sure the path doesn't match any of the exclude patterns
-		return !this.excludeFile(filepath)
+		return !this.excludeFile(filepath, { root })
 	}
 
 	pluginRuntimeDirectory(name: string) {


### PR DESCRIPTION
Fixes #1444 

The exclude glob wasn't properly converted to an absolute path, so a file like `/path/to/project/src/exclude_me/hello.js` wasn't being caught by `src/exclude_me/**`.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`

