### PR TITLE
Allow IDs to be passed as ints

### DIFF
--- a/packages/houdini-react/src/plugin/codegen/typeRoot.test.ts
+++ b/packages/houdini-react/src/plugin/codegen/typeRoot.test.ts
@@ -72,7 +72,7 @@ test('generates route prop type', async function () {
 
 			export type PageProps = {
 					Params: {
-					id: string,
+					id: string | number,
 				},
 					
 			    MyQuery: MyQuery$result,
@@ -82,7 +82,7 @@ test('generates route prop type', async function () {
 
 			export type LayoutProps = {
 				Params: {
-					id: string,
+					id: string | number,
 				},
 				children: React.ReactNode,
 			}

--- a/packages/houdini/src/codegen/generators/typescript/imperativeTypeDef.test.ts
+++ b/packages/houdini/src/codegen/generators/typescript/imperativeTypeDef.test.ts
@@ -163,7 +163,7 @@ test('generates type definitions for the imperative API', async function () {
 		import { UserInfo$data } from "../artifacts/UserInfo";
 
 		type NestedUserFilter = {
-		    id: string;
+		    id: string | number;
 		    firstName: string;
 		    admin?: boolean | null | undefined;
 		    age?: number | null | undefined;
@@ -186,7 +186,7 @@ test('generates type definitions for the imperative API', async function () {
 		                user: {
 		                    type: Record<CacheTypeDef, "User"> | null;
 		                    args: {
-		                        id?: string | null | undefined;
+		                        id?: string | number | null | undefined;
 		                        filter?: UserFilter | null | undefined;
 		                        filterList?: (UserFilter)[] | null | undefined;
 		                        enumArg?: ValueOf<typeof MyEnum> | null | undefined;
@@ -197,7 +197,7 @@ test('generates type definitions for the imperative API', async function () {
 		                    args: {
 		                        filter?: UserFilter | null | undefined;
 		                        list: (UserFilter)[];
-		                        id: string;
+		                        id: string | number;
 		                        firstName: string;
 		                        admin?: boolean | null | undefined;
 		                        age?: number | null | undefined;
@@ -223,7 +223,7 @@ test('generates type definitions for the imperative API', async function () {
 		                node: {
 		                    type: Record<CacheTypeDef, "Cat"> | Record<CacheTypeDef, "Ghost"> | Record<CacheTypeDef, "User"> | null;
 		                    args: {
-		                        id: string;
+		                        id: string | number;
 		                    };
 		                };
 		            };
@@ -231,11 +231,11 @@ test('generates type definitions for the imperative API', async function () {
 		        };
 		        Cat: {
 		            idFields: {
-		                id: string;
+		                id: string | number;
 		            };
 		            fields: {
 		                id: {
-		                    type: string;
+		                    type: string | number;
 		                    args: never;
 		                };
 		                kitty: {
@@ -260,7 +260,7 @@ test('generates type definitions for the imperative API', async function () {
 		            };
 		            fields: {
 		                id: {
-		                    type: string;
+		                    type: string | number;
 		                    args: never;
 		                };
 		                aka: {
@@ -276,11 +276,11 @@ test('generates type definitions for the imperative API', async function () {
 		        };
 		        User: {
 		            idFields: {
-		                id: string;
+		                id: string | number;
 		            };
 		            fields: {
 		                id: {
-		                    type: string;
+		                    type: string | number;
 		                    args: never;
 		                };
 		                firstName: {
@@ -327,7 +327,7 @@ test('generates type definitions for the imperative API', async function () {
 		            filters: {
 		                filter?: UserFilter | null | undefined;
 		                list?: (UserFilter)[];
-		                id?: string;
+		                id?: string | number;
 		                firstName?: string;
 		                admin?: boolean | null | undefined;
 		                age?: number | null | undefined;

--- a/packages/houdini/src/codegen/generators/typescript/loadingState.test.ts
+++ b/packages/houdini/src/codegen/generators/typescript/loadingState.test.ts
@@ -59,12 +59,12 @@ test('@loading on fragment - happy path', async function () {
 		};
 
 		export type UserBase$data = {
-		    readonly id: string;
+		    readonly id: string | number;
 		    readonly firstName: string;
 		    readonly parent: {
-		        readonly id: string;
+		        readonly id: string | number;
 		        readonly parent: {
-		            readonly id: string;
+		            readonly id: string | number;
 		        } | null;
 		    } | null;
 		} | {
@@ -215,9 +215,9 @@ test('@loading on query - happy path', async function () {
 		    readonly user: {
 		        readonly firstName: string;
 		        readonly parent: {
-		            readonly id: string;
+		            readonly id: string | number;
 		            readonly parent: {
-		                readonly id: string;
+		                readonly id: string | number;
 		            } | null;
 		        } | null;
 		    } | null;
@@ -380,7 +380,7 @@ test('@loading on list', async function () {
 
 		export type UserQuery$result = {
 		    readonly users: ({
-		        readonly id: string;
+		        readonly id: string | number;
 		    })[];
 		} | {
 		    readonly users: LoadingType[];

--- a/packages/houdini/src/codegen/generators/typescript/typescript.test.ts
+++ b/packages/houdini/src/codegen/generators/typescript/typescript.test.ts
@@ -198,7 +198,7 @@ describe('typescript', function () {
 			})
 		).toMatchInlineSnapshot(`
 			export type TestFragment$input = {
-			    name?: string | null | undefined;
+			    name?: string | number | null | undefined;
 			};
 
 			export type TestFragment = {
@@ -290,7 +290,7 @@ describe('typescript', function () {
 			})
 		).toMatchInlineSnapshot(`
 			export type TestFragment$input = {
-			    name: string;
+			    name: string | number;
 			};
 
 			export type TestFragment = {
@@ -488,7 +488,7 @@ describe('typescript', function () {
 			    readonly firstName: string;
 			    readonly admin: boolean | null;
 			    readonly age: number | null;
-			    readonly id: string;
+			    readonly id: string | number;
 			    readonly weight: number | null;
 			};
 
@@ -827,7 +827,7 @@ describe('typescript', function () {
 			};
 
 			export type MyQuery$input = {
-			    id: string;
+			    id: string | number;
 			    enum?: ValueOf<typeof MyEnum> | null | undefined;
 			};
 
@@ -915,10 +915,10 @@ describe('typescript', function () {
 
 			export type MyTestQuery$result = {
 			    readonly entity: {} & (({
-			        readonly id: string;
+			        readonly id: string | number;
 			        readonly __typename: "Cat";
 			    }) | ({
-			        readonly id: string;
+			        readonly id: string | number;
 			        readonly __typename: "User";
 			    }));
 			};
@@ -1038,7 +1038,7 @@ describe('typescript', function () {
 			};
 
 			type NestedUserFilter = {
-			    id: string;
+			    id: string | number;
 			    firstName: string;
 			    admin?: boolean | null | undefined;
 			    age?: number | null | undefined;
@@ -1056,7 +1056,7 @@ describe('typescript', function () {
 			export type MyMutation$input = {
 			    filter?: UserFilter | null | undefined;
 			    filterList: (UserFilter)[];
-			    id: string;
+			    id: string | number;
 			    firstName: string;
 			    admin?: boolean | null | undefined;
 			    age?: number | null | undefined;
@@ -1295,7 +1295,7 @@ describe('typescript', function () {
 			};
 
 			type NestedUserFilter = {
-			    id: string;
+			    id: string | number;
 			    firstName: string;
 			    admin?: boolean | null | undefined;
 			    age?: number | null | undefined;
@@ -1635,10 +1635,10 @@ describe('typescript', function () {
 
 			export type MyQuery$result = {
 			    readonly nodes: ({} & (({
-			        readonly id: string;
+			        readonly id: string | number;
 			        readonly __typename: "User";
 			    }) | ({
-			        readonly id: string;
+			        readonly id: string | number;
 			        readonly __typename: "Cat";
 			    }) | ({
 			        readonly __typename: "non-exhaustive; don't match this";
@@ -1762,10 +1762,10 @@ describe('typescript', function () {
 
 			export type MyQuery$result = {
 			    readonly entities: ({} & (({
-			        readonly id: string;
+			        readonly id: string | number;
 			        readonly __typename: "User";
 			    }) | ({
-			        readonly id: string;
+			        readonly id: string | number;
 			        readonly __typename: "Cat";
 			    })) | null)[] | null;
 			};
@@ -1883,7 +1883,7 @@ describe('typescript', function () {
 
 			export type MyQuery$result = {
 			    readonly nodes: ({
-			        readonly id: string;
+			        readonly id: string | number;
 			    } & (({
 			        readonly firstName: string;
 			        readonly __typename: "User";
@@ -2597,7 +2597,7 @@ describe('typescript', function () {
 
 			export type MyMutation$result = {
 			    readonly doThing: {
-			        readonly id: string;
+			        readonly id: string | number;
 			        readonly " $fragments": {
 			            My_Users_remove: {};
 			            My_Users_insert: {};
@@ -2606,7 +2606,7 @@ describe('typescript', function () {
 			};
 
 			type NestedUserFilter = {
-			    id: string;
+			    id: string | number;
 			    firstName: string;
 			    admin?: boolean | null | undefined;
 			    age?: number | null | undefined;
@@ -2624,7 +2624,7 @@ describe('typescript', function () {
 			export type MyMutation$input = {
 			    filter?: UserFilter | null | undefined;
 			    filterList: (UserFilter)[];
-			    id: string;
+			    id: string | number;
 			    firstName: string;
 			    admin?: boolean | null | undefined;
 			    age?: number | null | undefined;
@@ -2633,7 +2633,7 @@ describe('typescript', function () {
 
 			export type MyMutation$optimistic = {
 			    readonly doThing?: {
-			        readonly id?: string;
+			        readonly id?: string | number;
 			    } | null;
 			};
 
@@ -2911,10 +2911,10 @@ describe('typescript', function () {
 
 			export type MyQuery$result = {
 			    readonly user: {
-			        readonly id: string;
+			        readonly id: string | number;
 			        readonly firstName: string;
 			        readonly friends: ({
-			            readonly id: string;
+			            readonly id: string | number;
 			            readonly firstName: string;
 			            readonly " $fragments": {
 			                UserBase: {};
@@ -3084,7 +3084,7 @@ describe('typescript', function () {
 
 			export type MyQuery$result = {
 			    readonly user: {
-			        readonly id: string;
+			        readonly id: string | number;
 			        readonly firstName: string;
 			        readonly " $fragments": {
 			            UserBase: {};
@@ -3337,7 +3337,7 @@ describe('typescript', function () {
 			export type MyQuery$result = {
 			    readonly user: {
 			        readonly friends: ({
-			            readonly id: string;
+			            readonly id: string | number;
 			            readonly firstName: string;
 			            readonly " $fragments": {
 			                UserBase: {};
@@ -3469,7 +3469,7 @@ describe('typescript', function () {
 
 			export type UserMore$data = {
 			    readonly friends: ({
-			        readonly id: string;
+			        readonly id: string | number;
 			        readonly firstName: string;
 			        readonly " $fragments": {
 			            UserBase: {};
@@ -3574,7 +3574,7 @@ describe('typescript', function () {
 
 			export type MyQuery$result = {
 			    readonly user: {
-			        readonly id: string;
+			        readonly id: string | number;
 			        readonly firstName: string | undefined;
 			        readonly admin: boolean | null | undefined;
 			    } | null;
@@ -3678,7 +3678,7 @@ describe('typescript', function () {
 
 			export type MyQuery$result = {
 			    readonly user: {
-			        readonly id: string;
+			        readonly id: string | number;
 			        readonly firstName: string;
 			        readonly nickname: string;
 			    } | null;
@@ -3772,7 +3772,7 @@ describe('typescript', function () {
 			export type MyQuery$result = {
 			    readonly user: {
 			        readonly parent: {
-			            readonly id: string;
+			            readonly id: string | number;
 			            readonly firstName: string;
 			            readonly nickname: string | null;
 			        };
@@ -3885,7 +3885,7 @@ describe('typescript', function () {
 			export type MyQuery$result = {
 			    readonly user: {
 			        readonly parent: {
-			            readonly id: string;
+			            readonly id: string | number;
 			            readonly firstName: string;
 			            readonly nickname: string;
 			        };
@@ -4003,7 +4003,7 @@ describe('typescript', function () {
 			export type MyQuery$result = {
 			    readonly user: {
 			        readonly parentRequired: {
-			            readonly id: string;
+			            readonly id: string | number;
 			            readonly firstName: string;
 			            readonly nickname: string;
 			        } | null;
@@ -4128,16 +4128,16 @@ describe('typescript', function () {
 			};
 
 			export type MyFragment$data = {
-			    readonly id: string;
+			    readonly id: string | number;
 			    readonly firstName: string;
 			    readonly nickname: string;
 			    readonly parent: {
-			        readonly id: string;
+			        readonly id: string | number;
 			        readonly firstName: string;
 			        readonly nickname: string;
 			    };
 			    readonly parentRequired: {
-			        readonly id: string;
+			        readonly id: string | number;
 			        readonly firstName: string;
 			        readonly nickname: string;
 			    } | null;
@@ -4468,10 +4468,10 @@ describe('typescript', function () {
 			};
 
 			export type MyFragmentA$data = {} & (({
-			    readonly id: string;
+			    readonly id: string | number;
 			    readonly __typename: "User";
 			}) | ({
-			    readonly id: string;
+			    readonly id: string | number;
 			    readonly __typename: "Cat";
 			}));
 
@@ -4696,7 +4696,7 @@ describe('typescript', function () {
 			};
 
 			export type MyFragmentA$data = {} & (({
-			    readonly id: string;
+			    readonly id: string | number;
 			    readonly __typename: "User";
 			}) | ({
 			    readonly __typename: "non-exhaustive; don't match this";
@@ -4799,7 +4799,7 @@ test('overlapping fragments', async function () {
 		};
 
 		export type UserBase$data = {
-		    readonly id: string;
+		    readonly id: string | number;
 		    readonly firstName: string;
 		    readonly " $fragments": {
 		        UserMore: {};

--- a/packages/houdini/src/lib/typescript.ts
+++ b/packages/houdini/src/lib/typescript.ts
@@ -196,7 +196,7 @@ export function scalarPropertyValue(
 			return AST.tsBooleanKeyword()
 		}
 		case 'ID': {
-			return AST.tsStringKeyword()
+			return  AST.tsUnionType([AST.tsStringKeyword(), AST.tsNumberKeyword()])
 		}
 		default: {
 			// if we're looking at a non-null type


### PR DESCRIPTION
This PR updates the type generation logic to allow for users to pass numbers as strings 

### To help everyone out, please make sure your PR does the following:

- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Ensure your code is formatted to conform to standard style with `pnpm run format:write` (or `format:check` if you want to preview changes) and linted `pnpm run lint`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`
