### PR TITLE
[houdini-svelte] properly warn against using page/layout queries when not include-ing .js files in houdini.config.js

### DIFF
--- a/.changeset/purple-readers-punch.md
+++ b/.changeset/purple-readers-punch.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+properly warn against using page/layout queries when not include-ing .js files in houdini.config.js

--- a/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
@@ -68,10 +68,9 @@ export default async function svelteKitGenerator(
 				// Include path doesn't include js
 				!config.include.some((path) => path.includes('js')) &&
 				// And the plugin isn't configured to run in static mode
-				(!plugin_config(config).static ||
-					// User uses layout/page queries
-					uniquePageQueries.length > 0 ||
-					uniqueLayoutQueries.length > 0)
+				!plugin_config(config).static &&
+				// User uses layout/page queries
+				(uniquePageQueries.length > 0 || uniqueLayoutQueries.length > 0)
 			) {
 				console.error(
 					`⚠️ You are using at least one page/layout query but aren't "include"ing .js files in your config. \n 


### PR DESCRIPTION
Fixes #1416

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Ensure your code is formatted to conform to standard style with `pnpm run format:write` (or `format:check` if you want to preview changes) and linted `pnpm run lint`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`
