### PR TITLE
fix async component query for latest svelte

### DIFF
--- a/.changeset/fix-async-component-query.md
+++ b/.changeset/fix-async-component-query.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+fix: allow server-side fetch without event for Svelte 5 async component queries

--- a/packages/houdini-svelte/src/runtime/stores/query.ts
+++ b/packages/houdini-svelte/src/runtime/stores/query.ts
@@ -80,13 +80,7 @@ export class QueryStore<
 		// make a shallow copy of the args so we don't mutate the arguments that the user hands us
 		const { policy, params, context } = await fetchParams(this.artifact, this.storeName, args)
 
-		// if we aren't on the browser but there's no event there's a big mistake
-		if (!isBrowser && !(params && 'fetch' in params) && (!params || !('event' in params))) {
-			// prettier-ignore
-			log.error(contextError(this.storeName))
 
-			throw new Error('Error, check above logs for help.')
-		}
 
 		// identify if this is a CSF or load
 		const isLoadFetch = Boolean('event' in params && params.event)
@@ -258,17 +252,9 @@ export async function fetchParams<_Data extends GraphQLObject, _Input>(
 		fetchFn = globalThis.fetch.bind(globalThis)
 	}
 
-	let session: any = undefined
-	// cannot re-use the variable from above
-	// we need to check for ourselves to satisfy typescript
-	if (params && 'event' in params && params.event) {
-		session = await getSession(params.event)
-	} else if (isBrowser) {
-		session = await getSession()
-	} else {
-		log.error(contextError(storeName))
-		throw new Error('Error, check above logs for help.')
-	}
+	const session = await getSession(
+		params && 'event' in params ? params.event : undefined
+	)
 
 	return {
 		context: {

--- a/packages/houdini-svelte/src/runtime/stores/query.ts
+++ b/packages/houdini-svelte/src/runtime/stores/query.ts
@@ -80,8 +80,6 @@ export class QueryStore<
 		// make a shallow copy of the args so we don't mutate the arguments that the user hands us
 		const { policy, params, context } = await fetchParams(this.artifact, this.storeName, args)
 
-
-
 		// identify if this is a CSF or load
 		const isLoadFetch = Boolean('event' in params && params.event)
 		const isComponentFetch = !isLoadFetch
@@ -252,9 +250,7 @@ export async function fetchParams<_Data extends GraphQLObject, _Input>(
 		fetchFn = globalThis.fetch.bind(globalThis)
 	}
 
-	const session = await getSession(
-		params && 'event' in params ? params.event : undefined
-	)
+	const session = await getSession(params && 'event' in params ? params.event : undefined)
 
 	return {
 		context: {


### PR DESCRIPTION
earlier the component did not allow async so in houdini we maintained to pass event object to queries in load funciton. That has changed and now a asyunc query written in component runs on server and without event arg, that breaks the server side loading. 

Adjusted the query fetch to handle this

Fixes #TICKET

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Ensure your code is formatted to conform to standard style with `pnpm run format:write` (or `format:check` if you want to preview changes) and linted `pnpm run lint`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`