### PR TITLE
Generate and include static runtimes before collecting documents

### DIFF
--- a/.changeset/rare-poets-walk.md
+++ b/.changeset/rare-poets-walk.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix static runtime generation

--- a/packages/houdini/src/codegen/generators/indexFile/index.ts
+++ b/packages/houdini/src/codegen/generators/indexFile/index.ts
@@ -55,8 +55,8 @@ export default async function writeIndexFile(config: Config, docs: Document[]) {
 				module: relative(config.pluginRuntimeDirectory(plugin.name)),
 			})
 		}
-		
-    // if the plugin generated a static runtime
+
+		// if the plugin generated a static runtime
 		if (plugin.staticRuntime) {
 			body += exportStar({
 				module: relative(config.pluginStaticRuntimeDirectory(plugin.name)),

--- a/packages/houdini/src/codegen/generators/indexFile/index.ts
+++ b/packages/houdini/src/codegen/generators/indexFile/index.ts
@@ -57,7 +57,7 @@ export default async function writeIndexFile(config: Config, docs: Document[]) {
 		}
 		
     // if the plugin generated a static runtime
-		if (plugin.includeRuntime) {
+		if (plugin.staticRuntime) {
 			body += exportStar({
 				module: relative(config.pluginStaticRuntimeDirectory(plugin.name)),
 			})

--- a/packages/houdini/src/codegen/generators/indexFile/index.ts
+++ b/packages/houdini/src/codegen/generators/indexFile/index.ts
@@ -55,6 +55,13 @@ export default async function writeIndexFile(config: Config, docs: Document[]) {
 				module: relative(config.pluginRuntimeDirectory(plugin.name)),
 			})
 		}
+		
+    // if the plugin generated a static runtime
+		if (plugin.includeRuntime) {
+			body += exportStar({
+				module: relative(config.pluginStaticRuntimeDirectory(plugin.name)),
+			})
+		}
 	}
 
 	// write the index file that exports the runtime

--- a/packages/houdini/src/codegen/generators/runtime/pluginRuntime.ts
+++ b/packages/houdini/src/codegen/generators/runtime/pluginRuntime.ts
@@ -38,7 +38,7 @@ export async function generateStaticRuntimes({ config }: { config: Config }) {
 			.filter((plugin) => plugin.staticRuntime)
 			.map(async (plugin) => {
 				// a plugin has told us to include a runtime then the path is relative to the plugin file
-				const runtime_path = config.pluginRuntimeSource(plugin)
+				const runtime_path = config.pluginStaticRuntimeSource(plugin)
 				if (!runtime_path) {
 					return
 				}

--- a/packages/houdini/src/codegen/generators/runtime/pluginRuntime.ts
+++ b/packages/houdini/src/codegen/generators/runtime/pluginRuntime.ts
@@ -27,6 +27,41 @@ export function moduleStatments(config: Config) {
 	}
 }
 
+export async function generateStaticRuntimes({ config }: { config: Config }) {
+	if (houdini_mode.is_testing) {
+		return
+	}
+
+	// generate the runtime for each plugin
+	await Promise.all(
+		config.plugins
+			.filter((plugin) => plugin.staticRuntime)
+			.map(async (plugin) => {
+				// a plugin has told us to include a runtime then the path is relative to the plugin file
+				const runtime_path = config.pluginRuntimeSource(plugin)
+				if (!runtime_path) {
+					return
+				}
+
+				// make sure the source file exists
+				try {
+					await fs.stat(runtime_path)
+				} catch {
+					throw new HoudiniError({
+						message: 'Cannot find runtime to generate for ' + plugin.name,
+						description: 'Maybe it was bundled?',
+					})
+				}
+
+				// copy the runtime
+				const pluginDir = config.pluginStaticRuntimeDirectory(plugin.name)
+
+				await fs.mkdirp(pluginDir)
+				await fs.recursiveCopy(runtime_path, pluginDir)
+			})
+	)
+}
+
 export async function generatePluginRuntimes({
 	config,
 	docs,

--- a/packages/houdini/src/codegen/index.ts
+++ b/packages/houdini/src/codegen/index.ts
@@ -5,11 +5,14 @@ import { runPipeline as run, LogLevel, find_graphql, parseJS, HoudiniError, fs, 
 import { ArtifactKind, type ArtifactKinds } from '../runtime/lib/types'
 import * as generators from './generators'
 import type { ArtifactStats } from './generators/artifacts'
+import { generateStaticRuntimes } from './generators/runtime/pluginRuntime'
 import * as transforms from './transforms'
 import * as validators from './validators'
 
 // the main entry point of the compile script
 export default async function compile(config: Config): Promise<ArtifactStats | undefined> {
+	await generateStaticRuntimes({ config })
+
 	// grab the graphql documents
 	const documents = await collectDocuments(config)
 

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -211,17 +211,24 @@ export class Config {
 		// documents
 		for (const plugin of this.plugins) {
 			const runtimeDir = this.pluginRuntimeSource(plugin)
+			const staticDir = this.pluginStaticRuntimeSource(plugin)
 
 			// skip plugins that dont' include runtimes
-			if (!runtimeDir) {
+			if (!runtimeDir && !staticDir) {
 				continue
 			}
 
-			// the include path is relative to root of the vite project
-			const includePath = path.relative(this.projectRoot, runtimeDir)
+			for (const dir of [runtimeDir, staticDir]) {
+				if (!dir) {
+					continue
+				}
 
-			// add the plugin's directory to the include pile
-			include.push(`${includePath}/**/*{${extensions.join(',')}}`)
+				// the include path is relative to root of the vite project
+				const includePath = path.relative(this.projectRoot, dir)
+
+				// add the plugin's directory to the include pile
+				include.push(`${includePath}/**/*{${extensions.join(',')}}`)
+			}
 		}
 
 		return include
@@ -300,6 +307,19 @@ export class Config {
 			typeof plugin.includeRuntime === 'string'
 				? plugin.includeRuntime
 				: plugin.includeRuntime?.[this.module]
+		)
+	}
+
+	pluginStaticRuntimeSource(plugin: PluginMeta) {
+		if (!plugin.staticRuntime) {
+			return null
+		}
+
+		return path.join(
+			path.dirname(plugin.filepath),
+			typeof plugin.staticRuntime === 'string'
+				? plugin.staticRuntime
+				: plugin.staticRuntime?.[this.module]
 		)
 	}
 
@@ -602,6 +622,10 @@ export class Config {
 
 	pluginRuntimeDirectory(name: string) {
 		return path.join(this.pluginDirectory(name), 'runtime')
+	}
+
+	pluginStaticRuntimeDirectory(name: string) {
+		return path.join(this.pluginDirectory(name), 'static')
 	}
 
 	get pluginRootDirectory() {


### PR DESCRIPTION
This PR adds back the ability for plugins to include a static runtime that will be considered for document collection


### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Ensure your code is formatted to conform to standard style with `pnpm run format:write` (or `format:check` if you want to preview changes) and linted `pnpm run lint`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`
