### PR TITLE
fixes from testing in prod

### DIFF
--- a/.changeset/strong-flowers-watch.md
+++ b/.changeset/strong-flowers-watch.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+fix svelte 5 root layout sessio injection and using $effect to sync the houdini and app session

--- a/e2e/kit/package.json
+++ b/e2e/kit/package.json
@@ -31,7 +31,7 @@
     "build:build": "pnpm build: && pnpm build",
     "build:tests": "pnpm build:build && pnpm test",
     "houdini": "node ensureLinks.js && houdini",
-    "build": "vite build",
+    "build": "node ensureLinks.js && vite build",
     "preview": "vite preview --port 3007",
     "preview-e2e": "concurrently \"pnpm run preview\" \"pnpm run api\" -n \"web,api\" -c \"green,magenta\""
   },

--- a/e2e/kit/src/routes/+layout.svelte
+++ b/e2e/kit/src/routes/+layout.svelte
@@ -17,13 +17,13 @@
   let routesKvp = Object.keys(routes).map((key: string) => {
     return { key, value: (routes as Record<string, string>)[key] };
   });
+  let {data, children}:{data:LayoutData} = $props()
 
-  let {data}:{data:LayoutData} = $props()
   let info= $derived(data.LayoutSession)
 </script>
 
-<slot />
 
+{@render children?.()}
 <Test />
 
 <nav>
@@ -35,5 +35,5 @@
 </nav>
 
 <div id="layout-session">
-  {info?.data?.session}
+  {$info?.data?.session}
 </div>

--- a/e2e/kit/src/routes/+layout.svelte
+++ b/e2e/kit/src/routes/+layout.svelte
@@ -18,8 +18,8 @@
     return { key, value: (routes as Record<string, string>)[key] };
   });
 
-  export let data: LayoutData
-  $: ({LayoutSession: info } = data)
+  let {data}:{data:LayoutData} = $props()
+  let info= $derived(data.LayoutSession)
 </script>
 
 <slot />
@@ -35,5 +35,5 @@
 </nav>
 
 <div id="layout-session">
-  {$info?.data?.session}
+  {info?.data?.session}
 </div>

--- a/packages/houdini-svelte/package/vite/transform/init.ts
+++ b/packages/houdini-svelte/package/vite/transform/init.ts
@@ -46,8 +46,8 @@ export default async function kit_init(config: Config, page: SvelteTransformPage
 		sourceModule: '$app/state',
 		import: ['page'],
 	}).ids[0]
-  
-  // $effect dont get anyting in callback so we got to use store_page that is like page
+
+	// $effect dont get anyting in callback so we got to use store_page that is like page
 	page.script.body.push(
 		AST.expressionStatement(
 			AST.callExpression(AST.identifier('$effect'), [
@@ -57,10 +57,7 @@ export default async function kit_init(config: Config, page: SvelteTransformPage
 						AST.expressionStatement(
 							AST.callExpression(set_session, [
 								AST.callExpression(extract_session, [
-									AST.memberExpression(
-										page_store,
-										AST.identifier('data')
-									),
+									AST.memberExpression(page_store, AST.identifier('data')),
 								]),
 							])
 						),

--- a/packages/houdini-svelte/package/vite/transform/init.ts
+++ b/packages/houdini-svelte/package/vite/transform/init.ts
@@ -40,24 +40,25 @@ export default async function kit_init(config: Config, page: SvelteTransformPage
 		)
 	)
 
-	// we need to track updates in the page store as the client-side session
-	const store_id = ensure_imports({
+	// we need to track updates in page data as the client-side session
+	const page_store = ensure_imports({
 		script: page.script,
-		sourceModule: '$app/stores',
+		sourceModule: '$app/state',
 		import: ['page'],
 	}).ids[0]
-
+  
+  // $effect dont get anyting in callback so we got to use store_page that is like page
 	page.script.body.push(
 		AST.expressionStatement(
-			AST.callExpression(AST.memberExpression(store_id, AST.identifier('subscribe')), [
+			AST.callExpression(AST.identifier('$effect'), [
 				AST.arrowFunctionExpression(
-					[AST.identifier('val')],
+					[],
 					AST.blockStatement([
 						AST.expressionStatement(
 							AST.callExpression(set_session, [
 								AST.callExpression(extract_session, [
 									AST.memberExpression(
-										AST.identifier('val'),
+										page_store,
 										AST.identifier('data')
 									),
 								]),

--- a/packages/houdini/src/cmd/generate.ts
+++ b/packages/houdini/src/cmd/generate.ts
@@ -28,7 +28,7 @@ export async function generate(
 		headers: [],
 		verbose: false,
 		preserveDatabase: false,
-	},
+	}
 ) {
 	// make sure there is always a mode
 	const mode = args.mode ?? 'development'
@@ -48,12 +48,7 @@ export async function generate(
 		const [db, dbFilepath] = await init_db(config, args.preserveDatabase)
 
 		// initialize the codegen pipe
-		const { trigger_hook, close } = await codegen_setup(
-			config,
-			mode,
-			db,
-			dbFilepath,
-		)
+		const { trigger_hook, close } = await codegen_setup(config, mode, db, dbFilepath)
 
 		// Function to handle graceful shutdown
 		on_close = async () => {
@@ -72,12 +67,16 @@ export async function generate(
 		// Validate phase arguments
 		if (args.afterPhase && !PIPELINE_HOOKS.includes(args.afterPhase)) {
 			throw new Error(
-				`Invalid --after-phase: ${args.afterPhase}. Valid phases are: ${PIPELINE_HOOKS.join(', ')}`,
+				`Invalid --after-phase: ${args.afterPhase}. Valid phases are: ${PIPELINE_HOOKS.join(
+					', '
+				)}`
 			)
 		}
 		if (args.beforePhase && !PIPELINE_HOOKS.includes(args.beforePhase)) {
 			throw new Error(
-				`Invalid --before-phase: ${args.beforePhase}. Valid phases are: ${PIPELINE_HOOKS.join(', ')}`,
+				`Invalid --before-phase: ${
+					args.beforePhase
+				}. Valid phases are: ${PIPELINE_HOOKS.join(', ')}`
 			)
 		}
 

--- a/packages/houdini/src/lib/plugins.ts
+++ b/packages/houdini/src/lib/plugins.ts
@@ -1,11 +1,12 @@
 import { createRequire } from 'node:module'
 import { pathToFileURL } from 'node:url'
+
 import * as fs from './fs.js'
 import * as path from './path.js'
 
 export async function plugin_path(
 	plugin_name: string,
-	config_path: string,
+	config_path: string
 ): Promise<{ executable: string; directory: string }> {
 	try {
 		// check if we are in a PnP environment
@@ -29,9 +30,7 @@ export async function plugin_path(
 		const plugin_dir = find_module(plugin_name, config_path)
 
 		// load up the package json
-		const package_json_src = await fs.readFile(
-			path.join(plugin_dir, 'package.json'),
-		)
+		const package_json_src = await fs.readFile(path.join(plugin_dir, 'package.json'))
 		if (!package_json_src) {
 			throw new Error('There is no package.json.')
 		}
@@ -48,7 +47,7 @@ export async function plugin_path(
 		}
 	} catch (e) {
 		const err = new Error(
-			`Could not find plugin: ${plugin_name}. Are you sure its installed? If so, please open a ticket on GitHub. ${e}`,
+			`Could not find plugin: ${plugin_name}. Are you sure its installed? If so, please open a ticket on GitHub. ${e}`
 		)
 
 		throw err
@@ -85,10 +84,7 @@ function find_module(pkg: string, config_path: string): string {
  * Fallback module finding function that manually traverses node_modules directories.
  * Used when Node.js built-in module resolution fails for edge cases.
  */
-function find_module_walking_modules(
-	pkg: string = 'houdini',
-	currentLocation: string,
-) {
+function find_module_walking_modules(pkg: string = 'houdini', currentLocation: string) {
 	const pathEndingBy = ['node_modules', pkg]
 
 	// Build the first possible location

--- a/packages/houdini/src/runtime/cache/index.ts
+++ b/packages/houdini/src/runtime/cache/index.ts
@@ -1,11 +1,11 @@
 import type { ConfigFile } from 'houdini'
 
-import { computeID, defaultConfigValues, keyFieldsForType } from '../config'
-import { deepEquals } from '../deepEquals'
-import { flatten } from '../flatten'
-import { computeKey } from '../key'
-import { getFieldsForType } from '../selection'
-import { PendingValue } from '../types'
+import { computeID, defaultConfigValues, keyFieldsForType } from '../config.js'
+import { deepEquals } from '../deepEquals.js'
+import { flatten } from '../flatten.js'
+import { computeKey } from '../key.js'
+import { getFieldsForType } from '../selection.js'
+import { PendingValue } from '../types.js'
 import type {
 	GraphQLObject,
 	GraphQLValue,
@@ -14,16 +14,16 @@ import type {
 	SubscriptionSpec,
 	ValueMap,
 	ValueNode,
-} from '../types'
-import { fragmentKey } from '../types'
-import { GarbageCollector } from './gc'
-import type { ListCollection } from './lists'
-import { ListManager } from './lists'
-import { StaleManager } from './staleManager'
-import type { Layer, LayerID } from './storage'
-import { InMemoryStorage } from './storage'
-import { evaluateKey, rootID } from './stuff'
-import { InMemorySubscriptions, type FieldSelection } from './subscription'
+} from '../types.js'
+import { fragmentKey } from '../types.js'
+import { GarbageCollector } from './gc.js'
+import type { ListCollection } from './lists.js'
+import { ListManager } from './lists.js'
+import { StaleManager } from './staleManager.js'
+import type { Layer, LayerID } from './storage.js'
+import { InMemoryStorage } from './storage.js'
+import { evaluateKey, rootID } from './stuff.js'
+import { InMemorySubscriptions, type FieldSelection } from './subscription.js'
 
 export class Cache {
 	// the internal implementation for a lot of the cache's methods are moved into

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -1,8 +1,8 @@
-import { flatten } from '../flatten'
-import type { SubscriptionSelection, ListWhen, SubscriptionSpec, NestedList } from '../types'
+import { flatten } from '../flatten.js'
+import type { SubscriptionSelection, ListWhen, SubscriptionSpec, NestedList } from '../types.js'
 import type { Cache } from './index.js'
-import type { Layer } from './storage'
-import { rootID } from './stuff'
+import type { Layer } from './storage.js'
+import { rootID } from './stuff.js'
 
 export class ListManager {
 	rootID: string

--- a/packages/houdini/src/runtime/cache/storage.ts
+++ b/packages/houdini/src/runtime/cache/storage.ts
@@ -1,5 +1,5 @@
-import { flatten } from '../flatten'
-import type { GraphQLValue } from '../types'
+import { flatten } from '../flatten.js'
+import type { GraphQLValue } from '../types.js'
 
 // NOTE: the current implementation of delete is slow. it should try to compare the
 // type of the id being deleted with the type contained in the linked list so that

--- a/packages/houdini/src/runtime/cache/subscription.ts
+++ b/packages/houdini/src/runtime/cache/subscription.ts
@@ -1,8 +1,8 @@
-import { flatten } from '../flatten'
-import { getFieldsForType } from '../selection'
-import type { GraphQLValue, SubscriptionSelection, SubscriptionSpec, NestedList } from '../types'
-import type { Cache } from './index'
-import { evaluateKey, rootID } from './stuff'
+import { flatten } from '../flatten.js'
+import { getFieldsForType } from '../selection.js'
+import type { GraphQLValue, SubscriptionSelection, SubscriptionSpec, NestedList } from '../types.js'
+import type { Cache } from './index.js'
+import { evaluateKey, rootID } from './stuff.js'
 
 export type FieldSelection = [
 	SubscriptionSpec,

--- a/packages/houdini/src/runtime/client.ts
+++ b/packages/houdini/src/runtime/client.ts
@@ -1,9 +1,9 @@
 import type { ConfigFile } from 'houdini'
 
-import type { Cache } from './cache'
+import type { Cache } from './cache/index.js'
 import type { ClientHooks, ClientPlugin } from './documentStore.js'
 import { DocumentStore } from './documentStore.js'
-import type { DocumentArtifact, GraphQLVariables, GraphQLObject, NestedList } from './types'
+import type { DocumentArtifact, GraphQLVariables, GraphQLObject, NestedList } from './types.js'
 
 // export the plugin constructors
 export { DocumentStore } from './documentStore.js'

--- a/packages/houdini/src/runtime/documentStore.ts
+++ b/packages/houdini/src/runtime/documentStore.ts
@@ -1,10 +1,10 @@
 import type { ConfigFile } from 'houdini'
 
 import type { HoudiniClient } from '.'
-import type { Layer } from './cache/storage'
-import { deepEquals } from './deepEquals'
-import { marshalInputs } from './scalars'
-import { Writable } from './store'
+import type { Layer } from './cache/storage.js'
+import { deepEquals } from './deepEquals.js'
+import { marshalInputs } from './scalars.js'
+import { Writable } from './store.js'
 import type {
 	DocumentArtifact,
 	QueryResult,
@@ -13,8 +13,8 @@ import type {
 	SubscriptionSpec,
 	CachePolicies,
 	GraphQLVariables,
-} from './types'
-import { ArtifactKind, DedupeMatchMode } from './types'
+} from './types.js'
+import { ArtifactKind, DedupeMatchMode } from './types.js'
 
 // the list of states to step in what direction
 const steps = {

--- a/packages/houdini/src/runtime/flatten.ts
+++ b/packages/houdini/src/runtime/flatten.ts
@@ -1,4 +1,4 @@
-import type { NestedList } from './types'
+import type { NestedList } from './types.js'
 
 // flatten processes a deeply nested lists of lists
 export function flatten<T>(source?: NestedList<T>): T[] {

--- a/packages/houdini/src/runtime/index.ts
+++ b/packages/houdini/src/runtime/index.ts
@@ -1,18 +1,18 @@
-export * from './client'
-export { deepEquals } from './deepEquals'
-export * from './scalars'
-export * from './types'
+export * from './client.js'
+export { deepEquals } from './deepEquals.js'
+export * from './scalars.js'
+export * from './types.js'
 export {
 	computeID,
 	keyFieldsForType,
 	setMockConfig,
 	getMockConfig,
 	getCurrentConfig,
-} from './config'
-export { getFieldsForType } from './selection'
-export { flatten } from './flatten'
-export * from './pageInfo'
-export * from './pagination'
-export * from './constants'
-export * from './log'
-export { LRUCache, createLRUCache } from './lru'
+} from './config.js'
+export { getFieldsForType } from './selection.js'
+export { flatten } from './flatten.js'
+export * from './pageInfo.js'
+export * from './pagination.js'
+export * from './constants.js'
+export * from './log.js'
+export { LRUCache, createLRUCache } from './lru.js'

--- a/packages/houdini/src/runtime/pageInfo.ts
+++ b/packages/houdini/src/runtime/pageInfo.ts
@@ -1,5 +1,5 @@
-import { siteURL } from './constants'
-import type { GraphQLObject, PageInfo } from './types'
+import { siteURL } from './constants.js'
+import type { GraphQLObject, PageInfo } from './types.js'
 
 export function nullPageInfo(): PageInfo {
 	return { startCursor: null, endCursor: null, hasNextPage: false, hasPreviousPage: false }

--- a/packages/houdini/src/runtime/pagination.ts
+++ b/packages/houdini/src/runtime/pagination.ts
@@ -1,7 +1,7 @@
-import { deepEquals } from './deepEquals'
-import type { SendParams } from './documentStore'
-import { countPage, extractPageInfo, missingPageSizeError } from './pageInfo'
-import { CachePolicy, DataSource } from './types'
+import { deepEquals } from './deepEquals.js'
+import type { SendParams } from './documentStore.js'
+import { countPage, extractPageInfo, missingPageSizeError } from './pageInfo.js'
+import { CachePolicy, DataSource } from './types.js'
 import type {
 	CursorHandlers,
 	FetchFn,
@@ -10,7 +10,7 @@ import type {
 	QueryArtifact,
 	QueryResult,
 	FetchParams,
-} from './types'
+} from './types.js'
 
 export function cursorHandlers<
 	_Data extends GraphQLObject,

--- a/packages/houdini/src/runtime/scalars.ts
+++ b/packages/houdini/src/runtime/scalars.ts
@@ -1,7 +1,7 @@
 import type { ConfigFile } from 'houdini'
 
-import { getCurrentConfig } from './config'
-import { getFieldsForType } from './selection'
+import { getCurrentConfig } from './config.js'
+import { getFieldsForType } from './selection.js'
 import {
 	fragmentKey,
 	type FragmentArtifact,
@@ -9,7 +9,7 @@ import {
 	type QueryArtifact,
 	type SubscriptionArtifact,
 	type SubscriptionSelection,
-} from './types'
+} from './types.js'
 
 export function marshalSelection({
 	selection,

--- a/packages/houdini/src/runtime/selection.ts
+++ b/packages/houdini/src/runtime/selection.ts
@@ -1,4 +1,4 @@
-import type { SubscriptionSelection } from './types'
+import type { SubscriptionSelection } from './types.js'
 
 export function getFieldsForType(
 	selection: SubscriptionSelection,

--- a/packages/houdini/src/runtime/types.ts
+++ b/packages/houdini/src/runtime/types.ts
@@ -12,7 +12,7 @@ export const DedupeMatchMode = {
 
 export type DedupeMatchModes = ValuesOf<typeof DedupeMatchMode>
 
-export * from '../router/types'
+export * from '../router/types.js'
 
 declare global {
 	namespace App {


### PR DESCRIPTION
1. added .js extension to all imports so `esbuild` dont break it for node while bundling
2. earlier we used `page.subscribe` that is `__legacy-page $app/stores`to sync houdini & `page.data`. svelte5 introduced new rune compatible page `__new-page $app/state`.
 Our ast transformation fails because sometimes user may already have imported page in the file and then `ensure_imports` will skip it because it only compares by name.
  `__new-page` dont have subscribe method on it instead we can use `$effect` rune. 
  
  Changed the `ensure_import` to compare by source also and wrote Ast for using `$effect` in place of page.subscrube.

Fixes #TICKET

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Ensure your code is formatted to conform to standard style with `pnpm run format:write` (or `format:check` if you want to preview changes) and linted `pnpm run lint`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`
