### PR TITLE
fix(houdini-svelte): strip type annotations from load param in session transform

### DIFF
--- a/packages/houdini-svelte/src/plugin/transforms/kit/session.test.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/kit/session.test.ts
@@ -386,3 +386,94 @@ test('value assignment for load function', async function () {
 		const houdini__intermediate__load__ = someFn;
 	`)
 })
+
+test('strips type annotation from load function param - function declaration', async function () {
+	const result = await test_transform_js(
+		'src/routes/+layout.server.ts',
+		`
+			import type { RequestEvent } from '@sveltejs/kit';
+
+			export async function load(event: RequestEvent) {
+				return {
+					hello: "world",
+				}
+			}
+		`
+	)
+
+	// The event_id used in buildSessionObject() must NOT carry the
+	// TypeScript type annotation, otherwise recast emits
+	// `buildSessionObject(event: RequestEvent)` which is invalid JS.
+	expect(result).toMatchInlineSnapshot(`
+		import { buildSessionObject } from "$houdini/plugins/houdini-svelte/runtime/session";
+		import type { RequestEvent } from "@sveltejs/kit";
+
+		export async function load(event: RequestEvent) {
+		    return {
+		        ...buildSessionObject(event),
+
+		        ...{
+		            hello: "world"
+		        }
+		    };
+		}
+	`)
+})
+
+test('strips type annotation from load param - const arrow with return type', async function () {
+	const result = await test_transform_js(
+		'src/routes/+layout.server.ts',
+		`
+			import type { RequestEvent } from '@sveltejs/kit';
+
+			export const load = async (event: RequestEvent): Promise<{ isAdmin?: boolean }> => {
+				return { isAdmin: true }
+			}
+		`
+	)
+
+	expect(result).toMatchInlineSnapshot(`
+		import { buildSessionObject } from "$houdini/plugins/houdini-svelte/runtime/session";
+		import type { RequestEvent } from "@sveltejs/kit";
+
+		export const load = async (event: RequestEvent): Promise<{
+		    isAdmin?: boolean;
+		}> => {
+		    return {
+		        ...buildSessionObject(event),
+
+		        ...{
+		            isAdmin: true
+		        }
+		    };
+		};
+	`)
+})
+
+test('strips type annotation from load param - const function expression', async function () {
+	const result = await test_transform_js(
+		'src/routes/+layout.server.ts',
+		`
+			import type { RequestEvent } from '@sveltejs/kit';
+
+			export const load = function(event: RequestEvent) {
+				return { data: 42 }
+			}
+		`
+	)
+
+	expect(result).toMatchInlineSnapshot(`
+		import { buildSessionObject } from "$houdini/plugins/houdini-svelte/runtime/session";
+		import type { RequestEvent } from "@sveltejs/kit";
+
+		export const load = function(event: RequestEvent) {
+		    return {
+		        ...buildSessionObject(event),
+
+		        ...{
+		            data: 42
+		        }
+		    };
+		};
+	`)
+})

--- a/packages/houdini-svelte/src/plugin/transforms/kit/session.ts
+++ b/packages/houdini-svelte/src/plugin/transforms/kit/session.ts
@@ -178,7 +178,12 @@ function modify_load(
 		}
 		// if the first parameter of the function declaration is an identifier, we're in business
 		else if (load_fn.params[0]?.type === 'Identifier') {
-			event_id = load_fn.params[0]
+			// Create a clean identifier from just the name to strip any TypeScript
+			// type annotations (e.g., `event: RequestEvent`). Reusing the original
+			// AST node would cause recast to emit the annotation inside call
+			// expressions like `buildSessionObject(event: RequestEvent)`, which is
+			// syntactically invalid JavaScript and breaks esbuild.
+			event_id = AST.identifier(load_fn.params[0].name)
 		}
 		// the first parameter is not an identifier so it's almost certainly an object pattern pulling parameters out
 		else if (load_fn.params[0].type === 'ObjectPattern') {


### PR DESCRIPTION
## Problem

When the root layout server's `load` function has a TypeScript type annotation on the event parameter:

```ts
export async function load(event: RequestEvent) {
    return { hello: "world" }
}
```

The `modify_load` transform in `session.ts` reuses the full Babel AST `Identifier` node (which carries a `typeAnnotation` property) as a call argument for `buildSessionObject()`.

This causes `recast` to emit:

```js
...buildSessionObject(event: RequestEvent)
```

which is **syntactically invalid JavaScript**, breaking the esbuild transform step during `vite build` with:

```
Expected ")" but found ":"
```

### Root Cause

In [`modify_load()`](https://github.com/HoudiniGraphql/houdini/blob/houdini-2.0/packages/houdini-svelte/src/plugin/transforms/kit/session.ts#L182-L184), when the first parameter is an `Identifier`:

```ts
else if (load_fn.params[0]?.type === 'Identifier') {
    event_id = load_fn.params[0]  // ← reuses node WITH typeAnnotation
}
```

Babel's TypeScript parser produces an `Identifier` node whose `.type` is still `"Identifier"`, but it carries a `typeAnnotation` child. When this node is later placed inside `AST.callExpression(buildSessionObject, [event_id])`, recast faithfully prints the annotation in a position where it's syntactically invalid.

## Fix

Create a clean `AST.identifier()` from just the parameter name, stripping any TypeScript type annotations:

```ts
event_id = AST.identifier(load_fn.params[0].name)
```

The original parameter node in `load_fn.params[0]` is left untouched, so the function signature still prints with its type annotation. Only the `event_id` used in injected call expressions is a clean identifier.

## Tests

Added 3 test cases covering:
- `export async function load(event: RequestEvent)` — function declaration with typed param
- `export const load = async (event: RequestEvent): Promise<...> => { ... }` — const arrow with typed param and return type
- `export const load = function(event: RequestEvent) { ... }` — const function expression with typed param

All 3 tests **fail before** the fix (Babel parser throws `Did not expect a type annotation here`) and **pass after**.

All 15 existing session transform tests continue to pass.

---

> **Disclosure**: This bug was found and this fix was authored by Claude Opus 4.6 while debugging a production build failure in a downstream SvelteKit project using `houdini-svelte@3.0.0-next.13`.
