### PR TITLE
Feat implement cache upserts for lists

### DIFF
--- a/.changeset/long-countries-smoke.md
+++ b/.changeset/long-countries-smoke.md
@@ -1,0 +1,5 @@
+---
+'houdini': minor
+---
+
+Added support for `[ListName]_upsert` list operation and upsert method in the imperative cache API

--- a/packages/houdini/src/codegen/generators/definitions/schema.test.ts
+++ b/packages/houdini/src/codegen/generators/definitions/schema.test.ts
@@ -236,6 +236,10 @@ test('list operations are included', async function () {
 			fragment Friends_remove on User {
 			  id
 			}
+
+			fragment Friends_upsert on User {
+			  id
+			}
 		`)
 })
 
@@ -363,6 +367,10 @@ test('list operations are included but delete directive should not be in when we
 			  id
 			}
 
+			fragment Friends_upsert on User {
+			  id
+			}
+
 			fragment theList_insert on CustomIdType {
 			  foo
 			  bar
@@ -374,6 +382,11 @@ test('list operations are included but delete directive should not be in when we
 			}
 
 			fragment theList_remove on CustomIdType {
+			  foo
+			  bar
+			}
+
+			fragment theList_upsert on CustomIdType {
 			  foo
 			  bar
 			}

--- a/packages/houdini/src/codegen/transforms/list.ts
+++ b/packages/houdini/src/codegen/transforms/list.ts
@@ -287,6 +287,24 @@ export default async function addListFragments(
 								},
 							},
 						},
+						// add a fragment to upsert into the specific list
+						{
+							name: {
+								value: config.listUpsertFragment(name),
+								kind: graphql.Kind.NAME,
+							},
+							kind: graphql.Kind.FRAGMENT_DEFINITION,
+							// in order to insert an item into this list, it must
+							// have the same selection as the field
+							selectionSet: fragmentSelection,
+							typeCondition: {
+								kind: graphql.Kind.NAMED_TYPE,
+								name: {
+									kind: graphql.Kind.NAME,
+									value: type.name,
+								},
+							},
+						},
 					]
 				}
 			) as graphql.DefinitionNode[]

--- a/packages/houdini/src/codegen/transforms/lists.test.ts
+++ b/packages/houdini/src/codegen/transforms/lists.test.ts
@@ -675,6 +675,12 @@ test('list with Custom Ids & an extra field', async function () {
 		  foo
 		  bar
 		}
+
+		fragment theList_upsert on CustomIdType {
+		  foo
+		  dummy
+		  bar
+		}
 	`
 	)
 })

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -716,6 +716,10 @@ export class Config {
 		return `_delete`
 	}
 
+	get upsertFragmentSuffix() {
+		return `_upsert`
+	}
+
 	get loadingDirective() {
 		return `loading`
 	}
@@ -804,8 +808,16 @@ export class Config {
 		return name.endsWith(this.toggleFragmentSuffix)
 	}
 
+	isUpsertFragment(name: string) {
+		return name.endsWith(this.upsertFragmentSuffix)
+	}
+
 	listRemoveFragment(name: string): string {
 		return name + this.removeFragmentSuffix
+	}
+
+	listUpsertFragment(name: string): string {
+		return name + this.upsertFragmentSuffix
 	}
 
 	isInternalEnum(node: graphql.EnumTypeDefinitionNode): boolean {
@@ -955,7 +967,8 @@ export class Config {
 		return (
 			name.endsWith(this.insertFragmentSuffix) ||
 			name.endsWith(this.removeFragmentSuffix) ||
-			name.endsWith(this.toggleFragmentSuffix)
+			name.endsWith(this.toggleFragmentSuffix) ||
+			name.endsWith(this.upsertFragmentSuffix)
 		)
 	}
 
@@ -968,7 +981,7 @@ export class Config {
 	}
 
 	// return 'insert' for All_Users_insert
-	listOperationFromFragment(fragmentName: string): 'insert' | 'remove' | 'toggle' {
+	listOperationFromFragment(fragmentName: string): 'insert' | 'remove' | 'toggle' | 'upsert' {
 		// check the name against the fragment patterns
 		if (this.isInsertFragment(fragmentName)) {
 			return 'insert'
@@ -976,6 +989,8 @@ export class Config {
 			return 'remove'
 		} else if (this.isToggleFragment(fragmentName)) {
 			return 'toggle'
+		} else if (this.isUpsertFragment(fragmentName)) {
+			return 'upsert'
 		}
 
 		throw new Error('Could not determine list operation from fragment name: ' + fragmentName)

--- a/packages/houdini/src/runtime/cache/cache.ts
+++ b/packages/houdini/src/runtime/cache/cache.ts
@@ -963,6 +963,30 @@ class CacheInternal {
 
 						this.cache.delete(targetID, layer)
 					}
+
+					// upsert to a list
+					else if (
+						operation.action === 'upsert' &&
+						target instanceof Object &&
+						fieldSelection &&
+						operation.list
+					) {
+						this.cache
+							.list(
+								operation.list,
+								parentID,
+								operation.target === 'all',
+								processedOperations
+							)
+							.when(operation.when)
+							.upsert({
+								selection: fieldSelection,
+								data: target,
+								variables,
+								where: operation.position || 'last',
+								layer,
+							})
+					}
 				}
 
 				if (operation.list) {

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -520,6 +520,54 @@ export class List {
 		}
 	}
 
+	upsert({
+		selection,
+		data,
+		variables = {},
+		layer,
+		where,
+	}: {
+		selection: SubscriptionSelection
+		data: {}
+		variables?: {}
+		layer?: Layer
+		where: 'first' | 'last'
+	}) {
+		// Check if item exists in list
+		const targetListId = this.cache._internal_unstable.id(this.listType(data), data)
+		if (!targetListId) {
+			return
+		}
+
+		let value = this.cache._internal_unstable.storage.get(this.recordID, this.key).value as
+			| NestedList
+			| string
+
+		let entries: string[] = []
+
+		if (!this.connection) {
+			entries = flatten(value as NestedList)
+		} else {
+			entries = this.cache._internal_unstable.storage.get(value as string, 'edges')
+				.value as string[]
+		}
+
+		const itemExists = entries.includes(targetListId)
+		if (!itemExists) {
+			this.addToList(selection, data, variables, where, layer)
+			return
+		}
+
+		this.cache.write({
+			selection: selection,
+			data: data,
+			variables,
+			parent: targetListId,
+			applyUpdates: [],
+			layer: layer?.id,
+		})
+	}
+
 	// iterating over the list handler should be the same as iterating over
 	// the underlying linked list
 	*[Symbol.iterator]() {
@@ -584,6 +632,10 @@ export class ListCollection {
 
 	toggleElement(...args: Parameters<List['toggleElement']>) {
 		this.lists.forEach((list) => list.toggleElement(...args))
+	}
+
+	upsert(...args: Parameters<List['upsert']>) {
+		this.lists.forEach((list) => list.upsert(...args))
 	}
 
 	when(when?: ListWhen): ListCollection {

--- a/packages/houdini/src/runtime/cache/tests/list.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/list.test.ts
@@ -5618,3 +5618,1041 @@ test("two operations referencing the same list don't commit twice", function () 
 		],
 	})
 })
+
+test('upsert in list - adds new item when not exists', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						id: {
+							type: 'ID',
+							visible: true,
+							keyRaw: 'id',
+						},
+						friends: {
+							type: 'User',
+							visible: true,
+							keyRaw: 'friends',
+							list: {
+								name: 'All_Users',
+								connection: false,
+								type: 'User',
+							},
+							selection: {
+								fields: {
+									id: {
+										type: 'ID',
+										visible: true,
+										keyRaw: 'id',
+									},
+									firstName: {
+										type: 'String',
+										visible: true,
+										keyRaw: 'firstName',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// start off associated with one object
+	cache.write({
+		selection,
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						id: '2',
+						firstName: 'jane',
+					},
+				],
+			},
+		},
+	})
+
+	// a function to spy on that will play the role of set
+	const set = vi.fn()
+
+	// subscribe to the fields
+	cache.subscribe({
+		rootType: 'Query',
+		set,
+		selection,
+	})
+
+	// upsert an element that doesn't exist yet (should add it)
+	cache.list('All_Users').upsert({
+		selection: {
+			fields: {
+				id: { visible: true, type: 'ID', keyRaw: 'id' },
+				firstName: { visible: true, type: 'String', keyRaw: 'firstName' },
+			},
+		},
+		data: {
+			id: '3',
+			firstName: 'mary',
+		},
+		where: 'last',
+	})
+
+	// make sure we got the new value appended
+	expect(set).toHaveBeenCalledWith({
+		viewer: {
+			id: '1',
+			friends: [
+				{
+					firstName: 'jane',
+					id: '2',
+				},
+				{
+					firstName: 'mary',
+					id: '3',
+				},
+			],
+		},
+	})
+})
+
+test('upsert in list - updates existing item', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						id: {
+							type: 'ID',
+							visible: true,
+							keyRaw: 'id',
+						},
+						friends: {
+							type: 'User',
+							visible: true,
+							keyRaw: 'friends',
+							list: {
+								name: 'All_Users',
+								connection: false,
+								type: 'User',
+							},
+							selection: {
+								fields: {
+									id: {
+										type: 'ID',
+										visible: true,
+										keyRaw: 'id',
+									},
+									firstName: {
+										type: 'String',
+										visible: true,
+										keyRaw: 'firstName',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// start off associated with two objects
+	cache.write({
+		selection,
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						id: '2',
+						firstName: 'jane',
+					},
+					{
+						id: '3',
+						firstName: 'mary',
+					},
+				],
+			},
+		},
+	})
+
+	// a function to spy on that will play the role of set
+	const set = vi.fn()
+
+	// subscribe to the fields
+	cache.subscribe({
+		rootType: 'Query',
+		set,
+		selection,
+	})
+
+	// upsert an element that already exists (should update it)
+	cache.list('All_Users', '1').upsert({
+		selection: {
+			fields: {
+				id: { visible: true, type: 'ID', keyRaw: 'id' },
+				firstName: { visible: true, type: 'String', keyRaw: 'firstName' },
+			},
+		},
+		data: {
+			id: '3',
+			firstName: 'mary-updated',
+		},
+		where: 'last',
+	})
+
+	const result = cache.read({
+		selection,
+	})
+
+	// make sure the existing item was updated, not added again
+	expect(result.data).toEqual({
+		viewer: {
+			id: '1',
+			friends: [
+				{
+					firstName: 'jane',
+					id: '2',
+				},
+				{
+					firstName: 'mary-updated',
+					id: '3',
+				},
+			],
+		},
+	})
+})
+
+test('upsert in list - prepend position when item does not exist', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						id: {
+							type: 'ID',
+							visible: true,
+							keyRaw: 'id',
+						},
+						friends: {
+							type: 'User',
+							visible: true,
+							keyRaw: 'friends',
+							list: {
+								name: 'All_Users',
+								connection: false,
+								type: 'User',
+							},
+							selection: {
+								fields: {
+									id: {
+										type: 'ID',
+										visible: true,
+										keyRaw: 'id',
+									},
+									firstName: {
+										type: 'String',
+										visible: true,
+										keyRaw: 'firstName',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// start off associated with one object
+	cache.write({
+		selection,
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						id: '2',
+						firstName: 'jane',
+					},
+				],
+			},
+		},
+	})
+
+	// a function to spy on that will play the role of set
+	const set = vi.fn()
+
+	// subscribe to the fields
+	cache.subscribe({
+		rootType: 'Query',
+		set,
+		selection,
+	})
+
+	// upsert an element that doesn't exist with 'first' position (should prepend it)
+	cache.list('All_Users').upsert({
+		selection: {
+			fields: {
+				id: { visible: true, type: 'ID', keyRaw: 'id' },
+				firstName: { visible: true, type: 'String', keyRaw: 'firstName' },
+			},
+		},
+		data: {
+			id: '3',
+			firstName: 'mary',
+		},
+		where: 'first',
+	})
+
+	// make sure we got the new value prepended
+	expect(set).toHaveBeenCalledWith({
+		viewer: {
+			id: '1',
+			friends: [
+				{
+					firstName: 'mary',
+					id: '3',
+				},
+				{
+					firstName: 'jane',
+					id: '2',
+				},
+			],
+		},
+	})
+})
+
+test('upsert in connection - adds new item when not exists', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						id: {
+							type: 'ID',
+							visible: true,
+							keyRaw: 'id',
+						},
+						friends: {
+							type: 'User',
+							visible: true,
+							keyRaw: 'friends',
+							list: {
+								name: 'All_Users',
+								connection: true,
+								type: 'User',
+							},
+							selection: {
+								fields: {
+									edges: {
+										type: 'UserEdge',
+										visible: true,
+										keyRaw: 'edges',
+										selection: {
+											fields: {
+												node: {
+													type: 'Node',
+													visible: true,
+													keyRaw: 'node',
+													abstract: true,
+													selection: {
+														fields: {
+															__typename: {
+																type: 'String',
+																visible: true,
+																keyRaw: '__typename',
+															},
+															id: {
+																type: 'ID',
+																visible: true,
+																keyRaw: 'id',
+															},
+															firstName: {
+																type: 'String',
+																visible: true,
+																keyRaw: 'firstName',
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// start off associated with one object
+	cache.write({
+		selection,
+		data: {
+			viewer: {
+				id: '1',
+				friends: {
+					edges: [
+						{
+							node: {
+								__typename: 'User',
+								id: '2',
+								firstName: 'jane',
+							},
+						},
+					],
+				},
+			},
+		},
+	})
+
+	// a function to spy on that will play the role of set
+	const set = vi.fn()
+
+	// subscribe to the fields
+	cache.subscribe({
+		rootType: 'Query',
+		set,
+		selection,
+	})
+
+	// upsert an element into the connection that doesn't exist yet
+	cache.list('All_Users').upsert({
+		selection: {
+			fields: {
+				id: { visible: true, type: 'ID', keyRaw: 'id' },
+				firstName: { visible: true, type: 'String', keyRaw: 'firstName' },
+			},
+		},
+		data: {
+			id: '3',
+			firstName: 'mary',
+		},
+		where: 'last',
+	})
+
+	const result = cache.read({
+		selection,
+	})
+
+	// make sure we got the new value
+	expect(result.data).toEqual({
+		viewer: {
+			id: '1',
+			friends: {
+				edges: [
+					{
+						node: {
+							__typename: 'User',
+							id: '2',
+							firstName: 'jane',
+						},
+					},
+					{
+						node: {
+							__typename: 'User',
+							id: '3',
+							firstName: 'mary',
+						},
+					},
+				],
+			},
+		},
+	})
+})
+
+test('upsert in connection - updates existing item', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						id: {
+							type: 'ID',
+							visible: true,
+							keyRaw: 'id',
+						},
+						friends: {
+							type: 'User',
+							visible: true,
+							keyRaw: 'friends',
+							list: {
+								name: 'All_Users',
+								connection: true,
+								type: 'User',
+							},
+							selection: {
+								fields: {
+									edges: {
+										type: 'UserEdge',
+										visible: true,
+										keyRaw: 'edges',
+										selection: {
+											fields: {
+												node: {
+													type: 'Node',
+													visible: true,
+													keyRaw: 'node',
+													abstract: true,
+													selection: {
+														fields: {
+															__typename: {
+																type: 'String',
+																visible: true,
+																keyRaw: '__typename',
+															},
+															id: {
+																type: 'ID',
+																visible: true,
+																keyRaw: 'id',
+															},
+															firstName: {
+																type: 'String',
+																visible: true,
+																keyRaw: 'firstName',
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// start off associated with two objects
+	cache.write({
+		selection,
+		data: {
+			viewer: {
+				id: '1',
+				friends: {
+					edges: [
+						{
+							node: {
+								__typename: 'User',
+								id: '2',
+								firstName: 'jane',
+							},
+						},
+						{
+							node: {
+								__typename: 'User',
+								id: '3',
+								firstName: 'mary',
+							},
+						},
+					],
+				},
+			},
+		},
+	})
+
+	// a function to spy on that will play the role of set
+	const set = vi.fn()
+
+	// subscribe to the fields
+	cache.subscribe({
+		rootType: 'Query',
+		set,
+		selection,
+	})
+
+	// upsert an element that already exists (should update it)
+	cache.list('All_Users').upsert({
+		selection: {
+			fields: {
+				id: { visible: true, type: 'ID', keyRaw: 'id' },
+				firstName: { visible: true, type: 'String', keyRaw: 'firstName' },
+			},
+		},
+		data: {
+			id: '3',
+			firstName: 'mary-updated',
+		},
+		where: 'last',
+	})
+
+	const result = cache.read({
+		selection,
+	})
+
+	// make sure the existing item was updated, not added again
+	expect(result.data).toEqual({
+		viewer: {
+			id: '1',
+			friends: {
+				edges: [
+					{
+						node: {
+							__typename: 'User',
+							id: '2',
+							firstName: 'jane',
+						},
+					},
+					{
+						node: {
+							__typename: 'User',
+							id: '3',
+							firstName: 'mary-updated',
+						},
+					},
+				],
+			},
+		},
+	})
+})
+
+test('upsert with list filters - applies when condition', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						id: {
+							type: 'ID',
+							visible: true,
+							keyRaw: 'id',
+						},
+						friends: {
+							type: 'User',
+							visible: true,
+							keyRaw: 'friends',
+							list: {
+								name: 'All_Users',
+								connection: false,
+								type: 'User',
+							},
+							filters: {
+								foo: {
+									kind: 'String',
+									value: 'bar',
+								},
+							},
+							selection: {
+								fields: {
+									id: {
+										type: 'ID',
+										visible: true,
+										keyRaw: 'id',
+									},
+									firstName: {
+										type: 'String',
+										visible: true,
+										keyRaw: 'firstName',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// start off associated with one object
+	cache.write({
+		selection,
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						id: '2',
+						firstName: 'jane',
+					},
+				],
+			},
+		},
+	})
+
+	// a function to spy on that will play the role of set
+	const set = vi.fn()
+
+	// subscribe to the fields
+	cache.subscribe({
+		rootType: 'Query',
+		set,
+		selection,
+	})
+
+	// upsert with a matching filter condition
+	cache
+		.list('All_Users')
+		.when({ must: { foo: 'bar' } })
+		.upsert({
+			selection: {
+				fields: {
+					id: { visible: true, type: 'ID', keyRaw: 'id' },
+					firstName: { visible: true, type: 'String', keyRaw: 'firstName' },
+				},
+			},
+			data: {
+				id: '3',
+				firstName: 'mary',
+			},
+			where: 'last',
+		})
+
+	const result = cache.read({
+		selection,
+	})
+
+	// make sure we got the new value
+	expect(result.data).toEqual({
+		viewer: {
+			id: '1',
+			friends: [
+				{
+					firstName: 'jane',
+					id: '2',
+				},
+				{
+					firstName: 'mary',
+					id: '3',
+				},
+			],
+		},
+	})
+})
+
+test('upsert with list filters - skips when condition not met', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						id: {
+							type: 'ID',
+							visible: true,
+							keyRaw: 'id',
+						},
+						friends: {
+							type: 'User',
+							visible: true,
+							keyRaw: 'friends',
+							list: {
+								name: 'All_Users',
+								connection: false,
+								type: 'User',
+							},
+							filters: {
+								foo: {
+									kind: 'String',
+									value: 'bar',
+								},
+							},
+							selection: {
+								fields: {
+									id: {
+										type: 'ID',
+										visible: true,
+										keyRaw: 'id',
+									},
+									firstName: {
+										type: 'String',
+										visible: true,
+										keyRaw: 'firstName',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// start off associated with one object
+	cache.write({
+		selection,
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						id: '2',
+						firstName: 'jane',
+					},
+				],
+			},
+		},
+	})
+
+	// a function to spy on that will play the role of set
+	const set = vi.fn()
+
+	// subscribe to the fields
+	cache.subscribe({
+		rootType: 'Query',
+		set,
+		selection,
+	})
+
+	// upsert with a non-matching filter condition
+	cache
+		.list('All_Users')
+		.when({ must: { foo: 'baz' } })
+		.upsert({
+			selection: {
+				fields: {
+					id: { visible: true, type: 'ID', keyRaw: 'id' },
+					firstName: { visible: true, type: 'String', keyRaw: 'firstName' },
+				},
+			},
+			data: {
+				id: '3',
+				firstName: 'mary',
+			},
+			where: 'last',
+		})
+
+	// make sure we did NOT get called (filter condition not met)
+	expect(set).not.toHaveBeenCalled()
+})
+
+test('upsert operation in cache write', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	// create a list we will upsert to
+	cache.write({
+		selection: {
+			fields: {
+				viewer: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'viewer',
+					selection: {
+						fields: {
+							id: {
+								type: 'ID',
+								visible: true,
+								keyRaw: 'id',
+							},
+						},
+					},
+				},
+			},
+		},
+		data: {
+			viewer: {
+				id: '1',
+			},
+		},
+	})
+
+	// subscribe to the data to register the list
+	cache.subscribe(
+		{
+			rootType: 'User',
+			selection: {
+				fields: {
+					friends: {
+						type: 'User',
+						visible: true,
+						keyRaw: 'friends',
+						list: {
+							name: 'All_Users',
+							connection: false,
+							type: 'User',
+						},
+						selection: {
+							fields: {
+								id: {
+									type: 'ID',
+									visible: true,
+									keyRaw: 'id',
+								},
+								firstName: {
+									type: 'String',
+									visible: true,
+									keyRaw: 'firstName',
+								},
+							},
+						},
+					},
+				},
+			},
+			parentID: cache._internal_unstable.id('User', '1')!,
+			set: vi.fn(),
+		},
+		{}
+	)
+
+	// write some data with an upsert operation
+	cache.write({
+		selection: {
+			fields: {
+				newUser: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'newUser',
+					operations: [
+						{
+							action: 'upsert',
+							list: 'All_Users',
+						},
+					],
+					selection: {
+						fields: {
+							id: {
+								type: 'ID',
+								visible: true,
+								keyRaw: 'id',
+							},
+							firstName: {
+								type: 'String',
+								visible: true,
+								keyRaw: 'firstName',
+							},
+						},
+					},
+				},
+			},
+		},
+		data: {
+			newUser: {
+				id: '2',
+				firstName: 'jane',
+			},
+		},
+	})
+
+	// make sure we added to the list
+	expect([...cache.list('All_Users', '1')]).toEqual(['User:2'])
+
+	// write again with updated data for the same user
+	cache.write({
+		selection: {
+			fields: {
+				newUser: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'newUser',
+					operations: [
+						{
+							action: 'upsert',
+							list: 'All_Users',
+						},
+					],
+					selection: {
+						fields: {
+							id: {
+								type: 'ID',
+								visible: true,
+								keyRaw: 'id',
+							},
+							firstName: {
+								type: 'String',
+								visible: true,
+								keyRaw: 'firstName',
+							},
+						},
+					},
+				},
+			},
+		},
+		data: {
+			newUser: {
+				id: '2',
+				firstName: 'jane-updated',
+			},
+		},
+	})
+
+	// make sure we still only have one item in the list
+	expect([...cache.list('All_Users', '1')]).toEqual(['User:2'])
+
+	// verify the item was updated, not duplicated
+	const result = cache.read({
+		selection: {
+			fields: {
+				friends: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'friends',
+					selection: {
+						fields: {
+							id: {
+								type: 'ID',
+								visible: true,
+								keyRaw: 'id',
+							},
+							firstName: {
+								type: 'String',
+								visible: true,
+								keyRaw: 'firstName',
+							},
+						},
+					},
+				},
+			},
+		},
+		parent: cache._internal_unstable.id('User', '1')!,
+	})
+
+	expect(result.data).toEqual({
+		friends: [
+			{
+				id: '2',
+				firstName: 'jane-updated',
+			},
+		],
+	})
+})

--- a/packages/houdini/src/runtime/lib/types.ts
+++ b/packages/houdini/src/runtime/lib/types.ts
@@ -173,7 +173,7 @@ export const DataSource = {
 export type DataSources = ValuesOf<typeof DataSource>
 
 export type MutationOperation = {
-	action: 'insert' | 'remove' | 'delete' | 'toggle'
+	action: 'insert' | 'remove' | 'delete' | 'toggle' | 'upsert'
 	list?: string
 	type?: string
 	parentID?: {

--- a/packages/houdini/src/runtime/public/list.ts
+++ b/packages/houdini/src/runtime/public/list.ts
@@ -106,6 +106,24 @@ export class ListCollection<Def extends CacheTypeDef, ListName extends ValidList
 		}
 	}
 
+	upsert(where: 'first' | 'last', ...records: ListType<Def, ListName>[]) {
+		if (!this.#collection) {
+			return
+		}
+
+		const { selection, data } = this.#listOperationPayload(records)
+
+		for (const entry of data) {
+			if (entry) {
+				this.#collection.upsert({
+					selection,
+					data: entry,
+					where: where || 'last',
+				})
+			}
+		}
+	}
+
 	*[Symbol.iterator]() {
 		for (const entry of this.#collection ?? []) {
 			yield entry

--- a/site/src/routes/api/graphql-magic/+page.svx
+++ b/site/src/routes/api/graphql-magic/+page.svx
@@ -16,6 +16,7 @@ A field marked with `@list` or by passing a name to `@paginate` can use the foll
 - `[ListName]_insert`: insert the reference into the list
 - `[ListName]_remove`: remove the reference from the list
 - `[ListName]_toggle`: if the reference is already in the list, remove it; otherwise, add it to the list
+- `[ListName]_upsert`: insert if not in list, otherwise update the existing item in place
 
 Some things worth mentioning:
 


### PR DESCRIPTION
Fixes #1557

This PR implements support for doing cache upserts 😀 
You can now add `My_List_upsert` to your subscriptions / queries, and it'll just work ™️ 

### To help everyone out, please make sure your PR does the following:

- [X] Update the first line to point to the ticket that this PR fixes
- [X] Add a message that clearly describes the fix
- [X] If applicable, add a test that would fail without this fix
- [X] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [X] Ensure your code is formatted to conform to standard style with `pnpm run format:write` (or `format:check` if you want to preview changes) and linted `pnpm run lint`
- [X] Includes a changeset if your fix affects the user with `pnpm changeset`
