### PR TITLE
Feat config writepulledschema

### DIFF
--- a/.changeset/small-rice-remember.md
+++ b/.changeset/small-rice-remember.md
@@ -1,0 +1,5 @@
+---
+'houdini': minor
+---
+
+allow configuring schemaPolling to write the pulled schema to a file

--- a/packages/houdini/src/cmd/init.ts
+++ b/packages/houdini/src/cmd/init.ts
@@ -157,7 +157,7 @@ export async function init(
 				fetchTimeout,
 				schemaPath,
 				local_headers,
-				false
+				true
 			)
 
 			if (pullSchema_content === null) {
@@ -196,11 +196,6 @@ export async function init(
 		)
 
 		schemaPath = answers.schema_path
-	}
-
-	// Let's write the schema only now (after the function "after_questions" where the project has been created)
-	if (is_remote_endpoint && pullSchema_content) {
-		await fs.writeFile(path.join(targetPath, schemaPath), pullSchema_content)
 	}
 
 	// try to detect which tools they are using

--- a/packages/houdini/src/cmd/init.ts
+++ b/packages/houdini/src/cmd/init.ts
@@ -157,7 +157,7 @@ export async function init(
 				fetchTimeout,
 				schemaPath,
 				local_headers,
-				true
+				false
 			)
 
 			if (pullSchema_content === null) {

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -59,6 +59,7 @@ export class Config {
 	routesDir: string
 	schemaPollInterval: number | null
 	schemaPollTimeout: number
+	schemaPollWriteToDisk: boolean = false
 	schemaPollHeaders:
 		| ((env: any) => Record<string, string>)
 		| Record<string, string | ((env: any) => string)>
@@ -163,6 +164,7 @@ export class Config {
 		this.routesDir = path.join(this.projectRoot, 'src', 'routes')
 		this.schemaPollInterval = watchSchema?.interval === undefined ? 2000 : watchSchema.interval
 		this.schemaPollTimeout = watchSchema?.timeout ?? 30000
+		this.schemaPollWriteToDisk = !(watchSchema?.skipWriting ?? false)
 		this.schemaPollHeaders = watchSchema?.headers ?? {}
 		this.rootDir = path.join(this.projectRoot, this.runtimeDir)
 		this.persistedQueriesPath =
@@ -1157,11 +1159,14 @@ export async function getConfig({
 			// we might have to pull the schema first
 			if (apiURL) {
 				// make sure we don't have a pattern pointing to multiple files and a remove URL
-				if (fs.glob.hasMagic(_config.schemaPath)) {
+				if (fs.glob.hasMagic(_config.schemaPath) && _config.schemaPollWriteToDisk) {
 					console.log(
 						`⚠️  Your houdini configuration contains an apiUrl and a path pointing to multiple files.
-	This will prevent your schema from being pulled.`
+	This will prevent your schema from being written to disk. If this is expected, please set the skipWriting value to true.`
 					)
+
+					// Don't write the schema to disk, since it'll error out
+					_config.schemaPollWriteToDisk = false
 				}
 				// we might have to create the file
 				else if (!(await fs.readFile(_config.schemaPath))) {
@@ -1170,7 +1175,9 @@ export async function getConfig({
 						(await pullSchema(
 							apiURL,
 							_config.schemaPollTimeout,
-							_config.schemaPath
+							_config.schemaPath,
+							{},
+							_config.schemaPollWriteToDisk
 						)) !== null
 				}
 			}

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -164,7 +164,7 @@ export class Config {
 		this.routesDir = path.join(this.projectRoot, 'src', 'routes')
 		this.schemaPollInterval = watchSchema?.interval === undefined ? 2000 : watchSchema.interval
 		this.schemaPollTimeout = watchSchema?.timeout ?? 30000
-		this.schemaPollWriteToDisk = !(watchSchema?.skipWriting ?? false)
+		this.schemaPollWriteToDisk = !(watchSchema?.writePolledSchema ?? true)
 		this.schemaPollHeaders = watchSchema?.headers ?? {}
 		this.rootDir = path.join(this.projectRoot, this.runtimeDir)
 		this.persistedQueriesPath =
@@ -1162,7 +1162,7 @@ export async function getConfig({
 				if (fs.glob.hasMagic(_config.schemaPath) && _config.schemaPollWriteToDisk) {
 					console.log(
 						`⚠️  Your houdini configuration contains an apiUrl and a path pointing to multiple files.
-	This will prevent your schema from being written to disk. If this is expected, please set the skipWriting value to true.`
+	This will prevent your schema from being written to disk. If this is expected, please set the writePolledSchema value to false.`
 					)
 
 					// Don't write the schema to disk, since it'll error out

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -164,7 +164,7 @@ export class Config {
 		this.routesDir = path.join(this.projectRoot, 'src', 'routes')
 		this.schemaPollInterval = watchSchema?.interval === undefined ? 2000 : watchSchema.interval
 		this.schemaPollTimeout = watchSchema?.timeout ?? 30000
-		this.schemaPollWriteToDisk = !(watchSchema?.writePolledSchema ?? true)
+		this.schemaPollWriteToDisk = watchSchema?.writePolledSchema ?? true
 		this.schemaPollHeaders = watchSchema?.headers ?? {}
 		this.rootDir = path.join(this.projectRoot, this.runtimeDir)
 		this.persistedQueriesPath =

--- a/packages/houdini/src/lib/introspection.ts
+++ b/packages/houdini/src/lib/introspection.ts
@@ -70,7 +70,14 @@ export async function pullSchema(
 			fileData = JSON.stringify(jsonSchema)
 		}
 		if (writeToDisk) {
-			await fs.writeFile(schemaPath, fileData)
+			try {
+				await fs.writeFile(schemaPath, fileData)
+			} catch (e) {
+				console.warn(
+					`⚠️  Couldn't write your pulled schema to disk: ${(e as Error).message}
+If this is expected, please set watchSchema.skipWriting to true in your config file.`
+				)
+			}
 		}
 
 		return fileData

--- a/packages/houdini/src/lib/introspection.ts
+++ b/packages/houdini/src/lib/introspection.ts
@@ -75,7 +75,7 @@ export async function pullSchema(
 			} catch (e) {
 				console.warn(
 					`⚠️  Couldn't write your pulled schema to disk: ${(e as Error).message}
-If this is expected, please set watchSchema.skipWriting to true in your config file.`
+	If this is expected, please set watchSchema.writePolledSchema to false in your config file.`
 				)
 			}
 		}

--- a/packages/houdini/src/lib/introspection.ts
+++ b/packages/houdini/src/lib/introspection.ts
@@ -9,7 +9,7 @@ export async function pullSchema(
 	fetchTimeout: number,
 	schemaPath: string,
 	headers?: Record<string, string>,
-	skipWriting?: boolean
+	writeToDisk: boolean = true
 ): Promise<string | null> {
 	let content = ''
 	try {
@@ -69,7 +69,7 @@ export async function pullSchema(
 		} else {
 			fileData = JSON.stringify(jsonSchema)
 		}
-		if (!skipWriting) {
+		if (writeToDisk) {
 			await fs.writeFile(schemaPath, fileData)
 		}
 

--- a/packages/houdini/src/runtime/lib/config.ts
+++ b/packages/houdini/src/runtime/lib/config.ts
@@ -312,6 +312,12 @@ export type WatchSchemaConfig = {
 	headers?:
 		| Record<string, string | ((env: Record<string, string | undefined>) => string)>
 		| ((env: Record<string, string | undefined>) => Record<string, string>)
+	
+	/**
+	 * Do not write the schema to disk on pull.
+	 * Useful when you have read only access to the schema or directory it's in.
+	*/
+	skipWriting?: boolean
 }
 
 export type ScalarSpec = {

--- a/packages/houdini/src/runtime/lib/config.ts
+++ b/packages/houdini/src/runtime/lib/config.ts
@@ -314,10 +314,11 @@ export type WatchSchemaConfig = {
 		| ((env: Record<string, string | undefined>) => Record<string, string>)
 	
 	/**
-	 * Do not write the schema to disk on pull.
-	 * Useful when you have read only access to the schema or directory it's in.
-	*/
-	skipWriting?: boolean
+	 * Write the schema to disk on pull.
+	 * Useful for IDE integration.
+	 * Set to false when you have read only access to the schema or directory it's in.
+	 */
+	writePolledSchema?: boolean
 }
 
 export type ScalarSpec = {

--- a/packages/houdini/src/runtime/lib/config.ts
+++ b/packages/houdini/src/runtime/lib/config.ts
@@ -318,7 +318,7 @@ export type WatchSchemaConfig = {
 	 * Useful for IDE integration.
 	 * Set to false when you have read only access to the schema or directory it's in.
 	 */
-	writePulledSchema?: boolean
+	writePolledSchema?: boolean
 }
 
 export type ScalarSpec = {

--- a/packages/houdini/src/runtime/lib/config.ts
+++ b/packages/houdini/src/runtime/lib/config.ts
@@ -317,6 +317,7 @@ export type WatchSchemaConfig = {
 	 * Write the schema to disk on pull.
 	 * Useful for IDE integration.
 	 * Set to false when you have read only access to the schema or directory it's in.
+	 * Defaults to true
 	 */
 	writePolledSchema?: boolean
 }

--- a/packages/houdini/src/runtime/lib/config.ts
+++ b/packages/houdini/src/runtime/lib/config.ts
@@ -312,13 +312,13 @@ export type WatchSchemaConfig = {
 	headers?:
 		| Record<string, string | ((env: Record<string, string | undefined>) => string)>
 		| ((env: Record<string, string | undefined>) => Record<string, string>)
-	
+
 	/**
 	 * Write the schema to disk on pull.
 	 * Useful for IDE integration.
 	 * Set to false when you have read only access to the schema or directory it's in.
 	 */
-	writePolledSchema?: boolean
+	writePulledSchema?: boolean
 }
 
 export type ScalarSpec = {

--- a/packages/houdini/src/vite/schema.ts
+++ b/packages/houdini/src/vite/schema.ts
@@ -42,7 +42,8 @@ export function watch_remote_schema(opts: PluginConfig = {}): Plugin {
 						apiURL!,
 						config.schemaPollTimeout,
 						config.schemaPath ?? path.resolve(process.cwd(), 'schema.json'),
-						await config.pullHeaders()
+						await config.pullHeaders(),
+						config.schemaPollWriteToDisk
 					)
 
 					nbPullError = schemaState ? 0 : nbPullError + 1

--- a/site/src/routes/api/config/+page.svx
+++ b/site/src/routes/api/config/+page.svx
@@ -151,7 +151,7 @@ You can pass the following parameters to `watchSchema`:
 - `headers` (optional): An object specifying the headers to use when pulling your schema. Keys of the object are header names and its values can be either a strings or a function that takes the current `process.env` and returns the the value to use. If you want to access an environment variable, prefix your string with `env:`, ie `env:API_KEY`. For more information see the [section below](#environment-variables).
 - `interval` (optional, default: `2000`): Configures the schema polling behavior for the kit plugin. If its value is greater than `0`, the plugin will poll the set number of milliseconds. If set to `0`, the plugin will only pull the schema when you first run `dev`. If you set to `null`, the plugin will never look for schema changes. You can see use the [pull-schema command](/api/cli#pull-schema) to get updates.
 - `timeout` (optional, default: `30000`): Sets a custom timeout in milliseconds which is used to cancel fetching the schema. If the timeout is reached before the remote API has responded, the request is cancelled and an error is displayed. The default is 30 seconds.
-- `writePolledSchema` (optional, default: `true`): Wether to save the updated schema to `schemaPath` whenever it is updated (on watchSchema pull).
+- `writePolledSchema` (optional, default: `true`): Save the updated schema to `schemaPath` locally whenever it is updated (on watchSchema pull).
 
 ### Environment Variables
 

--- a/site/src/routes/api/config/+page.svx
+++ b/site/src/routes/api/config/+page.svx
@@ -151,6 +151,7 @@ You can pass the following parameters to `watchSchema`:
 - `headers` (optional): An object specifying the headers to use when pulling your schema. Keys of the object are header names and its values can be either a strings or a function that takes the current `process.env` and returns the the value to use. If you want to access an environment variable, prefix your string with `env:`, ie `env:API_KEY`. For more information see the [section below](#environment-variables).
 - `interval` (optional, default: `2000`): Configures the schema polling behavior for the kit plugin. If its value is greater than `0`, the plugin will poll the set number of milliseconds. If set to `0`, the plugin will only pull the schema when you first run `dev`. If you set to `null`, the plugin will never look for schema changes. You can see use the [pull-schema command](/api/cli#pull-schema) to get updates.
 - `timeout` (optional, default: `30000`): Sets a custom timeout in milliseconds which is used to cancel fetching the schema. If the timeout is reached before the remote API has responded, the request is cancelled and an error is displayed. The default is 30 seconds.
+- `writePolledSchema` (optional, default: `true`): Wether to save the updated schema to `schemaPath` whenever it is updated (on watchSchema pull).
 
 ### Environment Variables
 


### PR DESCRIPTION
Fixes #1483

Implement schema poll without writing to disk.
Gracefully error out of schema write, since that's not technically required for houdini codegen.

By extension, allows glob local schemaPath & api poll (wathSchema) at the same time.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Ensure your code is formatted to conform to standard style with `pnpm run format:write` (or `format:check` if you want to preview changes) and linted `pnpm run lint`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`
