### PR TITLE
Fix incorrect typings for automatic load event parameter

### DIFF
--- a/.changeset/mighty-games-happen.md
+++ b/.changeset/mighty-games-happen.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Fix incorrect typings for automatic load event parameter

--- a/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/index.ts
@@ -193,28 +193,9 @@ export default async function svelteKitGenerator(
 					.concat(pageTypeImports)
 					.concat(componentQueryTypeImports)
 
-				// if we need Page/LayoutParams, generate this type.
-				// verify if necessary. might not be.
-				const layoutParams = `${
-					layoutQueries.length > 0 && !utilityTypes.includes('LayoutParams')
-						? "\ntype LayoutParams = LayoutLoadEvent['params'];"
-						: ''
-				}`
-
-				//page params are necessary though.
-				const pageParams = `${
-					pageQueries.length > 0 && !utilityTypes.includes('PageParams')
-						? "\ntype PageParams = PageLoadEvent['params'];"
-						: ''
-				}`
-
-				// mutate utilityTypes with our layoutParams, pageParams.
-				utilityTypes = utilityTypes
-					.concat(layoutParams)
-					.concat(pageParams)
-					//replace all instances of $types.js with $houdini to ensure type inheritence.
-					//any type imports will always be in the utilityTypes block
-					.replaceAll(/\$types\.js/gm, '$houdini')
+				//replace all instances of $types.js with $houdini to ensure type inheritence.
+				//any type imports will always be in the utilityTypes block
+				utilityTypes = utilityTypes.replaceAll(/\$types\.js/gm, '$houdini')
 
 				// main bulk of the work done here.
 				typeExports = typeExports
@@ -364,7 +345,7 @@ function append_VariablesFunction(
 			// define the variable function
 			return `\nexport type ${config.variableFunctionName(
 				name
-			)} = VariableFunction<${type}Params, ${input_type}>;`
+			)} = VariableFunction<${type}LoadEvent, ${input_type}>;`
 		})
 		.join('\n')
 }

--- a/packages/houdini-svelte/src/plugin/codegen/routes/kit.test.ts
+++ b/packages/houdini-svelte/src/plugin/codegen/routes/kit.test.ts
@@ -203,7 +203,6 @@ test('generates types for inline page queries', async function () {
 		    [Key in Keys]?: Target[Key] | undefined | null;
 		};
 
-		type PageParams = PageLoadEvent["params"];
 		export type PageServerData = null;
 		export type PageLoad<OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>> = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 		export type PageLoadEvent = Parameters<PageLoad>[0];
@@ -370,7 +369,6 @@ query MyPageQuery {
 		    [Key in Keys]?: Target[Key] | undefined | null;
 		};
 
-		type PageParams = PageLoadEvent["params"];
 		export type PageServerData = null;
 		export type PageLoad<OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>> = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 		export type PageLoadEvent = Parameters<PageLoad>[0];
@@ -604,7 +602,7 @@ test('generates types for layout onError', async function () {
 		    error: Kit.HttpError;
 		};
 
-		export type MyPageLoad1QueryVariables = VariableFunction<LayoutParams, MyPageLoad1Query$input>;
+		export type MyPageLoad1QueryVariables = VariableFunction<LayoutLoadEvent, MyPageLoad1Query$input>;
 	`)
 })
 
@@ -700,7 +698,6 @@ test('generates types for page onError', async function () {
 		    [Key in Keys]?: Target[Key] | undefined | null;
 		};
 
-		type PageParams = PageLoadEvent["params"];
 		export type PageServerData = null;
 		export type PageLoad<OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>> = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 		export type PageLoadEvent = Parameters<PageLoad>[0];
@@ -722,7 +719,7 @@ test('generates types for page onError', async function () {
 		    error: Kit.HttpError;
 		};
 
-		export type MyPageLoad1QueryVariables = VariableFunction<PageParams, MyPageLoad1Query$input>;
+		export type MyPageLoad1QueryVariables = VariableFunction<PageLoadEvent, MyPageLoad1Query$input>;
 	`)
 })
 
@@ -834,7 +831,7 @@ test('generates types for layout beforeLoad', async function () {
 
 		export type BeforeLoadEvent = LayoutLoadEvent;
 		type BeforeLoadReturn = Awaited<ReturnType<typeof import("./+layout")._houdini_beforeLoad>>;
-		export type MyPageLoad1QueryVariables = VariableFunction<LayoutParams, MyPageLoad1Query$input>;
+		export type MyPageLoad1QueryVariables = VariableFunction<LayoutLoadEvent, MyPageLoad1Query$input>;
 	`)
 })
 
@@ -930,7 +927,6 @@ test('generates types for page beforeLoad', async function () {
 		    [Key in Keys]?: Target[Key] | undefined | null;
 		};
 
-		type PageParams = PageLoadEvent["params"];
 		export type PageServerData = null;
 		export type PageLoad<OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>> = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 		export type PageLoadEvent = Parameters<PageLoad>[0];
@@ -946,7 +942,7 @@ test('generates types for page beforeLoad', async function () {
 
 		export type BeforeLoadEvent = PageLoadEvent;
 		type BeforeLoadReturn = Awaited<ReturnType<typeof import("./+page")._houdini_beforeLoad>>;
-		export type MyPageLoad1QueryVariables = VariableFunction<PageParams, MyPageLoad1Query$input>;
+		export type MyPageLoad1QueryVariables = VariableFunction<PageLoadEvent, MyPageLoad1Query$input>;
 	`)
 })
 
@@ -1069,7 +1065,7 @@ test('generates types for layout afterLoad', async function () {
 		    input: LoadInput;
 		};
 
-		export type MyPageLoad1QueryVariables = VariableFunction<LayoutParams, MyPageLoad1Query$input>;
+		export type MyPageLoad1QueryVariables = VariableFunction<LayoutLoadEvent, MyPageLoad1Query$input>;
 	`)
 })
 
@@ -1165,7 +1161,6 @@ test('generates types for page afterLoad', async function () {
 		    [Key in Keys]?: Target[Key] | undefined | null;
 		};
 
-		type PageParams = PageLoadEvent["params"];
 		export type PageServerData = null;
 		export type PageLoad<OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>> = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 		export type PageLoadEvent = Parameters<PageLoad>[0];
@@ -1192,7 +1187,7 @@ test('generates types for page afterLoad', async function () {
 		    input: LoadInput;
 		};
 
-		export type MyPageLoad1QueryVariables = VariableFunction<PageParams, MyPageLoad1Query$input>;
+		export type MyPageLoad1QueryVariables = VariableFunction<PageLoadEvent, MyPageLoad1Query$input>;
 	`)
 })
 
@@ -1280,6 +1275,6 @@ test('Marks required query arguments as optional if the url param provides it', 
 		    MyPageLoad1Query: MyPageLoad1Query$input;
 		};
 
-		export type MyPageLoad1QueryVariables = VariableFunction<LayoutParams, MakeOptional<MyPageLoad1Query$input, "userID">>;
+		export type MyPageLoad1QueryVariables = VariableFunction<LayoutLoadEvent, MakeOptional<MyPageLoad1Query$input, "userID">>;
 	`)
 })

--- a/packages/houdini-svelte/src/runtime/types.ts
+++ b/packages/houdini-svelte/src/runtime/types.ts
@@ -14,8 +14,8 @@ import type { Readable } from 'svelte/store'
 
 export type QueryInputs<_Data> = FetchQueryResult<_Data> & { variables: { [key: string]: any } }
 
-export type VariableFunction<_Params extends Record<string, string>, _Input> = (
-	event: LoadEvent<_Params>
+export type VariableFunction<_Event extends LoadEvent, _Input> = (
+	event: _Event
 ) => _Input | Promise<_Input>
 
 export type AfterLoadFunction<


### PR DESCRIPTION
When trying to get a route's parent data in an automatic load function, the typings for the `event` parameter are handled incorrectly, losing type information vs the manual sveltekit load function:

Before the fix:
![image](https://github.com/user-attachments/assets/3204d692-ac06-4219-a941-005620c3e18a)

And after the fix:
![image](https://github.com/user-attachments/assets/5d3061fb-94c9-4ef0-a62f-68a7cae0b179)


### To help everyone out, please make sure your PR does the following:

- [ ] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Ensure your code is formatted to conform to standard style with `pnpm run format:write` (or `format:check` if you want to preview changes) and linted `pnpm run lint`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`
