### PR TITLE
Avoid page state conflict

### DIFF
--- a/.changeset/shiny-kangaroos-cheat.md
+++ b/.changeset/shiny-kangaroos-cheat.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix issue when import page state in root layout

--- a/packages/houdini-svelte/src/plugin/transforms/kit/init.test.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/kit/init.test.ts
@@ -14,14 +14,14 @@ test('modifies root +layout.svelte to import adapter', async function () {
 	)
 
 	expect(result).toMatchInlineSnapshot(`
-		import { page } from "$app/stores";
+		import __houdini__pageStores from "$app/stores";
 		import { extractSession, setClientSession } from "$houdini/plugins/houdini-svelte/runtime/session";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/plugins/houdini-svelte/runtime/adapter";
 		export let data;
 		onMount(() => setClientStarted());
 
-		page.subscribe(val => {
+		__houdini__pageStores.page.subscribe(val => {
 		    setClientSession(extractSession(val.data));
 		});
 	`)

--- a/packages/houdini-svelte/src/plugin/transforms/kit/init.test.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/kit/init.test.ts
@@ -14,7 +14,7 @@ test('modifies root +layout.svelte to import adapter', async function () {
 	)
 
 	expect(result).toMatchInlineSnapshot(`
-		import __houdini__pageStores from "$app/stores";
+		import * as __houdini__pageStores from "$app/stores";
 		import { extractSession, setClientSession } from "$houdini/plugins/houdini-svelte/runtime/session";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/plugins/houdini-svelte/runtime/adapter";

--- a/packages/houdini-svelte/src/plugin/transforms/kit/init.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/kit/init.ts
@@ -48,12 +48,17 @@ export default async function kit_init(page: SvelteTransformPage) {
 		script: page.script,
 		config: page.config,
 		sourceModule: '$app/stores',
-		import: ['page'],
-	}).ids[0]
+    importKind: 'module',
+		import: '__houdini__pageStores',
+	}).ids
 
 	page.script.body.push(
 		AST.expressionStatement(
-			AST.callExpression(AST.memberExpression(store_id, AST.identifier('subscribe')), [
+			AST.callExpression(
+        AST.memberExpression(
+          AST.memberExpression(store_id, AST.identifier("page")), 
+          AST.identifier('subscribe')
+        ), [
 				AST.arrowFunctionExpression(
 					[AST.identifier('val')],
 					AST.blockStatement([

--- a/packages/houdini-svelte/src/plugin/transforms/kit/init.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/kit/init.ts
@@ -48,33 +48,35 @@ export default async function kit_init(page: SvelteTransformPage) {
 		script: page.script,
 		config: page.config,
 		sourceModule: '$app/stores',
-    importKind: 'module',
+		importKind: 'module',
 		import: '__houdini__pageStores',
 	}).ids
 
 	page.script.body.push(
 		AST.expressionStatement(
 			AST.callExpression(
-        AST.memberExpression(
-          AST.memberExpression(store_id, AST.identifier("page")), 
-          AST.identifier('subscribe')
-        ), [
-				AST.arrowFunctionExpression(
-					[AST.identifier('val')],
-					AST.blockStatement([
-						AST.expressionStatement(
-							AST.callExpression(set_session, [
-								AST.callExpression(extract_session, [
-									AST.memberExpression(
-										AST.identifier('val'),
-										AST.identifier('data')
-									),
-								]),
-							])
-						),
-					])
+				AST.memberExpression(
+					AST.memberExpression(store_id, AST.identifier('page')),
+					AST.identifier('subscribe')
 				),
-			])
+				[
+					AST.arrowFunctionExpression(
+						[AST.identifier('val')],
+						AST.blockStatement([
+							AST.expressionStatement(
+								AST.callExpression(set_session, [
+									AST.callExpression(extract_session, [
+										AST.memberExpression(
+											AST.identifier('val'),
+											AST.identifier('data')
+										),
+									]),
+								])
+							),
+						])
+					),
+				]
+			)
 		)
 	)
 }

--- a/packages/houdini-svelte/src/plugin/transforms/kit/load.test.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/kit/load.test.ts
@@ -530,13 +530,13 @@ describe('kit route processor', function () {
 		`)
 
 		expect(route.layout).toMatchInlineSnapshot(`
-			import { page } from "$app/stores";
+			import __houdini__pageStores from "$app/stores";
 			import { extractSession, setClientSession } from "$houdini/plugins/houdini-svelte/runtime/session";
 			import { onMount } from "svelte";
 			import { setClientStarted } from "$houdini/plugins/houdini-svelte/runtime/adapter";
 			onMount(() => setClientStarted());
 
-			page.subscribe(val => {
+			__houdini__pageStores.page.subscribe(val => {
 			    setClientSession(extractSession(val.data));
 			});
 		`)
@@ -567,13 +567,13 @@ describe('kit route processor', function () {
 		expect(route.script).toMatchInlineSnapshot('')
 
 		expect(route.layout).toMatchInlineSnapshot(`
-			import { page } from "$app/stores";
+			import __houdini__pageStores from "$app/stores";
 			import { extractSession, setClientSession } from "$houdini/plugins/houdini-svelte/runtime/session";
 			import { onMount } from "svelte";
 			import { setClientStarted } from "$houdini/plugins/houdini-svelte/runtime/adapter";
 			onMount(() => setClientStarted());
 
-			page.subscribe(val => {
+			__houdini__pageStores.page.subscribe(val => {
 			    setClientSession(extractSession(val.data));
 			});
 		`)
@@ -1184,13 +1184,13 @@ test('layout loads', async function () {
 	`)
 
 	expect(route.layout).toMatchInlineSnapshot(`
-		import { page } from "$app/stores";
+		import __houdini__pageStores from "$app/stores";
 		import { extractSession, setClientSession } from "$houdini/plugins/houdini-svelte/runtime/session";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/plugins/houdini-svelte/runtime/adapter";
 		onMount(() => setClientStarted());
 
-		page.subscribe(val => {
+		__houdini__pageStores.page.subscribe(val => {
 		    setClientSession(extractSession(val.data));
 		});
 	`)
@@ -1212,7 +1212,7 @@ test('layout inline query', async function () {
 	})
 
 	expect(route.layout).toMatchInlineSnapshot(`
-		import { page } from "$app/stores";
+		import __houdini__pageStores from "$app/stores";
 		import { extractSession, setClientSession } from "$houdini/plugins/houdini-svelte/runtime/session";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/plugins/houdini-svelte/runtime/adapter";
@@ -1223,7 +1223,7 @@ test('layout inline query', async function () {
 
 		onMount(() => setClientStarted());
 
-		page.subscribe(val => {
+		__houdini__pageStores.page.subscribe(val => {
 		    setClientSession(extractSession(val.data));
 		});
 	`)

--- a/packages/houdini-svelte/src/plugin/transforms/kit/load.test.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/kit/load.test.ts
@@ -530,7 +530,7 @@ describe('kit route processor', function () {
 		`)
 
 		expect(route.layout).toMatchInlineSnapshot(`
-			import __houdini__pageStores from "$app/stores";
+			import * as __houdini__pageStores from "$app/stores";
 			import { extractSession, setClientSession } from "$houdini/plugins/houdini-svelte/runtime/session";
 			import { onMount } from "svelte";
 			import { setClientStarted } from "$houdini/plugins/houdini-svelte/runtime/adapter";
@@ -567,7 +567,7 @@ describe('kit route processor', function () {
 		expect(route.script).toMatchInlineSnapshot('')
 
 		expect(route.layout).toMatchInlineSnapshot(`
-			import __houdini__pageStores from "$app/stores";
+			import * as __houdini__pageStores from "$app/stores";
 			import { extractSession, setClientSession } from "$houdini/plugins/houdini-svelte/runtime/session";
 			import { onMount } from "svelte";
 			import { setClientStarted } from "$houdini/plugins/houdini-svelte/runtime/adapter";
@@ -1184,7 +1184,7 @@ test('layout loads', async function () {
 	`)
 
 	expect(route.layout).toMatchInlineSnapshot(`
-		import __houdini__pageStores from "$app/stores";
+		import * as __houdini__pageStores from "$app/stores";
 		import { extractSession, setClientSession } from "$houdini/plugins/houdini-svelte/runtime/session";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/plugins/houdini-svelte/runtime/adapter";
@@ -1212,7 +1212,7 @@ test('layout inline query', async function () {
 	})
 
 	expect(route.layout).toMatchInlineSnapshot(`
-		import __houdini__pageStores from "$app/stores";
+		import * as __houdini__pageStores from "$app/stores";
 		import { extractSession, setClientSession } from "$houdini/plugins/houdini-svelte/runtime/session";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/plugins/houdini-svelte/runtime/adapter";

--- a/packages/houdini-svelte/src/plugin/transforms/kit/session.test.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/kit/session.test.ts
@@ -14,14 +14,14 @@ test('modifies root +layout.svelte with data prop', async function () {
 	)
 
 	expect(result).toMatchInlineSnapshot(`
-		import { page } from "$app/stores";
+		import * as __houdini__pageStores from "$app/stores";
 		import { extractSession, setClientSession } from "$houdini/plugins/houdini-svelte/runtime/session";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/plugins/houdini-svelte/runtime/adapter";
 		export let data;
 		onMount(() => setClientStarted());
 
-		page.subscribe(val => {
+		__houdini__pageStores.page.subscribe(val => {
 		    setClientSession(extractSession(val.data));
 		});
 	`)
@@ -55,13 +55,13 @@ test('modifies root +layout.svelte without data prop', async function () {
 	const result = await test_transform_svelte('src/routes/+layout.svelte', ``)
 
 	expect(result).toMatchInlineSnapshot(`
-		import { page } from "$app/stores";
+		import * as __houdini__pageStores from "$app/stores";
 		import { extractSession, setClientSession } from "$houdini/plugins/houdini-svelte/runtime/session";
 		import { onMount } from "svelte";
 		import { setClientStarted } from "$houdini/plugins/houdini-svelte/runtime/adapter";
 		onMount(() => setClientStarted());
 
-		page.subscribe(val => {
+		__houdini__pageStores.page.subscribe(val => {
 		    setClientSession(extractSession(val.data));
 		});
 	`)

--- a/packages/houdini/src/vite/imports.ts
+++ b/packages/houdini/src/vite/imports.ts
@@ -1,9 +1,9 @@
+import { identifier } from '@babel/types'
 import * as recast from 'recast'
 
 import type { Config } from '../lib/config'
 import type { Script } from '../lib/types'
 import type { TransformPage } from './houdini'
-import { identifier } from '@babel/types'
 
 const AST = recast.types.builders
 
@@ -83,12 +83,12 @@ export function ensure_imports({
 
 	// add the import if it doesn't exist, add it
 	if (toImport.length > 0) {
-    const specifier = (identifier: Identifier, i: number) => (importKind !== 'module' ? 	
-      (!Array.isArray(importID)
+		const specifier = (identifier: Identifier, i: number) =>
+			importKind !== 'module'
+				? !Array.isArray(importID)
 					? AST.importDefaultSpecifier(identifier)
-					: AST.importSpecifier(identifier, as?.[i] ? AST.identifier(as[i]) : identifier))
-      : AST.importNamespaceSpecifier(identifier))
-
+					: AST.importSpecifier(identifier, as?.[i] ? AST.identifier(as[i]) : identifier)
+				: AST.importNamespaceSpecifier(identifier)
 
 		script.body.unshift({
 			type: 'ImportDeclaration',

--- a/packages/houdini/src/vite/imports.ts
+++ b/packages/houdini/src/vite/imports.ts
@@ -1,4 +1,3 @@
-import { identifier } from '@babel/types'
 import * as recast from 'recast'
 
 import type { Config } from '../lib/config'


### PR DESCRIPTION
Fixes #1462 

This PR updates the root layout transform so that the page stores we rely on are imported as a namespace to avoid a conflict if the user imports `page` from `$app/state`.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Ensure your code is formatted to conform to standard style with `pnpm run format:write` (or `format:check` if you want to preview changes) and linted `pnpm run lint`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`
