### PR TITLE
Add schemaPath to gitignore file if using a remote endpoint

### DIFF
--- a/.changeset/slow-countries-hug.md
+++ b/.changeset/slow-countries-hug.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Add schema path to gitignore file when setting up a project with a remote schema


### PR DESCRIPTION
This PR tweaks the init script so that it adds the auto-generated schema.graphql file to the gitignore, when using a remote API.