### PR TITLE
Add notices to redirect users to houdini@next

### DIFF
--- a/.changeset/breezy-geese-occur.md
+++ b/.changeset/breezy-geese-occur.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Add notice redirecting users to houdini@next

--- a/packages/houdini/src/cmd/init.ts
+++ b/packages/houdini/src/cmd/init.ts
@@ -31,6 +31,31 @@ export async function init(
 ): Promise<void> {
 	p.intro('🎩 Welcome to Houdini!')
 
+	// Show a notice to direct users to use houdini@next
+	{
+		const { confirm } = await p.group(
+			{
+				confirm: () => {
+					p.log.warning(
+						`You are using Houdini version "HOUDINI_PACKAGE_VERSION", which doesn't support the latest svelte-kit and vite versions.
+We recommend re-running this with houdini@next. See what's new here: https://houdini-docs-next.netlify.app/guides/migrateTo20`
+					)
+					return p.confirm({
+						message: 'Continue anyway?',
+						initialValue: false,
+					})
+				},
+			},
+			{
+				onCancel: () => pCancel(),
+			}
+		)
+
+		if (confirm !== true) {
+			pCancel()
+		}
+	}
+
 	// before we start anything, let's make sure they have initialized their project
 	try {
 		await fs.stat(path.resolve('./src'))

--- a/packages/houdini/src/vite/houdini.ts
+++ b/packages/houdini/src/vite/houdini.ts
@@ -1,4 +1,5 @@
 import * as graphql from 'graphql'
+import { yellow } from 'kleur/colors'
 import type { SourceMapInput } from 'rollup'
 import type { Plugin as VitePlugin, UserConfig, ResolvedConfig, ConfigEnv } from 'vite'
 
@@ -215,6 +216,21 @@ export default function Plugin(opts: PluginConfig = {}): VitePlugin {
 
 		async configureServer(server) {
 			devServer = true
+
+			// houdini@next notice.
+			if (config.plugins.some((plugin) => plugin.name === 'houdini-svelte')) {
+				console.log(
+					`${yellow(
+						'💡 Tip: we recommend upgrading to houdini@next for support with the latest vite and svelte-kit versions. Read more here: https://houdini-docs-next.netlify.app/guides/migrateTo20'
+					)}`
+				)
+			} else {
+				console.log(
+					`${yellow(
+						'💡 Tip: we recommend upgrading to houdini@next for support with the latest vite version. Read more here: https://houdini-docs-next.netlify.app/guides/migrateTo20'
+					)}`
+				)
+			}
 
 			await writeTsConfig(config)
 

--- a/site/src/components/VersionNotice.svelte
+++ b/site/src/components/VersionNotice.svelte
@@ -1,0 +1,35 @@
+<script>
+</script>
+
+<div class="version-notice-container">
+	<p>
+		Find the <code>houdini@next</code> docs
+		<a href="https://houdini-docs-next.netlify.app/guides/migrateTo20" target="_blank">here</a>
+	</p>
+</div>
+
+<style>
+	.version-notice-container {
+		top: 0;
+		width: 100%;
+		position: sticky;
+		z-index: 1000;
+		background: var(--experimental-background);
+		color: var(--experimental-text);
+	}
+
+	p {
+		font-size: 18px;
+		font-family: 'Hind', sans-serif;
+		font-weight: 500;
+		text-align: center;
+		padding: 0.5em;
+	}
+
+	a {
+		color: var(--experimental-text);
+		font-weight: bold;
+		text-decoration: underline;
+		white-space: nowrap;
+	}
+</style>

--- a/site/src/layouts/_page.svelte
+++ b/site/src/layouts/_page.svelte
@@ -6,6 +6,7 @@
 	import { browser } from '$app/environment'
 	import Toolbar from '~/components/Toolbar.svelte'
 	import Logo from '~/components/Logo.svelte'
+	import VersionNotice from '~/components/VersionNotice.svelte'
 
 	export let title = ''
 	export let link = ''
@@ -118,6 +119,8 @@
 <SEO {title} {description} />
 
 <SearchDialog />
+
+<VersionNotice />
 
 <main>
 	<aside class:open={menuOpen} class:blur={$searching}>
@@ -245,7 +248,8 @@
 		display: flex;
 		flex-direction: column;
 		flex-shrink: 0;
-		top: 0;
+		/* top: 0; */
+		top: 18px; /* add some padding to stay clear of the version notice */
 		position: fixed;
 		background-color: var(--hue);
 		z-index: 10;


### PR DESCRIPTION
This adds a couple of notices that redirect users to houdini@next, since houdini 1.0 currently doesn't have support for the latest svelte-kit versions.

note: we should undo this PR once we finalize 2.0

what it looks like:
<img width="1351" height="282" alt="image" src="https://github.com/user-attachments/assets/1a00dcef-ca20-4e65-8653-15892e12faae" />
<img width="1410" height="402" alt="image" src="https://github.com/user-attachments/assets/d21998a8-c768-4c48-9fdb-995d93f45f98" />
<img width="1305" height="427" alt="image" src="https://github.com/user-attachments/assets/90d693e6-88f9-4b33-aba9-6256d0b20bae" />
