### PR TITLE
deps(e2e tests): upgrade vite from v4 to v6, since v4 is not actually supported …

### DIFF
--- a/e2e/react/package.json
+++ b/e2e/react/package.json
@@ -48,7 +48,7 @@
 		"postcss": "^8.4.31",
 		"tailwindcss": "^3.3.3",
 		"typescript": "^4.9.3",
-		"vite": "^4.1.0",
+		"vite": "^6.0.3",
 		"wrangler": "^3.91.0"
 	}
 }

--- a/e2e/svelte/package.json
+++ b/e2e/svelte/package.json
@@ -33,6 +33,6 @@
 		"svelte-check": "^2.10.3",
 		"tslib": "^2.5.0",
 		"typescript": "^4.9.3",
-		"vite": "^4.1.1"
+		"vite": "^6.0.3"
 	}
 }

--- a/packages/create-houdini/templates/react-typescript/package.json
+++ b/packages/create-houdini/templates/react-typescript/package.json
@@ -23,7 +23,7 @@
 		"@types/react-dom": "^19.0.3",
 		"@vitejs/plugin-react": "^3.1.0",
 		"typescript": "^4.9.3",
-		"vite": "^4.1.0"
+		"vite": "^6.0.3"
 	},
 	"resolutions": {
 		"graphql": "15.8.0",

--- a/packages/create-houdini/templates/react/package.json
+++ b/packages/create-houdini/templates/react/package.json
@@ -20,7 +20,7 @@
 	},
 	"devDependencies": {
 		"@vitejs/plugin-react": "^3.1.0",
-		"vite": "^4.1.0"
+		"vite": "^6.0.3"
 	},
 	"resolutions": {
 		"graphql": "15.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,7 +256,7 @@ importers:
         version: 19.0.3(@types/react@19.0.7)
       '@vitejs/plugin-react':
         specifier: ^3.1.0
-        version: 3.1.0(vite@4.1.4(@types/node@18.11.15)(terser@5.16.1))
+        version: 3.1.0(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.16(postcss@8.4.31)
@@ -288,8 +288,8 @@ importers:
         specifier: ^4.9.3
         version: 4.9.4
       vite:
-        specifier: ^4.1.0
-        version: 4.1.4(@types/node@18.11.15)(terser@5.16.1)
+        specifier: ^6.0.3
+        version: 6.0.7(@types/node@18.11.15)(terser@5.16.1)
       wrangler:
         specifier: ^3.91.0
         version: 3.103.2(@cloudflare/workers-types@4.20230904.0)
@@ -304,7 +304,7 @@ importers:
         version: 1.48.0
       '@sveltejs/vite-plugin-svelte':
         specifier: ^2.0.2
-        version: 2.0.2(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1))
+        version: 2.0.2(svelte@3.57.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
       '@tsconfig/svelte':
         specifier: ^3.0.0
         version: 3.0.0
@@ -336,8 +336,8 @@ importers:
         specifier: ^4.9.3
         version: 4.9.4
       vite:
-        specifier: ^4.1.1
-        version: 4.1.1(@types/node@18.11.15)(terser@5.16.1)
+        specifier: ^6.0.3
+        version: 6.0.7(@types/node@18.11.15)(terser@5.16.1)
 
   packages/_scripts:
     dependencies:
@@ -7861,31 +7861,6 @@ packages:
       terser:
         optional: true
 
-  vite@4.1.4:
-    resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-
   vite@5.3.3:
     resolution: {integrity: sha512-NPQdeCU0Dv2z5fu+ULotpuq5yfCS1BzKUIPhNbP3YBfAMGJXbt2nS+sbTFu+qchaqWTD+H3JK++nRwr6XIcp6A==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -9780,7 +9755,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@2.0.2(svelte@3.57.0)(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1))':
+  '@sveltejs/vite-plugin-svelte@2.0.2(svelte@3.57.0)(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))':
     dependencies:
       debug: 4.3.4(supports-color@9.3.1)
       deepmerge: 4.2.2
@@ -9788,8 +9763,8 @@ snapshots:
       magic-string: 0.27.0
       svelte: 3.57.0
       svelte-hmr: 0.15.1(svelte@3.57.0)
-      vite: 4.1.1(@types/node@18.11.15)(terser@5.16.1)
-      vitefu: 0.2.3(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1))
+      vite: 6.0.7(@types/node@18.11.15)(terser@5.16.1)
+      vitefu: 0.2.3(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -10416,14 +10391,14 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitejs/plugin-react@3.1.0(vite@4.1.4(@types/node@18.11.15)(terser@5.16.1))':
+  '@vitejs/plugin-react@3.1.0(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1))':
     dependencies:
       '@babel/core': 7.21.4
       '@babel/plugin-transform-react-jsx-self': 7.21.0(@babel/core@7.21.4)
       '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.21.4)
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.1.4(@types/node@18.11.15)(terser@5.16.1)
+      vite: 6.0.7(@types/node@18.11.15)(terser@5.16.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -16424,17 +16399,6 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.16.1
 
-  vite@4.1.4(@types/node@18.11.15)(terser@5.16.1):
-    dependencies:
-      esbuild: 0.16.17
-      postcss: 8.4.39
-      resolve: 1.22.8
-      rollup: 3.27.1
-    optionalDependencies:
-      '@types/node': 18.11.15
-      fsevents: 2.3.3
-      terser: 5.16.1
-
   vite@5.3.3(@types/node@18.11.15)(terser@5.16.1):
     dependencies:
       esbuild: 0.21.5
@@ -16455,9 +16419,9 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.16.1
 
-  vitefu@0.2.3(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1)):
+  vitefu@0.2.3(vite@6.0.7(@types/node@18.11.15)(terser@5.16.1)):
     optionalDependencies:
-      vite: 4.1.1(@types/node@18.11.15)(terser@5.16.1)
+      vite: 6.0.7(@types/node@18.11.15)(terser@5.16.1)
 
   vitefu@0.2.5(vite@4.1.1(@types/node@18.11.15)(terser@5.16.1)):
     optionalDependencies:


### PR DESCRIPTION
Required for #1455 (hot update API)

The `e2e/react` and `e2e/svelte` project have an incompatible vite version (4.x.x), they should be 5 or 6.

https://github.com/HoudiniGraphql/houdini/blob/64fe7964266773f0b3eda4ee779481c811b6bfae/packages/houdini/package.json#L63

No breaking changes, so it's a plain dependency update:
V4-V5 https://v5.vite.dev/guide/migration.html
V5-V6 https://vite.dev/guide/migration.html

No changeset needed
