### PR TITLE
fix worker path

### DIFF
--- a/.changeset/nine-sheep-visit.md
+++ b/.changeset/nine-sheep-visit.md
@@ -1,0 +1,6 @@
+---
+'houdini-adapter-cloudflare': patch
+'houdini-adapter-auto': patch
+---
+
+Change path for generated worker file (now dist/worker.js)

--- a/packages/adapter-auto/src/index.ts
+++ b/packages/adapter-auto/src/index.ts
@@ -6,7 +6,7 @@ import { pathToFileURL } from 'node:url'
 const adapters = [
 	{
 		name: 'CloudFlare Pages',
-		test: () => Boolean(process.env.CF_PAGES),
+		test: () => Boolean(process.env.CF_PAGES) || Boolean(process.env.CLOUDFLARE_PAGES),
 		module: 'houdini-adapter-cloudflare',
 	},
 	{

--- a/packages/adapter-cloudflare/src/index.ts
+++ b/packages/adapter-cloudflare/src/index.ts
@@ -12,7 +12,7 @@ const adapter: Adapter = async ({ adapterPath, outDir }) => {
 	// make sure that the adapter module imports from the correct path
 	workerContents = workerContents.replaceAll('houdini/adapter', adapterPath)
 
-	await fs.writeFile(path.join(outDir, '_worker.js'), workerContents!)
+	await fs.writeFile(path.join(outDir, 'worker.js'), workerContents!)
 }
 
 export default adapter

--- a/packages/houdini/src/runtime/router/server.ts
+++ b/packages/houdini/src/runtime/router/server.ts
@@ -80,7 +80,7 @@ export function _serverHandler<ComponentType = unknown>({
 		})
 	}
 
-	return async (request: Request) => {
+	return async (request: Request, ...extraContext: Array<any>) => {
 		if (!manifest) {
 			return new Response(
 				"Adapter did not provide the project's manifest. Please open an issue on github.",
@@ -93,7 +93,7 @@ export function _serverHandler<ComponentType = unknown>({
 
 		// if its a request we can process with yoga, do it.
 		if (requestHandler && url === graphqlEndpoint) {
-			return requestHandler(request)
+			return requestHandler(request, ...extraContext)
 		}
 
 		// maybe its a session-related request

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,9 +229,6 @@ importers:
       houdini:
         specifier: workspace:^
         version: link:../../packages/houdini
-      houdini-adapter-cloudflare:
-        specifier: workspace:^
-        version: link:../../packages/adapter-cloudflare
       houdini-react:
         specifier: workspace:^
         version: link:../../packages/houdini-react
@@ -269,6 +266,9 @@ importers:
       hono:
         specifier: ^3.6.0
         version: 3.12.12
+      houdini-adapter-cloudflare:
+        specifier: workspace:^
+        version: link:../../packages/adapter-cloudflare
       houdini-adapter-node:
         specifier: workspace:^
         version: link:../../packages/adapter-node

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,9 @@ importers:
       houdini:
         specifier: workspace:^
         version: link:../../packages/houdini
+      houdini-adapter-cloudflare:
+        specifier: workspace:^
+        version: link:../../packages/adapter-cloudflare
       houdini-react:
         specifier: workspace:^
         version: link:../../packages/houdini-react
@@ -266,9 +269,6 @@ importers:
       hono:
         specifier: ^3.6.0
         version: 3.12.12
-      houdini-adapter-cloudflare:
-        specifier: workspace:^
-        version: link:../../packages/adapter-cloudflare
       houdini-adapter-node:
         specifier: workspace:^
         version: link:../../packages/adapter-node


### PR DESCRIPTION
The cloudflare adapter was previously designed to work with CF Pages which has been soft-deprecated in favor of workers. This PR updates the cloudflare adapter to remove page-isms