### PR TITLE
fix manual setup instructions for sveltekit config

### DIFF
--- a/site/src/routes/guides/setting-up-your-project/+page.svx
+++ b/site/src/routes/guides/setting-up-your-project/+page.svx
@@ -127,7 +127,7 @@ import path from 'path'
 export default {
     kit: {
         alias: {
-            $houdini: path.resolve('.', '$houdini')
+            $houdini: './$houdini/'
         }
     }
 }


### PR DESCRIPTION
Fixes #1553

Turns out that using path.resolve to point to the generated `.houdini/` directory, the `$houdini/*` alias is never generated, causing issues with type hints.

(The manual setup in the docs don't tweak the runtimeDir property, so it'll still be `$houdini/`, until we update the default in 2.0)