### PR TITLE
Update authentication header from 'Authentication' to 'Authorization'

### DIFF
--- a/.changeset/rich-parents-play.md
+++ b/.changeset/rich-parents-play.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fixed authentication header from `Authentication` to `Authorization`

--- a/e2e/svelte/src/client.ts
+++ b/e2e/svelte/src/client.ts
@@ -8,7 +8,7 @@ export default new HoudiniClient({
 	// fetchParams({ session }) {
 	//     return {
 	//         headers: {
-	//             Authentication: `Bearer ${session.token}`,
+	//             Authorization: `Bearer ${session.token}`,
 	//         }
 	//     }
 	// }

--- a/packages/houdini/src/cmd/init.ts
+++ b/packages/houdini/src/cmd/init.ts
@@ -384,7 +384,7 @@ export default new HoudiniClient({
     // fetchParams({ session }) {
     //     return {
     //         headers: {
-    //             Authentication: \`Bearer \${session.token}\`,
+    //             Authorization: \`Bearer \${session.token}\`,
     //         }
     //     }
     // }

--- a/site/src/routes/api/config/+page.svx
+++ b/site/src/routes/api/config/+page.svx
@@ -164,7 +164,7 @@ export default {
 	watchSchema: {
 		url: '...',
 		headers: {
-			Authentication: 'env:AUTH_TOKEN'
+			Authorization: 'env:AUTH_TOKEN'
 		}
 	}
 }

--- a/site/src/routes/guides/release-notes/+page.svx
+++ b/site/src/routes/guides/release-notes/+page.svx
@@ -13,7 +13,7 @@ description: A guide to migrating your application to each breaking version of h
 
 `2.0` is the largest release of Houdini in the last 3 years. Thanks so much to everyone involved with testing and contributing to this massive effort.
 
-Given the scale of the rewrite, we've written [a guide](/guides/migrateTo20) that details all of the necessary changes so please head over there for more information. 
+Given the scale of the rewrite, we've written [a guide](/guides/migrateTo20) that details all of the necessary changes so please head over there for more information.
 
 
 ## 1.2.0
@@ -162,7 +162,7 @@ If your application uses subscriptions, you'll need to import the
 +             url: 'ws://api.url',
 +             connectionParams: {
 +                 headers: {
-+                     Authentication: `Bearer ${session.user?.token}`
++                     Authorization: `Bearer ${session.user?.token}`
 +                 }
 +             }
 +  	      }))


### PR DESCRIPTION
Fixes #1577 

The `@next` generated client was incorrectly using the `Authentication` header instead of `Authorization`. This corrects the headers.

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [ ] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Ensure your code is formatted to conform to standard style with `pnpm run format:write` (or `format:check` if you want to preview changes) and linted `pnpm run lint`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`
