### PR TITLE
Fix @load directive not using renamed props

### DIFF
--- a/.changeset/orange-apricots-kiss.md
+++ b/.changeset/orange-apricots-kiss.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Properly generate load function with renamed props for component queries with an `@load` directive

--- a/packages/houdini-svelte/src/plugin/transforms/componentQuery.test.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/componentQuery.test.ts
@@ -477,7 +477,12 @@ describe('Svelte 5 runes', function () {
 					}
 				}
 	
-				const { prop1: renamedProp } = $props();
+				const {
+                    prop1: renamedProp,
+                    prop2: alsoRenamed = "with default",
+                    prop3,
+                    prop4 = "some default"
+                } = $props();
 	
 				const result = $derived(
 					graphql\`
@@ -505,7 +510,10 @@ describe('Svelte 5 runes', function () {
 			}
 
 			const {
-			    prop1: renamedProp
+			    prop1: renamedProp,
+			    prop2: alsoRenamed = "with default",
+			    prop3,
+			    prop4 = "some default"
 			} = $props();
 
 			const result = $derived(_houdini_TestQuery);
@@ -518,7 +526,10 @@ describe('Svelte 5 runes', function () {
 
 			            input: _TestQueryVariables.call(new RequestContext(), {
 			                props: {
-			                    prop1: renamedProp
+			                    prop1: renamedProp,
+			                    prop2: alsoRenamed,
+			                    prop3: prop3,
+			                    prop4: prop4
 			                }
 			            })
 			        })

--- a/packages/houdini-svelte/src/plugin/transforms/componentQuery.test.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/componentQuery.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, vi, describe } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import { component_test } from '../../test'
 
@@ -95,6 +95,64 @@ test('with variables', async function () {
 		                prop2: prop2,
 		                prop3: prop3,
 		                prop4: prop4
+		            }
+		        })
+		    })
+		});
+	`)
+})
+
+test('renamed variables', async function () {
+	const route = await component_test(
+		`
+            export function _TestQueryVariables() {
+                return {
+                    hello: 'world'
+                }
+            }
+
+            let className = ""
+            export { className as class }
+
+            $: result = graphql\`
+                query TestQuery($test: String!) @load {
+                    users(stringValue: $test) {
+                        id
+                    }
+                }
+            \`
+		`
+	)
+
+	expect(route).toMatchInlineSnapshot(`
+		import { TestQueryStore } from "$houdini/plugins/houdini-svelte/stores/TestQuery";
+		import { isBrowser } from "$houdini/plugins/houdini-svelte/runtime/adapter";
+		import { RequestContext } from "$houdini/plugins/houdini-svelte/runtime/session";
+		import { getCurrentConfig } from "$houdini/runtime/lib/config";
+		import { marshalInputs } from "$houdini/runtime/lib/scalars";
+		const _houdini_TestQuery = new TestQueryStore();
+
+		export function _TestQueryVariables() {
+		    return {
+		        hello: "world"
+		    };
+		}
+
+		let className = "";
+		export { className as class };
+
+		$:
+		result = _houdini_TestQuery;
+
+		$:
+		isBrowser && _houdini_TestQuery.fetch({
+		    variables: marshalInputs({
+		        config: getCurrentConfig(),
+		        artifact: _houdini_TestQuery.artifact,
+
+		        input: _TestQueryVariables.call(new RequestContext(), {
+		            props: {
+		                class: className
 		            }
 		        })
 		    })
@@ -405,6 +463,64 @@ describe('Svelte 5 runes', function () {
 			            config: getCurrentConfig(),
 			            artifact: _houdini_TestQuery.artifact,
 			            input: {}
+			        })
+			    });
+			});
+		`)
+	})
+
+	test('renamed props', async function () {
+		const route = await component_test(`
+				export function _TestQueryVariables() {
+					return {
+						hello: 'world'
+					}
+				}
+	
+				const { prop1: renamedProp } = $props();
+	
+				const result = $derived(
+					graphql\`
+						query TestQuery($test: String!) @load {
+							users(stringValue: $test) {
+								id
+							}
+						}
+					\`
+				)
+			`)
+
+		expect(route).toMatchInlineSnapshot(`
+			import { TestQueryStore } from "$houdini/plugins/houdini-svelte/stores/TestQuery";
+			import { isBrowser } from "$houdini/plugins/houdini-svelte/runtime/adapter";
+			import { RequestContext } from "$houdini/plugins/houdini-svelte/runtime/session";
+			import { getCurrentConfig } from "$houdini/runtime/lib/config";
+			import { marshalInputs } from "$houdini/runtime/lib/scalars";
+			const _houdini_TestQuery = new TestQueryStore();
+
+			export function _TestQueryVariables() {
+			    return {
+			        hello: "world"
+			    };
+			}
+
+			const {
+			    prop1: renamedProp
+			} = $props();
+
+			const result = $derived(_houdini_TestQuery);
+
+			$effect(() => {
+			    _houdini_TestQuery.fetch({
+			        variables: marshalInputs({
+			            config: getCurrentConfig(),
+			            artifact: _houdini_TestQuery.artifact,
+
+			            input: _TestQueryVariables.call(new RequestContext(), {
+			                props: {
+			                    prop1: renamedProp
+			                }
+			            })
 			        })
 			    });
 			});

--- a/packages/houdini-svelte/src/plugin/transforms/componentQuery.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/componentQuery.ts
@@ -62,11 +62,25 @@ export default async function QueryProcessor(config: Config, page: SvelteTransfo
 				propsStatement.id.properties.forEach((property) => {
 					if (property.type === 'ObjectProperty' && property.key.type === 'Identifier') {
 						const key = property.key.name
-						// If the prop was renamed, save the renamed name instead
-						const value =
-							property.value.type === 'Identifier'
-								? property.value.name
-								: property.key.name
+						let value = property.key.name
+
+						// There's a difference between `prop: renamed` and `prop: renamed = "default"`!
+						switch (property.value.type) {
+							// `prop: renamed` - key is an Identifier
+							case 'Identifier':
+								value = property.value.name
+								break
+
+							// `prop: renamed = "default"` - key is an AssignmentPattern
+							case 'AssignmentPattern':
+								if (property.value.left.type === 'Identifier') {
+									value = property.value.left.name
+								}
+								break
+
+							default:
+								break
+						}
 
 						props.push({ key, value })
 					}

--- a/packages/houdini-svelte/src/plugin/transforms/componentQuery.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/componentQuery.ts
@@ -1,15 +1,10 @@
 import { yellow } from '@kitql/helpers'
-import type {
-	ExpressionKind,
-	IdentifierKind,
-	StatementKind,
-	VariableDeclaratorKind,
-} from 'ast-types/lib/gen/kinds'
+import type { ExpressionKind, StatementKind, VariableDeclaratorKind } from 'ast-types/lib/gen/kinds'
 import type * as graphql from 'graphql'
 import type { Config, Script } from 'houdini'
 import { find_graphql, formatErrors } from 'houdini'
 import type { TransformPage } from 'houdini/vite'
-import { find_exported_fn, find_insert_index, ensure_imports } from 'houdini/vite'
+import { ensure_imports, find_exported_fn, find_insert_index } from 'houdini/vite'
 import * as recast from 'recast'
 
 import { is_component } from '../kit'
@@ -41,7 +36,7 @@ export default async function QueryProcessor(config: Config, page: SvelteTransfo
 	}
 
 	// Find all props of the component
-	let props: (string | IdentifierKind)[] = []
+	let props: { key: string; value: string }[] = []
 
 	if (page.svelte5Runes) {
 		// In runes, we need to find props defined by the `$props` rune.
@@ -66,7 +61,14 @@ export default async function QueryProcessor(config: Config, page: SvelteTransfo
 			if (propsStatement && propsStatement.id.type === 'ObjectPattern') {
 				propsStatement.id.properties.forEach((property) => {
 					if (property.type === 'ObjectProperty' && property.key.type === 'Identifier') {
-						props.push(property.key.name)
+						const key = property.key.name
+						// If the prop was renamed, save the renamed name instead
+						const value =
+							property.value.type === 'Identifier'
+								? property.value.name
+								: property.key.name
+
+						props.push({ key, value })
 					}
 				})
 			}
@@ -77,17 +79,29 @@ export default async function QueryProcessor(config: Config, page: SvelteTransfo
 			page.script.body.filter(
 				(statement) =>
 					statement.type === 'ExportNamedDeclaration' &&
-					statement.declaration?.type === 'VariableDeclaration'
+					(!statement.declaration || statement.declaration.type === 'VariableDeclaration')
 			) as ExportNamedDeclaration[]
-		).flatMap(({ declaration }) =>
-			(declaration as VariableDeclaration)!.declarations.map((dec) => {
-				if (dec.type === 'VariableDeclarator') {
-					return dec.id.type === 'Identifier' ? dec.id.name : ''
-				}
+		).flatMap(({ declaration, specifiers }) => {
+			if (declaration?.type === 'VariableDeclaration') {
+				// Simple `export let myProp` declarations
+				return declaration.declarations.map((dec) => {
+					if (dec.type === 'VariableDeclarator') {
+						const name = dec.id.type === 'Identifier' ? dec.id.name : ''
+						return { key: name, value: name }
+					}
 
-				return dec.name
-			})
-		)
+					return { key: dec.name as string, value: dec.name as string }
+				})
+			}
+
+			// Handle `export { localName as externalName }` cases
+			return (
+				specifiers?.flatMap((spec) => ({
+					key: spec.exported.name as string,
+					value: (spec.local?.name ?? '') as string,
+				})) ?? []
+			)
+		})
 	}
 
 	ensure_imports({
@@ -200,10 +214,10 @@ export default async function QueryProcessor(config: Config, page: SvelteTransfo
 																	props.map((prop) =>
 																		AST.objectProperty(
 																			AST.identifier(
-																				prop as string
+																				prop.key
 																			),
 																			AST.identifier(
-																				prop as string
+																				prop.value
 																			)
 																		)
 																	)


### PR DESCRIPTION
Fixes #1468

The generated load functions for component queries were not taking renamed props into account in Svelte 5, and ignoring them completely in legacy svelte mode. This PR fixes this bug.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Ensure your code is formatted to conform to standard style with `pnpm run format:write` (or `format:check` if you want to preview changes) and linted `pnpm run lint`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`
