### PR TITLE
Documentation: Fixed HTTP header in config examples

### DIFF
--- a/packages/houdini/src/cmd/init.ts
+++ b/packages/houdini/src/cmd/init.ts
@@ -389,7 +389,7 @@ export default new HoudiniClient({
     // fetchParams({ session }) {
     //     return {
     //         headers: {
-    //             Authentication: \`Bearer \${session.token}\`,
+    //             Authorization: \`Bearer \${session.token}\`,
     //         }
     //     }
     // }

--- a/site/src/routes/api/config/+page.svx
+++ b/site/src/routes/api/config/+page.svx
@@ -137,7 +137,7 @@ export default {
 	watchSchema: {
 		url: 'http://localhost:4000/graphql',
 		headers: {
-			Authentication(env) {
+			Authorization(env) {
 				return `Bearer ${env.AUTH_TOKEN}`
 			}
 		}
@@ -163,7 +163,7 @@ export default {
 	watchSchema: {
 		url: '...',
 		headers: {
-			Authentication: 'env:AUTH_TOKEN'
+			Authorization: 'env:AUTH_TOKEN'
 		}
 	}
 }
@@ -178,7 +178,7 @@ export default {
 	watchSchema: {
 		url: '...',
 		headers: {
-			Authentication(env) {
+			Authorization(env) {
 				return `Bearer ${env.AUTH_TOKEN}`
 			}
 		}

--- a/site/src/routes/guides/release-notes/+page.svx
+++ b/site/src/routes/guides/release-notes/+page.svx
@@ -103,7 +103,7 @@ config value:
 -        method: 'POST',
 -        headers: {
 -            'Content-Type': 'application/json',
--            'Authentication': `Bearer ${session.user?.token}`
+-            'Authorization': `Bearer ${session.user?.token}`
 -        },
 -        body: JSON.stringify({
 -            query: text,
@@ -121,7 +121,7 @@ config value:
 +    fetchParams({ session }) {
 +        return {
 +            headers: {
-+                'Authentication': `Bearer ${session.user?.token}`
++                'Authorization': `Bearer ${session.user?.token}`
 +            }
 +        }
 +    }
@@ -155,7 +155,7 @@ If your application uses subscriptions, you'll need to import the
 +             url: 'ws://api.url',
 +             connectionParams: {
 +                 headers: {
-+                     Authentication: `Bearer ${session.user?.token}`
++                     Authorization: `Bearer ${session.user?.token}`
 +                 }
 +             }
 +  	      }))


### PR DESCRIPTION
Fixes #1488 
Updated examples in documentation to use `Authorization` header (standard) instead of `Authentication` (non-standard).

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [ ] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Ensure your code is formatted to conform to standard style with `pnpm run format:write` (or `format:check` if you want to preview changes) and linted `pnpm run lint`
- [ ] Includes a changeset if your fix affects the user with `pnpm changeset`
