### PR TITLE
Perf improvements

### DIFF
--- a/.changeset/eight-apricots-work.md
+++ b/.changeset/eight-apricots-work.md
@@ -1,0 +1,6 @@
+---
+'houdini-core': patch
+'houdini': patch
+---
+
+Codegen pipeline now runs 4x faster

--- a/.changeset/eight-apricots-work.md
+++ b/.changeset/eight-apricots-work.md
@@ -3,4 +3,4 @@
 'houdini': patch
 ---
 
-Codegen pipeline now runs 4x faster
+Codegen pipeline now runs 5x faster

--- a/packages/houdini-core/plugin/componentFields/metadata.go
+++ b/packages/houdini-core/plugin/componentFields/metadata.go
@@ -177,13 +177,13 @@ func WriteMetadata[PluginConfig any](
 	defer typesStmt.Finalize()
 
 	// Prepare a statement to check for conflicts in type_fields.
+	// Note: component_fields.document is a raw_documents.id FK, not a documents.id.
 	tfStmt, err := conn.Prepare(`
-    SELECT COUNT(*) 
-    FROM type_fields 
+    SELECT COUNT(*)
+    FROM type_fields
       LEFT JOIN component_fields ON type_fields.id = component_fields.type_field
-      LEFT JOIN documents on component_fields.document = documents.id
-      LEFT JOIN raw_documents on documents.raw_document = raw_documents.id
-    WHERE type_fields.id = ? AND (component_fields.id IS NULL OR filepath != ?)
+      LEFT JOIN raw_documents ON component_fields.document = raw_documents.id
+    WHERE type_fields.id = ? AND (component_fields.id IS NULL OR raw_documents.filepath != ?)
   `)
 	if err != nil {
 		errs.Append(plugins.WrapError(err))

--- a/packages/houdini-core/plugin/documents/artifacts/artifacts.go
+++ b/packages/houdini-core/plugin/documents/artifacts/artifacts.go
@@ -3,6 +3,7 @@ package artifacts
 import (
 	"context"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -54,7 +55,7 @@ func GenerateDocumentArtifacts(
 	}
 
 	// start consuming names off of the channel
-	for range 1 {
+	for range runtime.NumCPU() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/packages/houdini-core/plugin/documents/artifacts/selection.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection.go
@@ -53,6 +53,11 @@ func writeSelectionDocument(
 	// compute the filepath to write the artifact to
 	artifactPath := projectConfig.ArtifactPath(name)
 
+	// skip the write if the content hasn't changed (common on incremental runs)
+	if existing, err := afero.ReadFile(fs, artifactPath); err == nil && string(existing) == artifact {
+		return "", nil
+	}
+
 	// write the file to disk
 	err = afero.WriteFile(fs, artifactPath, []byte(artifact), 0644)
 	if err != nil {

--- a/packages/houdini-core/plugin/documents/collected/collect.go
+++ b/packages/houdini-core/plugin/documents/collected/collect.go
@@ -131,9 +131,8 @@ func CollectDocuments(
 	resultCh := make(chan collectResult, len(docIDs))
 
 	// create a pool of worker goroutines to process the documents
-	// use single worker to avoid database contention
 	var wg sync.WaitGroup
-	for range 1 {
+	for range runtime.NumCPU() {
 		wg.Add(1)
 		go collectDoc(ctx, db, &wg, batchCh, resultCh, errList, sortKeys)
 	}

--- a/packages/houdini-core/plugin/documents/collected/collect.go
+++ b/packages/houdini-core/plugin/documents/collected/collect.go
@@ -1221,21 +1221,35 @@ func prepareCollectStatements(conn *sqlite.Conn, docIDs []int64) (*CollectStatem
 	}
 
 	// we need a query that looks up every abstract type that's used in
-	// the set of documents
+	// the set of documents. Split into three UNION branches (no OR in JOIN) so
+	// SQLite can use indexes on each branch independently.
 	possibleTypes, err := conn.Prepare(fmt.Sprintf(`
-    SELECT DISTINCT possible_types."type", possible_types."member"
-    FROM possible_types
-      LEFT JOIN type_fields ON possible_types."type" = type_fields."type"
-      JOIN selections ON selections.type = type_fields.id
-        OR (selections.kind = 'inline_fragment'
-            AND (
-              selections.field_name = possible_types."member"
-              OR selections.field_name = possible_types."type"
-            )
-        )
-      JOIN selection_refs ON selection_refs.child_id = selections.id
-    WHERE selection_refs.document IN %s
-  `, whereIn))
+    -- Case 1: abstract type appears as the declared type of a field in the selection set
+    SELECT DISTINCT pt."type", pt."member"
+    FROM possible_types pt
+      JOIN type_fields tf ON pt."type" = tf."type"
+      JOIN selections s ON s.type = tf.id
+      JOIN selection_refs sr ON sr.child_id = s.id
+    WHERE sr.document IN %s
+
+    UNION
+
+    -- Case 2: inline fragment whose type condition matches a concrete member name
+    SELECT DISTINCT pt."type", pt."member"
+    FROM possible_types pt
+      JOIN selections s ON s.kind = 'inline_fragment' AND s.field_name = pt."member"
+      JOIN selection_refs sr ON sr.child_id = s.id
+    WHERE sr.document IN %s
+
+    UNION
+
+    -- Case 3: inline fragment whose type condition matches the abstract type itself
+    SELECT DISTINCT pt."type", pt."member"
+    FROM possible_types pt
+      JOIN selections s ON s.kind = 'inline_fragment' AND s.field_name = pt."type"
+      JOIN selection_refs sr ON sr.child_id = s.id
+    WHERE sr.document IN %s
+  `, whereIn, whereIn, whereIn))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/houdini-core/plugin/documents/collected/collect.go
+++ b/packages/houdini-core/plugin/documents/collected/collect.go
@@ -226,7 +226,17 @@ func collectDoc(
 		// wrap each processing in a function so we have a defer context to avoid deadlocking the connection
 		func(ids []int64) {
 			// bind this batch's IDs; unused placeholder slots remain NULL from the previous ClearBindings
-			bindCollectStatements(statements, ids)
+			for _, stmt := range []*sqlite.Stmt{
+				statements.Search,
+				statements.DocumentVariables,
+				statements.DocumentDirectives,
+				statements.PossibleTypes,
+				statements.InputTypes,
+			} {
+				for i, id := range ids {
+					stmt.SetInt64(fmt.Sprintf("$document_%v", i), id)
+				}
+			}
 
 			// first we need to recreate the selection set for every document that we were given in the batch
 
@@ -1230,7 +1240,7 @@ func prepareCollectStatements(conn *sqlite.Conn, count int) (*CollectStatements,
 	}
 
 	// we need a query that looks up every abstract type that's used in
-	// the set of documents. Split into three UNION branches (no OR in JOIN) so
+	// the set of documents. Split into UNION branches (no OR in JOIN) so
 	// SQLite can use indexes on each branch independently.
 	possibleTypes, err := conn.Prepare(fmt.Sprintf(`
     -- Case 1: abstract type appears as the declared type of a field in the selection set
@@ -1258,7 +1268,29 @@ func prepareCollectStatements(conn *sqlite.Conn, count int) (*CollectStatements,
       JOIN selections s ON s.kind = 'inline_fragment' AND s.field_name = pt."type"
       JOIN selection_refs sr ON sr.child_id = s.id
     WHERE sr.document IN %s
-  `, whereIn, whereIn, whereIn))
+
+    UNION
+
+    -- Case 4: named fragment spread in the batch whose type condition is itself abstract
+    -- (needed so merge.go can recognise the fragment's TypeCondition as abstract when
+    -- it synthesises an inline fragment from the spread)
+    SELECT DISTINCT pt."type", pt."member"
+    FROM possible_types pt
+      JOIN documents d ON d.type_condition = pt."type"
+      JOIN selections s ON s.kind = 'fragment' AND s.field_name = d.name
+      JOIN selection_refs sr ON sr.child_id = s.id
+    WHERE sr.document IN %s
+
+    UNION
+
+    -- Case 5: named fragment spread in the batch whose type condition is a concrete member
+    SELECT DISTINCT pt."type", pt."member"
+    FROM possible_types pt
+      JOIN documents d ON d.type_condition = pt."member"
+      JOIN selections s ON s.kind = 'fragment' AND s.field_name = d.name
+      JOIN selection_refs sr ON sr.child_id = s.id
+    WHERE sr.document IN %s
+  `, whereIn, whereIn, whereIn, whereIn, whereIn))
 	if err != nil {
 		return nil, err
 	}
@@ -1354,22 +1386,6 @@ func prepareCollectStatements(conn *sqlite.Conn, count int) (*CollectStatements,
 	}, nil
 }
 
-// bindCollectStatements binds docIDs to the prepared statements. Unused placeholder slots stay
-// NULL (safe in an IN clause — NULL never matches a real document ID). StepStatement calls
-// ClearBindings after each run, so callers only need to bind the slots they use.
-func bindCollectStatements(statements *CollectStatements, docIDs []int64) {
-	for _, stmt := range []*sqlite.Stmt{
-		statements.Search,
-		statements.DocumentVariables,
-		statements.DocumentDirectives,
-		statements.PossibleTypes,
-		statements.InputTypes,
-	} {
-		for i, id := range docIDs {
-			stmt.SetInt64(fmt.Sprintf("$document_%v", i), id)
-		}
-	}
-}
 
 func (s *CollectStatements) Finalize() {
 	s.Search.Finalize()

--- a/packages/houdini-core/plugin/documents/collected/collect.go
+++ b/packages/houdini-core/plugin/documents/collected/collect.go
@@ -122,6 +122,9 @@ func CollectDocuments(
 	// the batch size depends on how many there are. at the maximum, the batch size is nDocuments / nCpus
 	// but if that's above 500, then we should cap it at 500
 	batchSize := max(1, min(500, len(docIDs)/runtime.NumCPU()+1))
+	// round up to the nearest power of two so every batch produces the same SQL string, letting
+	// SQLite reuse the compiled plan across batches (different placeholder counts = different SQL = cache miss)
+	paddedBatchSize := nextPowerOfTwo(batchSize)
 
 	// create a channel to send batches of ids to process
 	batchCh := make(chan []int64, len(docIDs))
@@ -134,7 +137,7 @@ func CollectDocuments(
 	var wg sync.WaitGroup
 	for range runtime.NumCPU() {
 		wg.Add(1)
-		go collectDoc(ctx, db, &wg, batchCh, resultCh, errList, sortKeys)
+		go collectDoc(ctx, db, &wg, batchCh, resultCh, errList, sortKeys, paddedBatchSize)
 	}
 
 	// partition the docIDs into batches and send them to the workers
@@ -197,6 +200,7 @@ func collectDoc(
 	resultCh chan<- collectResult,
 	errs *plugins.ErrorList,
 	sortKeys bool,
+	paddedBatchSize int,
 ) {
 	defer wg.Done()
 
@@ -208,16 +212,21 @@ func collectDoc(
 	}
 	defer db.Put(conn)
 
+	// Prepare statements once per worker with a fixed placeholder count. Every batch produces the
+	// same SQL string so SQLite reuses the compiled plan. StepStatement calls ClearBindings after
+	// each run, so unused slots stay NULL (which never matches real document IDs in an IN clause).
+	statements, err := prepareCollectStatements(conn, paddedBatchSize)
+	if err != nil {
+		errs.Append(plugins.WrapError(err))
+		return
+	}
+	defer statements.Finalize()
+
 	for batch := range docIDs {
 		// wrap each processing in a function so we have a defer context to avoid deadlocking the connection
 		func(ids []int64) {
-			// prepare the search statemetns
-			statements, err := prepareCollectStatements(conn, ids)
-			if err != nil {
-				errs.Append(plugins.WrapError(err))
-				return
-			}
-			defer statements.Finalize()
+			// bind this batch's IDs; unused placeholder slots remain NULL from the previous ClearBindings
+			bindCollectStatements(statements, ids)
 
 			// first we need to recreate the selection set for every document that we were given in the batch
 
@@ -932,11 +941,11 @@ type CollectStatements struct {
 	InputTypes         *sqlite.Stmt
 }
 
-func prepareCollectStatements(conn *sqlite.Conn, docIDs []int64) (*CollectStatements, error) {
-	// we are going to produce a version of the document that looks up a batch of documents
-	// which means we need to produce enough ?'s to create a WHERE IN
-	placeholders := make([]string, len(docIDs))
-	for i := range docIDs {
+func prepareCollectStatements(conn *sqlite.Conn, count int) (*CollectStatements, error) {
+	// Build a fixed-size placeholder list. count is always a power of two so all batches
+	// for this worker share the same SQL string and SQLite reuses the compiled plan.
+	placeholders := make([]string, count)
+	for i := range count {
 		placeholders[i] = fmt.Sprintf("$document_%v", i)
 	}
 
@@ -1336,13 +1345,6 @@ func prepareCollectStatements(conn *sqlite.Conn, docIDs []int64) (*CollectStatem
 		return nil, err
 	}
 
-	// bind each document ID to the variables that were prepared
-	for _, stmt := range []*sqlite.Stmt{search, documentVariables, documentDirectives, possibleTypes, inputTypes} {
-		for i, id := range docIDs {
-			stmt.SetInt64(fmt.Sprintf("$document_%v", i), id)
-		}
-	}
-
 	return &CollectStatements{
 		Search:             search,
 		DocumentVariables:  documentVariables,
@@ -1352,12 +1354,40 @@ func prepareCollectStatements(conn *sqlite.Conn, docIDs []int64) (*CollectStatem
 	}, nil
 }
 
+// bindCollectStatements binds docIDs to the prepared statements. Unused placeholder slots stay
+// NULL (safe in an IN clause — NULL never matches a real document ID). StepStatement calls
+// ClearBindings after each run, so callers only need to bind the slots they use.
+func bindCollectStatements(statements *CollectStatements, docIDs []int64) {
+	for _, stmt := range []*sqlite.Stmt{
+		statements.Search,
+		statements.DocumentVariables,
+		statements.DocumentDirectives,
+		statements.PossibleTypes,
+		statements.InputTypes,
+	} {
+		for i, id := range docIDs {
+			stmt.SetInt64(fmt.Sprintf("$document_%v", i), id)
+		}
+	}
+}
+
 func (s *CollectStatements) Finalize() {
 	s.Search.Finalize()
 	s.DocumentVariables.Finalize()
 	s.DocumentDirectives.Finalize()
 	s.PossibleTypes.Finalize()
 	s.InputTypes.Finalize()
+}
+
+func nextPowerOfTwo(n int) int {
+	if n <= 1 {
+		return 1
+	}
+	p := 1
+	for p < n {
+		p <<= 1
+	}
+	return p
 }
 
 // processArgumentValuesInBatches processes argument values in fixed-size batches

--- a/packages/houdini-core/plugin/documents/loadDocuments.go
+++ b/packages/houdini-core/plugin/documents/loadDocuments.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/vektah/gqlparser/v2/ast"
@@ -41,7 +42,7 @@ func LoadDocuments(
 
 	// start a pool of workers to process the documents
 	wg, _ := errgroup.WithContext(ctx)
-	for range 1 {
+	for range runtime.NumCPU() {
 		wg.Go(func() error {
 			conn, err := db.Take(context.Background())
 			if err != nil {

--- a/packages/houdini-core/plugin/documents/persistentQueries.go
+++ b/packages/houdini-core/plugin/documents/persistentQueries.go
@@ -92,9 +92,10 @@ func GeneratePersistentQueries(
 		return nil, plugins.WrapError(err)
 	}
 
-	// Load all fragment spreads for every document in one flat query, then do
-	// transitive closure in memory. This avoids a recursive UNION CTE with a
-	// large IN clause (400+ items), which SQLite executes slowly.
+	// Load all fragment spreads for every document in one flat query, then
+	// walk the spread graph in memory to find every fragment each document
+	// depends on (directly or through other fragments). This avoids a recursive
+	// UNION CTE with a large IN clause (400+ items), which SQLite executes slowly.
 	docToDirectFrags := make(map[string][]string) // doc_id/name → direct fragment spreads
 	err = sqlitex.Execute(conn, `
 		SELECT d.id, d.name, d.kind, s.field_name

--- a/packages/houdini-core/plugin/documents/persistentQueries.go
+++ b/packages/houdini-core/plugin/documents/persistentQueries.go
@@ -54,7 +54,7 @@ func GeneratePersistentQueries(
 	err = sqlitex.Execute(conn, `
 		SELECT d.id, d.name, d.kind, d.hash, d.printed
 		FROM documents d
-		WHERE  d.hash IS NOT NULL 
+		WHERE  d.hash IS NOT NULL
 			AND d.hash != ''
 			AND d.printed IS NOT NULL
 			AND d.printed != ''
@@ -92,57 +92,27 @@ func GeneratePersistentQueries(
 		return nil, plugins.WrapError(err)
 	}
 
-	// Batch query to get all fragment dependencies for all operations at once
-	operationFragmentDeps := make(map[string][]string)
-
-	// Create a list of operation IDs for the batch query
-	operationIDs := make([]string, 0, len(operations))
-	for _, op := range operations {
-		operationIDs = append(operationIDs, op.ID)
-	}
-
-	// Build the batch query with placeholders
-	placeholders := make([]string, len(operationIDs))
-	for i := range operationIDs {
-		placeholders[i] = "?"
-	}
-	whereIn := "(" + strings.Join(placeholders, ", ") + ")"
-
-	// Execute the batch query to get all fragment dependencies
-	batchQuery := `
-		WITH RECURSIVE fragment_deps AS (
-			-- Direct fragments used by operations
-			SELECT DISTINCT sr.document as operation_id, s.field_name as fragment_name
-			FROM selections s
-			JOIN selection_refs sr ON s.id = sr.child_id
-			WHERE sr.document IN ` + whereIn + ` AND s.kind = 'fragment'
-
-			UNION
-
-			-- Fragments used by other fragments (recursive)
-			SELECT DISTINCT fd.operation_id, s.field_name
-			FROM selections s
-			JOIN selection_refs sr ON s.id = sr.child_id
-			JOIN documents d ON sr.document = d.id
-			JOIN fragment_deps fd ON d.name = fd.fragment_name
-			WHERE s.kind = 'fragment' AND d.kind = 'fragment'
-		)
-		SELECT operation_id, fragment_name FROM fragment_deps
-		ORDER BY operation_id, fragment_name
-	`
-
-	// Convert operation IDs to interface{} for the query
-	args := make([]any, len(operationIDs))
-	for i, id := range operationIDs {
-		args[i] = id
-	}
-
-	err = sqlitex.Execute(conn, batchQuery, &sqlitex.ExecOptions{
-		Args: args,
+	// Load all fragment spreads for every document in one flat query, then do
+	// transitive closure in memory. This avoids a recursive UNION CTE with a
+	// large IN clause (400+ items), which SQLite executes slowly.
+	docToDirectFrags := make(map[string][]string) // doc_id/name → direct fragment spreads
+	err = sqlitex.Execute(conn, `
+		SELECT d.id, d.name, d.kind, s.field_name
+		FROM selections s
+		JOIN selection_refs sr ON s.id = sr.child_id
+		JOIN documents d ON sr.document = d.id
+		WHERE s.kind = 'fragment'
+	`, &sqlitex.ExecOptions{
 		ResultFunc: func(stmt *sqlite.Stmt) error {
-			operationID := stmt.ColumnText(0)
-			fragmentName := stmt.ColumnText(1)
-			operationFragmentDeps[operationID] = append(operationFragmentDeps[operationID], fragmentName)
+			docID := stmt.ColumnText(0)
+			docName := stmt.ColumnText(1)
+			kind := stmt.ColumnText(2)
+			fragName := stmt.ColumnText(3)
+			if kind == "fragment" {
+				docToDirectFrags[docName] = append(docToDirectFrags[docName], fragName)
+			} else {
+				docToDirectFrags[docID] = append(docToDirectFrags[docID], fragName)
+			}
 			return nil
 		},
 	})
@@ -150,19 +120,25 @@ func GeneratePersistentQueries(
 		return nil, plugins.WrapError(err)
 	}
 
-	// Now process each operation using the batched fragment dependencies
+	// For each operation, BFS the fragment dependency graph to find the transitive set.
 	for _, op := range operations {
-		fragmentNames := operationFragmentDeps[op.ID]
-
-		// Get the printed content for all required fragments
-		fragmentDefinitions := []string{}
-		for _, fragmentName := range fragmentNames {
-			// now we can use the named map
-			frag := fragments[fragmentName]
-			if frag == nil {
+		seen := make(map[string]bool)
+		queue := docToDirectFrags[op.ID]
+		for len(queue) > 0 {
+			name := queue[0]
+			queue = queue[1:]
+			if seen[name] {
 				continue
 			}
-			fragmentDefinitions = append(fragmentDefinitions, frag.Printed)
+			seen[name] = true
+			queue = append(queue, docToDirectFrags[name]...)
+		}
+
+		var fragmentDefinitions []string
+		for name := range seen {
+			if frag := fragments[name]; frag != nil {
+				fragmentDefinitions = append(fragmentDefinitions, frag.Printed)
+			}
 		}
 
 		completeGraphQL := op.Printed
@@ -171,10 +147,6 @@ func GeneratePersistentQueries(
 		}
 
 		queryMap[op.Hash] = completeGraphQL
-	}
-
-	if err != nil {
-		return nil, plugins.WrapError(err)
 	}
 
 	if len(queryMap) == 0 {

--- a/packages/houdini-core/plugin/runtime/imperativeCache.go
+++ b/packages/houdini-core/plugin/runtime/imperativeCache.go
@@ -206,7 +206,7 @@ func getDocumentsWithArguments(
 		       CASE WHEN dd.directive IS NOT NULL THEN 1 ELSE 0 END as has_arguments
 		FROM documents d
 		LEFT JOIN document_directives dd ON d.id = dd.document AND dd.directive = 'arguments'
-		WHERE d.visible = 1 
+		WHERE d.visible = 1
 		ORDER BY d.name
 	`, nil, func(stmt *sqlite.Stmt) {
 		doc := DocumentWithArgs{
@@ -260,34 +260,162 @@ func getInputNames(
 	return enumNames, err
 }
 
-type TypeInfo struct {
-	Name string
-	Kind string
+// cacheGenData holds all pre-fetched data needed for cache type def generation,
+// eliminating per-field and per-type database round-trips.
+type cacheGenData struct {
+	typesWithFields map[string]ConcreteTypeWithFields
+	fragmentsByType map[string][]string
+	typeKinds       map[string]string         // typeName → kind (all types, not just OBJECT/INTERFACE)
+	possibleTypes   map[string][]string        // abstract typeName → []member type names
+	fieldArguments  map[string][]FieldArgument // fieldID → []FieldArgument
+	keyFields       map[string][]InputField    // typeName → []InputField
 }
 
-func getTypeInfo(
+func prefetchCacheGenData(
 	ctx context.Context,
 	db plugins.DatabasePool[config.PluginConfig],
-	typeName string,
-) (*TypeInfo, error) {
-	var typeInfo *TypeInfo
+	projectConfig plugins.ProjectConfig,
+) (cacheGenData, error) {
+	var data cacheGenData
+	var err error
 
-	err := db.StepQuery(ctx, `
-		SELECT name, kind
-		FROM types
-		WHERE name = $typeName
-	`, map[string]any{"typeName": typeName}, func(stmt *sqlite.Stmt) {
-		typeInfo = &TypeInfo{
-			Name: stmt.ColumnText(0),
-			Kind: stmt.ColumnText(1),
-		}
-	})
-
-	if typeInfo == nil {
-		return nil, fmt.Errorf("type not found: %s", typeName)
+	data.typesWithFields, err = getTypesWithFields(ctx, db)
+	if err != nil {
+		return data, err
 	}
 
-	return typeInfo, err
+	data.fragmentsByType, err = getFragmentsByType(ctx, db)
+	if err != nil {
+		return data, err
+	}
+
+	data.typeKinds, err = fetchAllTypeKinds(ctx, db)
+	if err != nil {
+		return data, err
+	}
+
+	data.possibleTypes, err = fetchAllPossibleTypes(ctx, db)
+	if err != nil {
+		return data, err
+	}
+
+	data.fieldArguments, err = fetchAllFieldArguments(ctx, db)
+	if err != nil {
+		return data, err
+	}
+
+	data.keyFields, err = buildKeyFieldsMap(ctx, db, projectConfig, data.typesWithFields)
+	if err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+func fetchAllTypeKinds(
+	ctx context.Context,
+	db plugins.DatabasePool[config.PluginConfig],
+) (map[string]string, error) {
+	kinds := make(map[string]string)
+	err := db.StepQuery(ctx, `SELECT name, kind FROM types`, nil, func(stmt *sqlite.Stmt) {
+		kinds[stmt.ColumnText(0)] = stmt.ColumnText(1)
+	})
+	return kinds, err
+}
+
+func fetchAllPossibleTypes(
+	ctx context.Context,
+	db plugins.DatabasePool[config.PluginConfig],
+) (map[string][]string, error) {
+	result := make(map[string][]string)
+	err := db.StepQuery(ctx, `
+		SELECT type, member FROM possible_types ORDER BY type, member
+	`, nil, func(stmt *sqlite.Stmt) {
+		typeName := stmt.ColumnText(0)
+		member := stmt.ColumnText(1)
+		result[typeName] = append(result[typeName], member)
+	})
+	return result, err
+}
+
+func fetchAllFieldArguments(
+	ctx context.Context,
+	db plugins.DatabasePool[config.PluginConfig],
+) (map[string][]FieldArgument, error) {
+	result := make(map[string][]FieldArgument)
+	err := db.StepQuery(ctx, `
+		SELECT tfa.field, tfa.name, tfa.type, tfa.type_modifiers, t.kind
+		FROM type_field_arguments tfa
+		JOIN types t ON tfa.type = t.name
+		ORDER BY tfa.field, tfa.name
+	`, nil, func(stmt *sqlite.Stmt) {
+		fieldID := stmt.ColumnText(0)
+		arg := FieldArgument{
+			Name: stmt.ColumnText(1),
+			Type: stmt.ColumnText(2),
+			Kind: stmt.ColumnText(4),
+		}
+		if stmt.ColumnType(3) == sqlite.TypeText {
+			arg.TypeModifiers = stmt.ColumnText(3)
+		}
+		result[fieldID] = append(result[fieldID], arg)
+	})
+	return result, err
+}
+
+// buildKeyFieldsMap builds a map of typeName → []InputField using already-fetched
+// type field data, so no additional per-type queries are needed.
+func buildKeyFieldsMap(
+	ctx context.Context,
+	db plugins.DatabasePool[config.PluginConfig],
+	projectConfig plugins.ProjectConfig,
+	typesWithFields map[string]ConcreteTypeWithFields,
+) (map[string][]InputField, error) {
+	// Fetch custom key overrides from type_configs in one query
+	typeConfigKeys := make(map[string][]string)
+	err := db.StepQuery(ctx, `SELECT name, keys FROM type_configs`, nil, func(stmt *sqlite.Stmt) {
+		var keys []string
+		json.Unmarshal([]byte(stmt.ColumnText(1)), &keys)
+		if len(keys) > 0 {
+			typeConfigKeys[stmt.ColumnText(0)] = keys
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Build a field lookup: typeName → fieldName → TypeField
+	fieldsByName := make(map[string]map[string]TypeField, len(typesWithFields))
+	for typeName, typeInfo := range typesWithFields {
+		byName := make(map[string]TypeField, len(typeInfo.Fields))
+		for _, f := range typeInfo.Fields {
+			byName[f.Name] = f
+		}
+		fieldsByName[typeName] = byName
+	}
+
+	// For each type, resolve its key fields from the already-fetched data
+	result := make(map[string][]InputField, len(typesWithFields))
+	for typeName := range typesWithFields {
+		keys, hasCustom := typeConfigKeys[typeName]
+		if !hasCustom {
+			keys = projectConfig.DefaultKeys
+		}
+
+		var keyFields []InputField
+		for _, key := range keys {
+			if f, ok := fieldsByName[typeName][key]; ok {
+				keyFields = append(keyFields, InputField{
+					Name:          f.Name,
+					Type:          f.Type,
+					TypeModifiers: f.TypeModifiers,
+				})
+			}
+		}
+		result[typeName] = keyFields
+	}
+
+	return result, nil
 }
 
 func generateCacheTypeDef(
@@ -297,10 +425,16 @@ func generateCacheTypeDef(
 ) (string, error) {
 	var content strings.Builder
 
+	// Pre-fetch all data needed by sub-generators in batch queries
+	data, err := prefetchCacheGenData(ctx, db, projectConfig)
+	if err != nil {
+		return "", err
+	}
+
 	content.WriteString("export declare type CacheTypeDef = {\n")
 
 	// Generate types section
-	typesSection, err := generateTypesSection(ctx, db, projectConfig)
+	typesSection, err := generateTypesSection(projectConfig, data)
 	if err != nil {
 		return "", err
 	}
@@ -340,27 +474,14 @@ func generateCacheTypeDef(
 }
 
 func generateTypesSection(
-	ctx context.Context,
-	db plugins.DatabasePool[config.PluginConfig],
 	projectConfig plugins.ProjectConfig,
+	data cacheGenData,
 ) (string, error) {
 	var content strings.Builder
 
-	// Get all concrete types with their fields in a single query
-	typesWithFields, err := getTypesWithFields(ctx, db)
-	if err != nil {
-		return "", err
-	}
-
-	// Get fragments grouped by type
-	fragmentsByType, err := getFragmentsByType(ctx, db)
-	if err != nil {
-		return "", err
-	}
-
 	// Sort types to ensure __ROOT__ comes first, then alphabetical
 	var sortedTypes []ConcreteTypeWithFields
-	for _, typeInfo := range typesWithFields {
+	for _, typeInfo := range data.typesWithFields {
 		sortedTypes = append(sortedTypes, typeInfo)
 	}
 
@@ -387,15 +508,15 @@ func generateTypesSection(
 
 		content.WriteString(fmt.Sprintf("\t\t\t%s: {\n", typeName))
 
-		// Generate idFields
-		idFields, err := generateIdFields(ctx, db, typeInfo.Name, projectConfig)
+		// Generate idFields from pre-fetched key field data
+		idFields, err := generateIdFieldsFromCache(typeInfo.Name, projectConfig, data.keyFields)
 		if err != nil {
 			return "", err
 		}
 		content.WriteString(fmt.Sprintf("\t\t\t\tidFields: %s;\n", idFields))
 
-		// Generate fields
-		fields, err := generateTypeFieldsFromData(ctx, projectConfig, db, typeInfo.Fields)
+		// Generate fields using pre-fetched data (no per-field DB calls)
+		fields, err := generateTypeFieldsFromData(projectConfig, data, typeInfo.Fields)
 		if err != nil {
 			return "", err
 		}
@@ -405,84 +526,7 @@ func generateTypesSection(
 
 		// Generate fragments
 		fragments := "[]"
-		if typeFragments, exists := fragmentsByType[typeInfo.Name]; exists {
-			fragments = fmt.Sprintf("[%s]", strings.Join(typeFragments, ", "))
-		}
-		content.WriteString(fmt.Sprintf("\t\t\t\tfragments: %s;\n", fragments))
-
-		content.WriteString("\t\t\t};\n")
-	}
-
-	return content.String(), nil
-}
-
-// generateTypesSectionWithKeyFields is an optimized version that uses pre-fetched key fields
-func generateTypesSectionWithKeyFields(
-	ctx context.Context,
-	db plugins.DatabasePool[config.PluginConfig],
-	projectConfig plugins.ProjectConfig,
-	allKeyFields map[string][]InputField,
-) (string, error) {
-	var content strings.Builder
-
-	// Get all concrete types with their fields in a single query
-	typesWithFields, err := getTypesWithFields(ctx, db)
-	if err != nil {
-		return "", err
-	}
-
-	// Get fragments grouped by type
-	fragmentsByType, err := getFragmentsByType(ctx, db)
-	if err != nil {
-		return "", err
-	}
-
-	// Sort types to ensure __ROOT__ comes first, then alphabetical
-	var sortedTypes []ConcreteTypeWithFields
-	for _, typeInfo := range typesWithFields {
-		sortedTypes = append(sortedTypes, typeInfo)
-	}
-
-	sort.Slice(sortedTypes, func(i, j int) bool {
-		iIsQuery := sortedTypes[i].Operation != nil && *sortedTypes[i].Operation == "query"
-		jIsQuery := sortedTypes[j].Operation != nil && *sortedTypes[j].Operation == "query"
-
-		if iIsQuery && !jIsQuery {
-			return true
-		}
-		if !iIsQuery && jIsQuery {
-			return false
-		}
-		return sortedTypes[i].Name < sortedTypes[j].Name
-	})
-
-	for _, typeInfo := range sortedTypes {
-		typeName := typeInfo.Name
-
-		// Use __ROOT__ for Query type
-		if typeInfo.Operation != nil && *typeInfo.Operation == "query" {
-			typeName = "__ROOT__"
-		}
-
-		content.WriteString(fmt.Sprintf("\t\t\t%s: {\n", typeName))
-
-		// Generate idFields using pre-fetched data
-		idFields, err := generateIdFieldsFromCache(typeInfo.Name, projectConfig, allKeyFields)
-		if err != nil {
-			return "", err
-		}
-		content.WriteString(fmt.Sprintf("\t\t\t\tidFields: %s;\n", idFields))
-
-		// Generate fields
-		fields, err := generateTypeFieldsFromData(ctx, projectConfig, db, typeInfo.Fields)
-		if err != nil {
-			return "", err
-		}
-		content.WriteString(fmt.Sprintf("\t\t\t\tfields: %s;\n", fields))
-
-		// Generate fragments
-		fragments := "[]"
-		if typeFragments, exists := fragmentsByType[typeInfo.Name]; exists {
+		if typeFragments, exists := data.fragmentsByType[typeInfo.Name]; exists {
 			fragments = fmt.Sprintf("[%s]", strings.Join(typeFragments, ", "))
 		}
 		content.WriteString(fmt.Sprintf("\t\t\t\tfragments: %s;\n", fragments))
@@ -555,181 +599,7 @@ func getTypesWithFields(
 	return typesWithFields, err
 }
 
-func generateIdFields(
-	ctx context.Context,
-	db plugins.DatabasePool[config.PluginConfig],
-	typeName string,
-	projectConfig plugins.ProjectConfig,
-) (string, error) {
-	// For __ROOT__ (Query type), return empty object
-	if typeName == "Query" {
-		return "{}", nil
-	}
-
-	// Get key fields for this type
-	keyFields, err := getKeyFields(ctx, db, typeName, projectConfig)
-	if err != nil {
-		return "", err
-	}
-
-	if len(keyFields) == 0 {
-		return "never", nil
-	}
-
-	var fields []string
-	for _, field := range keyFields {
-		tsType, err := typescript.ConvertToTypeScriptType(
-			projectConfig,
-			"",
-			field.Type,
-			field.TypeModifiers,
-			false, // isInput = false for cache key fields
-		)
-		if err != nil {
-			return "", err
-		}
-		// Remove nullability for ID fields
-		tsType = strings.ReplaceAll(tsType, " | null | undefined", "")
-		fields = append(fields, fmt.Sprintf("\n\t\t\t\t\t%s: %s;", field.Name, tsType))
-	}
-
-	return fmt.Sprintf("{%s\n\t\t\t\t}", strings.Join(fields, "")), nil
-}
-
-func getKeyFields(
-	ctx context.Context,
-	db plugins.DatabasePool[config.PluginConfig],
-	typeName string,
-	projectConfig plugins.ProjectConfig,
-) ([]InputField, error) {
-	var keyFields []InputField
-
-	// First try to get type-specific keys
-	var keys []string
-	err := db.StepQuery(ctx, `
-		SELECT keys
-		FROM type_configs
-		WHERE name = $typeName
-	`, map[string]any{"typeName": typeName}, func(stmt *sqlite.Stmt) {
-		keysJSON := stmt.ColumnText(0)
-		json.Unmarshal([]byte(keysJSON), &keys)
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// If no type-specific keys, use default keys
-	if len(keys) == 0 {
-		keys = projectConfig.DefaultKeys
-	}
-
-	// Get field information for each key
-	for _, key := range keys {
-		err := db.StepQuery(ctx, `
-			SELECT name, type, type_modifiers
-			FROM type_fields
-			WHERE parent = $typeName AND name = $key AND internal = false
-		`, map[string]any{"typeName": typeName, "key": key}, func(stmt *sqlite.Stmt) {
-			field := InputField{
-				Name: stmt.ColumnText(0),
-				Type: stmt.ColumnText(1),
-			}
-			if stmt.ColumnType(2) == sqlite.TypeText {
-				field.TypeModifiers = stmt.ColumnText(2)
-			}
-			keyFields = append(keyFields, field)
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return keyFields, nil
-}
-
-// getAllKeyFields fetches all key fields for all types in a single batch query to avoid O(n²) behavior
-func getAllKeyFields(
-	ctx context.Context,
-	db plugins.DatabasePool[config.PluginConfig],
-	projectConfig plugins.ProjectConfig,
-) (map[string][]InputField, error) {
-	allKeyFields := make(map[string][]InputField)
-
-	// First, get all type configs with their keys
-	typeKeys := make(map[string][]string)
-	err := db.StepQuery(ctx, `
-		SELECT name, keys
-		FROM type_configs
-	`, nil, func(stmt *sqlite.Stmt) {
-		typeName := stmt.ColumnText(0)
-		keysJSON := stmt.ColumnText(1)
-		var keys []string
-		json.Unmarshal([]byte(keysJSON), &keys)
-		typeKeys[typeName] = keys
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Get all types that might need key fields
-	allTypes := make(map[string]bool)
-	err = db.StepQuery(ctx, `
-		SELECT DISTINCT parent
-		FROM type_fields
-		WHERE internal = false
-	`, nil, func(stmt *sqlite.Stmt) {
-		typeName := stmt.ColumnText(0)
-		allTypes[typeName] = true
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// For each type, determine its keys (either from type_configs or default)
-	typeToKeys := make(map[string][]string)
-	for typeName := range allTypes {
-		if keys, exists := typeKeys[typeName]; exists && len(keys) > 0 {
-			typeToKeys[typeName] = keys
-		} else {
-			typeToKeys[typeName] = projectConfig.DefaultKeys
-		}
-	}
-
-	// Now batch query all the key fields for all types
-	for typeName, keys := range typeToKeys {
-		if len(keys) == 0 {
-			continue
-		}
-
-		// Query each key field individually (simpler than building dynamic IN clause)
-		var keyFields []InputField
-		for _, key := range keys {
-			err := db.StepQuery(ctx, `
-				SELECT name, type, type_modifiers
-				FROM type_fields
-				WHERE parent = $typeName AND name = $key AND internal = false
-			`, map[string]any{"typeName": typeName, "key": key}, func(stmt *sqlite.Stmt) {
-				field := InputField{
-					Name: stmt.ColumnText(0),
-					Type: stmt.ColumnText(1),
-				}
-				if stmt.ColumnType(2) == sqlite.TypeText {
-					field.TypeModifiers = stmt.ColumnText(2)
-				}
-				keyFields = append(keyFields, field)
-			})
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		allKeyFields[typeName] = keyFields
-	}
-
-	return allKeyFields, nil
-}
-
-// generateIdFieldsFromCache generates idFields using pre-fetched key field data
+// generateIdFieldsFromCache generates idFields using pre-fetched key field data.
 func generateIdFieldsFromCache(
 	typeName string,
 	projectConfig plugins.ProjectConfig,
@@ -767,25 +637,19 @@ func generateIdFieldsFromCache(
 }
 
 func generateTypeFieldsFromData(
-	ctx context.Context,
 	projectConfig plugins.ProjectConfig,
-	db plugins.DatabasePool[config.PluginConfig],
+	data cacheGenData,
 	fields []TypeField,
 ) (string, error) {
 	var content strings.Builder
 
 	for _, field := range fields {
-		// Generate field type
-		fieldType, err := generateFieldType(ctx, projectConfig, db, field)
+		fieldType, err := generateFieldType(projectConfig, data, field)
 		if err != nil {
 			return "", err
 		}
 
-		// Generate field arguments
-		fieldArgs, err := generateFieldArguments(ctx, db, projectConfig, field.ID)
-		if err != nil {
-			return "", err
-		}
+		fieldArgs := generateFieldArgumentsFromCache(projectConfig, data.fieldArguments[field.ID])
 
 		content.WriteString(fmt.Sprintf("\t\t\t\t\t%s: {\n", field.Name))
 		content.WriteString(fmt.Sprintf("\t\t\t\t\t\ttype: %s;\n", fieldType))
@@ -804,88 +668,43 @@ type TypeField struct {
 }
 
 func generateFieldType(
-	ctx context.Context,
 	config plugins.ProjectConfig,
-	db plugins.DatabasePool[config.PluginConfig],
+	data cacheGenData,
 	field TypeField,
 ) (string, error) {
-	// Get the base type information
-	typeInfo, err := getTypeInfo(ctx, db, field.Type)
-	if err != nil {
-		return "", err
+	kind, ok := data.typeKinds[field.Type]
+	if !ok {
+		return "any", nil
 	}
 
 	var baseType string
-	switch typeInfo.Kind {
+	switch kind {
 	case "SCALAR":
-		baseType = typescript.ConvertScalarType(
-			config,
-			field.Type,
-			false,
-		) // isInput = false for cache field types
+		baseType = typescript.ConvertScalarType(config, field.Type, false)
 	case "ENUM":
 		baseType = fmt.Sprintf("%s$options", field.Type)
 	case "OBJECT":
 		baseType = fmt.Sprintf("Record<CacheTypeDef, \"%s\">", field.Type)
 	case "INTERFACE", "UNION":
-		// Get possible types for abstract types
-		possibleTypes, err := getPossibleTypes(ctx, db, field.Type)
-		if err != nil {
-			return "", err
-		}
+		members := data.possibleTypes[field.Type]
 		var recordTypes []string
-		for _, possibleType := range possibleTypes {
-			recordTypes = append(
-				recordTypes,
-				fmt.Sprintf("Record<CacheTypeDef, \"%s\">", possibleType),
-			)
+		for _, m := range members {
+			recordTypes = append(recordTypes, fmt.Sprintf("Record<CacheTypeDef, \"%s\">", m))
 		}
 		baseType = strings.Join(recordTypes, " | ")
 	default:
 		baseType = "any"
 	}
 
-	// Apply type modifiers
-	return typescript.ApplyTypeModifiers(
-		baseType,
-		field.TypeModifiers,
-		false,
-	), nil // Output type (cache field)
+	return typescript.ApplyTypeModifiers(baseType, field.TypeModifiers, false), nil
 }
 
-func getPossibleTypes(
-	ctx context.Context,
-	db plugins.DatabasePool[config.PluginConfig],
-	typeName string,
-) ([]string, error) {
-	var possibleTypes []string
-
-	err := db.StepQuery(ctx, `
-		SELECT member
-		FROM possible_types
-		WHERE type = $typeName
-		ORDER BY member
-	`, map[string]any{"typeName": typeName}, func(stmt *sqlite.Stmt) {
-		possibleTypes = append(possibleTypes, stmt.ColumnText(0))
-	})
-
-	return possibleTypes, err
-}
-
-func generateFieldArguments(
-	ctx context.Context,
-	db plugins.DatabasePool[config.PluginConfig],
+func generateFieldArgumentsFromCache(
 	projectConfig plugins.ProjectConfig,
-	fieldID string,
-) (string, error) {
-	// Get arguments for this field
-	args, err := getFieldArguments(ctx, db, fieldID)
-	if err != nil {
-		return "", err
-	}
-
+	args []FieldArgument,
+) string {
 	if len(args) == 0 {
-		return "never", nil
+		return "never"
 	}
 
 	var argStrings []string
@@ -895,10 +714,10 @@ func generateFieldArguments(
 			arg.Kind,
 			arg.Type,
 			arg.TypeModifiers,
-			true, // isInput = true for field arguments (these are inputs to GraphQL operations)
+			true,
 		)
 		if err != nil {
-			return "", err
+			continue
 		}
 
 		optional := ""
@@ -912,42 +731,7 @@ func generateFieldArguments(
 		)
 	}
 
-	return fmt.Sprintf("{%s\n\t\t\t\t\t\t}", strings.Join(argStrings, "")), nil
-}
-
-type FieldArgument struct {
-	Name          string
-	Type          string
-	Kind          string
-	TypeModifiers string
-}
-
-func getFieldArguments(
-	ctx context.Context,
-	db plugins.DatabasePool[config.PluginConfig],
-	fieldID string,
-) ([]FieldArgument, error) {
-	var args []FieldArgument
-
-	err := db.StepQuery(ctx, `
-		SELECT type_field_arguments.name, type, type_modifiers, types.kind
-		FROM type_field_arguments
-		JOIN types on type_field_arguments.type = types.name
-		WHERE field = $fieldID
-		ORDER BY type_field_arguments.name
-	`, map[string]any{"fieldID": fieldID}, func(stmt *sqlite.Stmt) {
-		arg := FieldArgument{
-			Name: stmt.ColumnText(0),
-			Type: stmt.ColumnText(1),
-			Kind: stmt.ColumnText(3),
-		}
-		if stmt.ColumnType(2) == sqlite.TypeText {
-			arg.TypeModifiers = stmt.ColumnText(2)
-		}
-		args = append(args, arg)
-	})
-
-	return args, err
+	return fmt.Sprintf("{%s\n\t\t\t\t\t\t}", strings.Join(argStrings, ""))
 }
 
 func getFragmentsByType(
@@ -1179,6 +963,11 @@ func generateQueriesSection(
 	return fmt.Sprintf("[%s]", strings.Join(queryTuples, ", ")), nil
 }
 
+type TypeInfo struct {
+	Name string
+	Kind string
+}
+
 type InputType struct {
 	Name string
 }
@@ -1186,5 +975,12 @@ type InputType struct {
 type InputField struct {
 	Name          string
 	Type          string
+	TypeModifiers string
+}
+
+type FieldArgument struct {
+	Name          string
+	Type          string
+	Kind          string
 	TypeModifiers string
 }

--- a/packages/houdini-svelte/plugin/generate/stores.go
+++ b/packages/houdini-svelte/plugin/generate/stores.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/spf13/afero"
 
@@ -34,7 +36,6 @@ func GenerateStores(
 	if err != nil {
 		return nil, err
 	}
-	defer db.Put(conn)
 
 	errs := &plugins.ErrorList{}
 
@@ -71,11 +72,10 @@ func GenerateStores(
 		ORDER BY d.name ASC
 	`)
 	if err != nil {
+		db.Put(conn)
 		return nil, err
 	}
-	defer stmt.Finalize()
 
-	var generatedFiles []string
 	storesDir := filepath.Join(projectConfig.PluginDirectory("houdini-svelte"), "stores")
 
 	// Make sure the stores directory exists
@@ -84,103 +84,111 @@ func GenerateStores(
 		return nil, fmt.Errorf("failed to create stores directory: %w", err)
 	}
 
-	var indexValue strings.Builder
-
-	// Execute the query and generate stores
+	// Collect all document rows first so we can release the DB connection before
+	// spawning workers (each worker needs its own connection for other queries).
+	type storeDoc struct {
+		name              string
+		kind              string
+		variablesRequired bool
+		refetchMethod     string
+	}
+	var docs []storeDoc
 	err = db.StepStatement(ctx, stmt, func() {
-		name := stmt.ColumnText(0)
-		kind := stmt.ColumnText(1)
-		variablesRequired := stmt.ColumnBool(2)
-		refetchMethod := stmt.ColumnText(3)
-
-		storeName := name + "Store"
-
-		fmt.Fprintf(&indexValue, "export * from './%s.js'\n", name)
-
-		var storeContent string
-		var err error
-
-		switch kind {
-		case "query":
-			storeContent, err = generateQueryStore(
-				pluginConfig,
-				name,
-				storeName,
-				variablesRequired,
-				refetchMethod,
-			)
-		case "mutation":
-			storeContent, err = generateMutationStore(pluginConfig, name, storeName)
-		case "subscription":
-			storeContent, err = generateSubscriptionStore(pluginConfig, name, storeName)
-		case "fragment":
-			storeContent, err = generateFragmentStore(
-				pluginConfig,
-				name,
-				storeName,
-				refetchMethod,
-				variablesRequired,
-			)
-		default:
-			errs.Append(plugins.WrapError(err))
-			return // Skip unknown kinds
-		}
-		if errs.Len() > 0 {
-			errs.Append(plugins.WrapError(err))
-			return
-		}
-
-		if err != nil {
-			errs.Append(plugins.WrapError(err))
-			return
-		}
-		// Write the store file
-		storePath := filepath.Join(storesDir, name+".ts")
-
-		var currentValue []byte
-		if exists, err := afero.Exists(fs, storePath); err == nil && exists {
-			currentValue, err = afero.ReadFile(fs, storePath)
-			if err != nil {
-				errs.Append(plugins.WrapError(err))
-				return
-			}
-		}
-
-		if string(currentValue) != storeContent {
-			err = afero.WriteFile(fs, storePath, []byte(storeContent), 0644)
-			if err != nil {
-				return
-			}
-
-			generatedFiles = append(generatedFiles, storePath)
-		}
+		docs = append(docs, storeDoc{
+			name:              stmt.ColumnText(0),
+			kind:              stmt.ColumnText(1),
+			variablesRequired: stmt.ColumnBool(2),
+			refetchMethod:     stmt.ColumnText(3),
+		})
 	})
 	if err != nil {
 		return nil, err
+	}
+	// Release the connection before the parallel section.
+	stmt.Finalize()
+	db.Put(conn)
+
+	// Fan out: generate + write each store file in parallel.
+	type storeResult struct {
+		storePath string
+		changed   bool
+		err       error
+	}
+	resultCh := make(chan storeResult, len(docs))
+	docCh := make(chan storeDoc, len(docs))
+
+	var wg sync.WaitGroup
+	for range runtime.NumCPU() {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for doc := range docCh {
+				storeName := doc.name + "Store"
+				var content string
+				var genErr error
+				switch doc.kind {
+				case "query":
+					content, genErr = generateQueryStore(pluginConfig, doc.name, storeName, doc.variablesRequired, doc.refetchMethod)
+				case "mutation":
+					content, genErr = generateMutationStore(pluginConfig, doc.name, storeName)
+				case "subscription":
+					content, genErr = generateSubscriptionStore(pluginConfig, doc.name, storeName)
+				case "fragment":
+					content, genErr = generateFragmentStore(pluginConfig, doc.name, storeName, doc.refetchMethod, doc.variablesRequired)
+				default:
+					// unknown kind — skip without error
+					continue
+				}
+				if genErr != nil {
+					resultCh <- storeResult{err: genErr}
+					continue
+				}
+				storePath := filepath.Join(storesDir, doc.name+".ts")
+				if existing, readErr := afero.ReadFile(fs, storePath); readErr == nil && string(existing) == content {
+					resultCh <- storeResult{storePath: storePath, changed: false}
+					continue
+				}
+				if writeErr := afero.WriteFile(fs, storePath, []byte(content), 0644); writeErr != nil {
+					resultCh <- storeResult{err: writeErr}
+					continue
+				}
+				resultCh <- storeResult{storePath: storePath, changed: true}
+			}
+		}()
+	}
+
+	for _, doc := range docs {
+		docCh <- doc
+	}
+	close(docCh)
+	wg.Wait()
+	close(resultCh)
+
+	var generatedFiles []string
+	for res := range resultCh {
+		if res.err != nil {
+			errs.Append(plugins.WrapError(res.err))
+			continue
+		}
+		if res.changed {
+			generatedFiles = append(generatedFiles, res.storePath)
+		}
 	}
 	if errs.Len() > 0 {
 		return nil, errs
 	}
 
-	// we have everything we need to write the index file
+	// Build the index file from the ordered docs slice (query was ORDER BY name ASC).
+	var indexValue strings.Builder
+	for _, doc := range docs {
+		fmt.Fprintf(&indexValue, "export * from './%s.js'\n", doc.name)
+	}
 	indexFilePath := filepath.Join(storesDir, "index.ts")
 	indexContent := indexValue.String()
-
-	var currentValue []byte
-	if exists, err := afero.Exists(fs, indexFilePath); err == nil && exists {
-		currentValue, err = afero.ReadFile(fs, indexFilePath)
-		if err != nil {
-			errs.Append(plugins.WrapError(err))
-			return nil, err
+	if existing, readErr := afero.ReadFile(fs, indexFilePath); readErr != nil || string(existing) != indexContent {
+		if writeErr := afero.WriteFile(fs, indexFilePath, []byte(indexContent), 0644); writeErr != nil {
+			return nil, writeErr
 		}
-	}
-
-	if string(currentValue) != indexContent {
-		err = afero.WriteFile(fs, indexFilePath, []byte(indexContent), 0644)
-		if err != nil {
-			return nil, err
-		}
-
 		generatedFiles = append(generatedFiles, indexFilePath)
 	}
 

--- a/packages/houdini/src/lib/codegen.ts
+++ b/packages/houdini/src/lib/codegen.ts
@@ -521,6 +521,24 @@ export async function run_pipeline(
 			opts.parallel_safe = true
 		}
 
+		// GenerateDocuments and GenerateRuntime have no data dependency on each other —
+		// both read from the DB which is fully settled after AfterValidate. Run them
+		// concurrently when they appear consecutively in the active range.
+		if (
+			hook === 'GenerateDocuments' &&
+			i + 1 <= endIndex &&
+			PIPELINE_HOOKS[i + 1] === 'GenerateRuntime'
+		) {
+			const [gdResult, grResult] = await Promise.all([
+				trigger_hook('GenerateDocuments', { task_id, parallel_safe: true }),
+				trigger_hook('GenerateRuntime', { task_id }),
+			])
+			results['GenerateDocuments'] = gdResult
+			results['GenerateRuntime'] = grResult
+			i++ // GenerateRuntime already handled
+			continue
+		}
+
 		results[hook] = await trigger_hook(hook, opts)
 	}
 

--- a/packages/houdini/src/lib/database.ts
+++ b/packages/houdini/src/lib/database.ts
@@ -386,65 +386,91 @@ CREATE TABLE IF NOT EXISTS document_dependencies (
 -- Indices
 -----------------------------------------------------------
 
+-- component_fields
 CREATE INDEX IF NOT EXISTS idx_component_fields_type_fields ON component_fields(type_field);
+
+-- discovered_lists
 CREATE INDEX IF NOT EXISTS idx_discovered_lists_document ON discovered_lists(document);
 CREATE INDEX IF NOT EXISTS idx_discovered_lists_node ON discovered_lists(node);
 CREATE INDEX IF NOT EXISTS idx_discovered_lists_list_field ON discovered_lists(list_field);
-CREATE INDEX IF NOT EXISTS idx_discovered_lists_connection ON discovered_lists(connection);
-CREATE INDEX IF NOT EXISTS idx_document_directive_arguments_value on document_directive_arguments(value);
-CREATE INDEX IF NOT EXISTS idx_type_field_arguments_id ON type_field_arguments(id);
-CREATE INDEX IF NOT EXISTS idx_type_fields_id ON type_fields(id);
+-- note: no index on discovered_lists(connection) — boolean column, ~2 distinct values
+
+-- types
 CREATE INDEX IF NOT EXISTS idx_types_kind_operation ON types(kind, operation);
+-- note: no index on types(name) — covered by PRIMARY KEY UNIQUE
+
+-- documents
 CREATE INDEX IF NOT EXISTS idx_documents_kind ON documents(kind);
 CREATE INDEX IF NOT EXISTS idx_documents_type_condition ON documents(type_condition);
-CREATE INDEX IF NOT EXISTS idx_raw_documents_current_task ON raw_documents(current_task);
 CREATE INDEX IF NOT EXISTS idx_documents_raw_document ON documents(raw_document);
+CREATE INDEX IF NOT EXISTS idx_documents_name_kind ON documents(name, kind);
+
+-- raw_documents
+CREATE INDEX IF NOT EXISTS idx_raw_documents_current_task ON raw_documents(current_task);
+
+-- selections
+CREATE INDEX IF NOT EXISTS idx_selections_type ON selections(type);
+CREATE INDEX IF NOT EXISTS idx_selections_alias ON selections(alias);
+CREATE INDEX IF NOT EXISTS idx_selections_field_name_kind ON selections(field_name, kind);
+
+-- selection_refs: composite covers document-only lookups, so no separate single-column index needed
 CREATE INDEX IF NOT EXISTS idx_selection_refs_parent_id ON selection_refs(parent_id);
 CREATE INDEX IF NOT EXISTS idx_selection_refs_child_id ON selection_refs(child_id);
-CREATE INDEX IF NOT EXISTS idx_selection_refs_document ON selection_refs(document);
--- Composite index for common query patterns in CollectDocuments
 CREATE INDEX IF NOT EXISTS idx_selection_refs_document_parent_id ON selection_refs(document, parent_id);
+
+-- selection_directives / selection_directive_arguments / selection_arguments
+CREATE INDEX IF NOT EXISTS idx_selection_directives_selection ON selection_directives(selection_id);
+CREATE INDEX IF NOT EXISTS idx_selection_directives_directive ON selection_directives(directive);
+CREATE INDEX IF NOT EXISTS idx_selection_directive_arguments_parent_name ON selection_directive_arguments(parent, name);
+-- note: no index on selection_directive_arguments(parent) alone — covered by (parent,name) composite
+CREATE INDEX IF NOT EXISTS idx_selection_directive_arguments_value ON selection_directive_arguments(value);
+CREATE INDEX IF NOT EXISTS idx_selection_arguments_selection ON selection_arguments(selection_id);
+CREATE INDEX IF NOT EXISTS idx_selection_arguments_value ON selection_arguments(value);
+
+-- type_fields / type_field_arguments
+-- note: no index on type_fields(id) or type_field_arguments(id) — covered by their TEXT PRIMARY KEYs
+CREATE INDEX IF NOT EXISTS idx_type_fields_parent ON type_fields(parent);
+CREATE INDEX IF NOT EXISTS idx_type_fields_name ON type_fields(name);
+CREATE INDEX IF NOT EXISTS idx_type_configs_name ON type_configs(name);
+
+-- possible_types
+-- note: no index on possible_types(type) — covered by PRIMARY KEY(type,member) leading column
+CREATE INDEX IF NOT EXISTS idx_possible_types_member ON possible_types(member);
+
+-- enum_values
+-- note: no index on enum_values(parent) or (parent,value) — both covered by UNIQUE(parent,value)
+
+-- document_directives / document_directive_arguments
+CREATE INDEX IF NOT EXISTS idx_document_directives_document ON document_directives(document);
+CREATE INDEX IF NOT EXISTS idx_document_directives_directive ON document_directives(directive);
+CREATE INDEX IF NOT EXISTS idx_document_directive_arguments_parent_name ON document_directive_arguments(parent, name);
+-- note: no index on document_directive_arguments(parent) alone — covered by (parent,name) composite
+CREATE INDEX IF NOT EXISTS idx_document_directive_arguments_value on document_directive_arguments(value);
+
+-- document_variables
+-- note: no index on document_variables(document,name) — covered by UNIQUE(document,name)
+CREATE INDEX IF NOT EXISTS idx_document_variables_document_id ON document_variables(document, id);
+CREATE INDEX IF NOT EXISTS idx_document_variables_document_type_modifiers_default ON document_variables(document, type_modifiers, default_value);
+
+-- document_variable_directives / document_variable_directive_arguments
 CREATE INDEX IF NOT EXISTS idx_document_variable_directives_parent ON document_variable_directives(parent);
 CREATE INDEX IF NOT EXISTS idx_document_variable_directives_directive ON document_variable_directives(directive);
 CREATE INDEX IF NOT EXISTS idx_document_variable_directive_arguments_parent ON document_variable_directive_arguments(parent);
-CREATE INDEX IF NOT EXISTS idx_selections_type ON selections(type);
-CREATE INDEX IF NOT EXISTS idx_document_directives_document ON document_directives(document);
-CREATE INDEX IF NOT EXISTS idx_document_directives_directive ON document_directives(directive);
-CREATE INDEX IF NOT EXISTS idx_document_directive_arguments_parent ON document_directive_arguments(parent);
-CREATE INDEX IF NOT EXISTS idx_document_directive_arguments_parent_name ON document_directive_arguments(parent, name);
-CREATE INDEX IF NOT EXISTS idx_type_fields_parent ON type_fields(parent);
-CREATE INDEX IF NOT EXISTS idx_selections_alias ON selections(alias);
-CREATE INDEX IF NOT EXISTS idx_selection_directives_selection ON selection_directives(selection_id);
-CREATE INDEX IF NOT EXISTS idx_selection_arguments_selection ON selection_arguments(selection_id);
-CREATE INDEX IF NOT EXISTS idx_selection_directive_args_parent ON selection_directive_arguments(parent);
-CREATE INDEX IF NOT EXISTS idx_possible_types_type ON possible_types(type);
-CREATE INDEX IF NOT EXISTS idx_possible_types_member ON possible_types(member);
-CREATE INDEX IF NOT EXISTS idx_enum_values_parent ON enum_values(parent);
-CREATE INDEX IF NOT EXISTS idx_type_fields_name ON type_fields(name);
-CREATE INDEX IF NOT EXISTS idx_type_configs_name ON type_configs(name);
-CREATE INDEX IF NOT EXISTS idx_argument_value_children_parent ON argument_value_children(parent);
-CREATE INDEX IF NOT EXISTS idx_argument_values_kind_raw ON argument_values(kind, raw);
-CREATE INDEX IF NOT EXISTS idx_document_variables_document_name ON document_variables(document, name);
-CREATE INDEX IF NOT EXISTS idx_selection_arguments_value ON selection_arguments(value);
-CREATE INDEX IF NOT EXISTS idx_selection_directive_arguments_parent_name ON selection_directive_arguments(parent, name);
-CREATE INDEX IF NOT EXISTS idx_selection_directives_directive ON selection_directives(directive);
-CREATE INDEX IF NOT EXISTS idx_argument_values_document ON argument_values(document);
-CREATE INDEX IF NOT EXISTS idx_types_name ON types(name);
-CREATE INDEX IF NOT EXISTS idx_enum_values_parent_value ON enum_values(parent, value);
-CREATE INDEX IF NOT EXISTS idx_selection_directive_arguments_value ON selection_directive_arguments(value);
-CREATE INDEX IF NOT EXISTS idx_argument_value_children_value ON argument_value_children(value);
-CREATE INDEX IF NOT EXISTS idx_document_dependency_document on document_dependencies(document);
+
+-- document_dependencies
+-- note: no index on document_dependencies(document) — covered by UNIQUE(document,depends_on) leading column
 CREATE INDEX IF NOT EXISTS idx_document_dependency_depends_on on document_dependencies(depends_on);
--- Performance optimization: composite index for argument_values joins with documents
+
+-- argument_values: composite (document,id) covers document-only lookups
+-- note: no separate index on argument_values(document) alone
+CREATE INDEX IF NOT EXISTS idx_argument_values_kind_raw ON argument_values(kind, raw);
 CREATE INDEX IF NOT EXISTS idx_argument_values_document_id ON argument_values(document, id);
--- Additional performance optimizations for the recursive CTE query
-CREATE INDEX IF NOT EXISTS idx_argument_value_children_parent_value ON argument_value_children(parent, value);
--- Complex query optimizations based on query analysis
-CREATE INDEX IF NOT EXISTS idx_selections_field_name_kind ON selections(field_name, kind);
-CREATE INDEX IF NOT EXISTS idx_documents_name_kind ON documents(name, kind);
-CREATE INDEX IF NOT EXISTS idx_document_variables_document_id ON document_variables(document, id);
 CREATE INDEX IF NOT EXISTS idx_argument_values_expected_type_document ON argument_values(expected_type, document);
-CREATE INDEX IF NOT EXISTS idx_document_variables_document_type_modifiers_default ON document_variables(document, type_modifiers, default_value);
+
+-- argument_value_children: composite (parent,value) covers parent-only lookups
+-- note: no separate index on argument_value_children(parent) alone
+CREATE INDEX IF NOT EXISTS idx_argument_value_children_parent_value ON argument_value_children(parent, value);
+CREATE INDEX IF NOT EXISTS idx_argument_value_children_value ON argument_value_children(value);
 `
 
 export async function write_config(

--- a/packages/houdini/src/lib/database.ts
+++ b/packages/houdini/src/lib/database.ts
@@ -415,6 +415,7 @@ CREATE INDEX IF NOT EXISTS idx_selections_field_name_kind ON selections(field_na
 
 -- selection_refs: composite covers document-only lookups, so no separate single-column index needed
 CREATE INDEX IF NOT EXISTS idx_selection_refs_parent_id ON selection_refs(parent_id);
+
 CREATE INDEX IF NOT EXISTS idx_selection_refs_child_id ON selection_refs(child_id);
 CREATE INDEX IF NOT EXISTS idx_selection_refs_document_parent_id ON selection_refs(document, parent_id);
 
@@ -424,6 +425,9 @@ CREATE INDEX IF NOT EXISTS idx_selection_directives_directive ON selection_direc
 CREATE INDEX IF NOT EXISTS idx_selection_directive_arguments_parent_name ON selection_directive_arguments(parent, name);
 -- note: no index on selection_directive_arguments(parent) alone — covered by (parent,name) composite
 CREATE INDEX IF NOT EXISTS idx_selection_directive_arguments_value ON selection_directive_arguments(value);
+-- document FK on selection_directive_arguments and selection_arguments: used in WHERE/JOIN in CollectDocuments
+CREATE INDEX IF NOT EXISTS idx_selection_directive_arguments_document ON selection_directive_arguments(document);
+CREATE INDEX IF NOT EXISTS idx_selection_arguments_document ON selection_arguments(document);
 CREATE INDEX IF NOT EXISTS idx_selection_arguments_selection ON selection_arguments(selection_id);
 CREATE INDEX IF NOT EXISTS idx_selection_arguments_value ON selection_arguments(value);
 
@@ -437,6 +441,10 @@ CREATE INDEX IF NOT EXISTS idx_type_configs_name ON type_configs(name);
 -- note: no index on possible_types(type) — covered by PRIMARY KEY(type,member) leading column
 CREATE INDEX IF NOT EXISTS idx_possible_types_member ON possible_types(member);
 
+-- type_fields: type and document FK columns have no implicit index
+CREATE INDEX IF NOT EXISTS idx_type_fields_type ON type_fields(type);
+CREATE INDEX IF NOT EXISTS idx_type_fields_document ON type_fields(document);
+
 -- enum_values
 -- note: no index on enum_values(parent) or (parent,value) — both covered by UNIQUE(parent,value)
 
@@ -449,6 +457,8 @@ CREATE INDEX IF NOT EXISTS idx_document_directive_arguments_value on document_di
 
 -- document_variables
 -- note: no index on document_variables(document,name) — covered by UNIQUE(document,name)
+-- default_value FK is used as a JOIN column in validate and fragmentArguments transforms
+CREATE INDEX IF NOT EXISTS idx_document_variables_default_value ON document_variables(default_value);
 CREATE INDEX IF NOT EXISTS idx_document_variables_document_id ON document_variables(document, id);
 CREATE INDEX IF NOT EXISTS idx_document_variables_document_type_modifiers_default ON document_variables(document, type_modifiers, default_value);
 
@@ -471,6 +481,8 @@ CREATE INDEX IF NOT EXISTS idx_argument_values_expected_type_document ON argumen
 -- note: no separate index on argument_value_children(parent) alone
 CREATE INDEX IF NOT EXISTS idx_argument_value_children_parent_value ON argument_value_children(parent, value);
 CREATE INDEX IF NOT EXISTS idx_argument_value_children_value ON argument_value_children(value);
+-- document FK: large table; index needed for efficient CASCADE DELETE from documents
+CREATE INDEX IF NOT EXISTS idx_argument_value_children_document ON argument_value_children(document);
 `
 
 export async function write_config(

--- a/packages/houdini/src/lib/error.ts
+++ b/packages/houdini/src/lib/error.ts
@@ -65,15 +65,10 @@ type HookErrorLocation = {
 	column: number
 }
 
-export function format_hook_error(
-	rootDir: string,
-	error: HookError,
-	plugin: string,
-	hook: string,
-) {
+export function format_hook_error(rootDir: string, error: HookError, plugin: string, hook: string) {
 	let message = `-- ${styleText(
 		'red',
-		`${error.kind ?? 'internal'} error during ${hook.toLowerCase()} @ ${plugin}`,
+		`${error.kind ?? 'internal'} error during ${hook.toLowerCase()} @ ${plugin}`
 	)} -----------------------------\n`
 	message += error.message + '\n'
 	message += '\n'

--- a/packages/houdini/src/vite/hmr.ts
+++ b/packages/houdini/src/vite/hmr.ts
@@ -80,6 +80,23 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
 
 				// so let's just blow away any raw documents related to the changed files and then we'll call extract
 				const placeholders = relativePaths.map(() => '?').join(', ')
+
+				// Capture the document names for the changed files before we delete them.
+				// After extraction we'll compare to detect whether operations were added or
+				// removed. GenerateRuntime (stores, index.ts) only needs to re-run when the
+				// document set changes; for content-only edits we can skip it.
+				const prevDocNames = new Set<string>(
+					(
+						ctx.db
+							.prepare(
+								`SELECT d.name FROM documents d
+                 JOIN raw_documents rd ON d.raw_document = rd.id
+                 WHERE rd.filepath IN (${placeholders})`
+							)
+							.all(...relativePaths) as Array<{ name: string }>
+					).map((r) => r.name)
+				)
+
 				ctx.db
 					.prepare(
 						`
@@ -214,11 +231,37 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
 					)
 					.run({ task_id: task_id })
 
+				// Compare the document set after extraction to decide whether GenerateRuntime
+				// needs to run. If the user only edited existing operation bodies (no renames,
+				// no adds, no removes), stores and the plugin index are unchanged and we can
+				// stop the pipeline at GenerateDocuments.
+				const currDocNames = new Set<string>(
+					(
+						ctx.db
+							.prepare(
+								`SELECT d.name FROM documents d
+                 JOIN raw_documents rd ON d.raw_document = rd.id
+                 WHERE rd.filepath IN (${placeholders})`
+							)
+							.all(...relativePaths) as Array<{ name: string }>
+					).map((r) => r.name)
+				)
+				const documentSetChanged =
+					prevDocNames.size !== currDocNames.size ||
+					[...currDocNames].some((n) => !prevDocNames.has(n))
+
 				// the task now includes every document that we need to process
 				const results = await run_pipeline(compiler.trigger_hook, {
 					task_id,
 					after: 'AfterValidate',
+					...(documentSetChanged ? {} : { through: 'GenerateDocuments' }),
 				})
+
+				// AfterGenerate must always run — when we stop at GenerateDocuments it is
+				// excluded from run_pipeline's range, so fire it explicitly here.
+				if (!documentSetChanged) {
+					await compiler.trigger_hook('AfterGenerate', { task_id })
+				}
 
 				// the return value of each generate invocation is the list of modules that were updated
 				const updated_modules = Object.values(

--- a/packages/houdini/src/vite/hmr.ts
+++ b/packages/houdini/src/vite/hmr.ts
@@ -1,13 +1,7 @@
 import type { Plugin as VitePlugin, ModuleNode, HmrContext } from 'vite'
 
 import type { VitePluginContext } from '.'
-import {
-	codegen_setup,
-	get_config,
-	path,
-	run_pipeline,
-	type CompilerProxy,
-} from '../lib/index.js'
+import { codegen_setup, get_config, path, run_pipeline, type CompilerProxy } from '../lib/index.js'
 
 /**
  * Houdini Vite HMR Plugin
@@ -68,15 +62,13 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
 						!filepath.includes(
 							path.join(
 								hmr.server.config.root,
-								ctx.config.config_file.runtimeDir ?? '.houdini',
-							),
+								ctx.config.config_file.runtimeDir ?? '.houdini'
+							)
 						) &&
 						(filepath.endsWith('.gql') || content.includes('$houdini'))
 					) {
 						filepaths.push(filepath)
-						relativePaths.push(
-							filepath.substring(hmr.server.config.root.length + 1),
-						)
+						relativePaths.push(filepath.substring(hmr.server.config.root.length + 1))
 					}
 				}
 				if (filepaths.length === 0) {
@@ -93,7 +85,7 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
 					.prepare(
 						`
             DELETE from raw_documents WHERE filepath IN (${placeholders})
-        `,
+        `
 					)
 					.run(...relativePaths)
 
@@ -107,7 +99,7 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
           WHERE s.fragment_ref IS NOT NULL
             AND s.kind = 'fragment'                              -- only fragment spreads
             AND NOT EXISTS (SELECT 1 FROM documents d WHERE d.name = s.field_name)
-          `,
+          `
 					)
 					.run()
 
@@ -124,7 +116,7 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
             )
             DELETE FROM selections
             WHERE id IN (SELECT id FROM orphan_selections)
-          `,
+          `
 					)
 					.run()
 
@@ -140,7 +132,7 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
               UPDATE raw_documents 
                 SET current_task = ? 
               WHERE filepath IN (${placeholders})
-            `,
+            `
 					)
 					.run(task_id, ...relativePaths)
 
@@ -219,7 +211,7 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
             UPDATE raw_documents
             SET current_task = $task_id
             WHERE id IN (SELECT raw_id FROM targets);
-          `,
+          `
 					)
 					.run({ task_id: task_id })
 
@@ -231,14 +223,12 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
 
 				// the return value of each generate invocation is the list of modules that were updated
 				const updated_modules = Object.values(
-					results.GenerateDocuments || {},
+					results.GenerateDocuments || {}
 				).flat() as Array<string>
 
 				// and finally we can remove the task id association
 				ctx.db
-					.prepare(
-						`UPDATE raw_documents SET current_task = NULL WHERE current_task = ?`,
-					)
+					.prepare(`UPDATE raw_documents SET current_task = NULL WHERE current_task = ?`)
 					.run(task_id)
 
 				// invalidate all of the modules we generated
@@ -255,7 +245,7 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
 
 type BatchCallback = (
 	filesWithContent: Record<string, string>,
-	batchId: string,
+	batchId: string
 ) => void | Promise<void>
 
 export function createDebounceHmr(debounceMs: number = 50) {
@@ -297,15 +287,13 @@ export function createDebounceHmr(debounceMs: number = 50) {
 				// Read all files in parallel
 				const filesWithContent: Record<string, string> = {}
 				await Promise.all(
-					Array.from(filesToProcess.entries()).map(
-						async ([filepath, readFn]) => {
-							try {
-								filesWithContent[filepath] = await readFn()
-							} catch {
-								// file disappeared between the HMR event and now — skip it
-							}
-						},
-					),
+					Array.from(filesToProcess.entries()).map(async ([filepath, readFn]) => {
+						try {
+							filesWithContent[filepath] = await readFn()
+						} catch {
+							// file disappeared between the HMR event and now — skip it
+						}
+					})
 				)
 
 				try {
@@ -327,7 +315,7 @@ export function createDebounceHmr(debounceMs: number = 50) {
 							} catch {
 								// file disappeared between the HMR event and now — skip it
 							}
-						}),
+						})
 					)
 
 					try {

--- a/packages/houdini/src/vite/hmr.ts
+++ b/packages/houdini/src/vite/hmr.ts
@@ -299,30 +299,31 @@ export function createDebounceHmr(debounceMs: number = 50) {
 
 				try {
 					await callback(filesWithContent, currentBatchId.toString())
-				} catch {}
+				} catch (err) {
+					console.error('[houdini] HMR pipeline error:', err)
+				}
 
-				// Process any pending batch that accumulated
-				if (pendingBatch) {
+				// Drain any pending batches that accumulated while we were processing
+				while (pendingBatch) {
 					const { files: nextFiles, batchId: nextBatchId } = pendingBatch
 					pendingBatch = null
 
-					// Read files for pending batch
 					const nextFilesWithContent: Record<string, string> = {}
-					const nextReadPromises = Array.from(nextFiles.entries()).map(
-						async ([filepath, readFn]) => {
+					await Promise.all(
+						Array.from(nextFiles.entries()).map(async ([filepath, readFn]) => {
 							try {
-								const content = await readFn()
-								nextFilesWithContent[filepath] = content
-							} catch (error) {
+								nextFilesWithContent[filepath] = await readFn()
+							} catch {
 								nextFilesWithContent[filepath] = ''
 							}
-						}
+						})
 					)
 
-					await Promise.all(nextReadPromises)
 					try {
 						await callback(nextFilesWithContent, nextBatchId.toString())
-					} catch {}
+					} catch (err) {
+						console.error('[houdini] HMR pipeline error:', err)
+					}
 				}
 			} finally {
 				isProcessing = false

--- a/packages/houdini/src/vite/hmr.ts
+++ b/packages/houdini/src/vite/hmr.ts
@@ -300,11 +300,9 @@ export function createDebounceHmr(debounceMs: number = 50) {
 					Array.from(filesToProcess.entries()).map(
 						async ([filepath, readFn]) => {
 							try {
-								const content = await readFn()
-								filesWithContent[filepath] = content
-							} catch (error) {
-								// Store empty string or rethrow based on your needs
-								filesWithContent[filepath] = ''
+								filesWithContent[filepath] = await readFn()
+							} catch {
+								// file disappeared between the HMR event and now — skip it
 							}
 						},
 					),
@@ -327,7 +325,7 @@ export function createDebounceHmr(debounceMs: number = 50) {
 							try {
 								nextFilesWithContent[filepath] = await readFn()
 							} catch {
-								nextFilesWithContent[filepath] = ''
+								// file disappeared between the HMR event and now — skip it
 							}
 						}),
 					)

--- a/packages/houdini/src/vite/hmr.ts
+++ b/packages/houdini/src/vite/hmr.ts
@@ -1,7 +1,13 @@
 import type { Plugin as VitePlugin, ModuleNode, HmrContext } from 'vite'
 
 import type { VitePluginContext } from '.'
-import { codegen_setup, get_config, path, run_pipeline, type CompilerProxy } from '../lib/index.js'
+import {
+	codegen_setup,
+	get_config,
+	path,
+	run_pipeline,
+	type CompilerProxy,
+} from '../lib/index.js'
 
 /**
  * Houdini Vite HMR Plugin
@@ -62,13 +68,15 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
 						!filepath.includes(
 							path.join(
 								hmr.server.config.root,
-								ctx.config.config_file.runtimeDir ?? '.houdini'
-							)
+								ctx.config.config_file.runtimeDir ?? '.houdini',
+							),
 						) &&
 						(filepath.endsWith('.gql') || content.includes('$houdini'))
 					) {
 						filepaths.push(filepath)
-						relativePaths.push(filepath.substring(hmr.server.config.root.length + 1))
+						relativePaths.push(
+							filepath.substring(hmr.server.config.root.length + 1),
+						)
 					}
 				}
 				if (filepaths.length === 0) {
@@ -81,27 +89,11 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
 				// so let's just blow away any raw documents related to the changed files and then we'll call extract
 				const placeholders = relativePaths.map(() => '?').join(', ')
 
-				// Capture the document names for the changed files before we delete them.
-				// After extraction we'll compare to detect whether operations were added or
-				// removed. GenerateRuntime (stores, index.ts) only needs to re-run when the
-				// document set changes; for content-only edits we can skip it.
-				const prevDocNames = new Set<string>(
-					(
-						ctx.db
-							.prepare(
-								`SELECT d.name FROM documents d
-                 JOIN raw_documents rd ON d.raw_document = rd.id
-                 WHERE rd.filepath IN (${placeholders})`
-							)
-							.all(...relativePaths) as Array<{ name: string }>
-					).map((r) => r.name)
-				)
-
 				ctx.db
 					.prepare(
 						`
             DELETE from raw_documents WHERE filepath IN (${placeholders})
-        `
+        `,
 					)
 					.run(...relativePaths)
 
@@ -115,7 +107,7 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
           WHERE s.fragment_ref IS NOT NULL
             AND s.kind = 'fragment'                              -- only fragment spreads
             AND NOT EXISTS (SELECT 1 FROM documents d WHERE d.name = s.field_name)
-          `
+          `,
 					)
 					.run()
 
@@ -132,7 +124,7 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
             )
             DELETE FROM selections
             WHERE id IN (SELECT id FROM orphan_selections)
-          `
+          `,
 					)
 					.run()
 
@@ -148,7 +140,7 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
               UPDATE raw_documents 
                 SET current_task = ? 
               WHERE filepath IN (${placeholders})
-            `
+            `,
 					)
 					.run(task_id, ...relativePaths)
 
@@ -227,50 +219,26 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
             UPDATE raw_documents
             SET current_task = $task_id
             WHERE id IN (SELECT raw_id FROM targets);
-          `
+          `,
 					)
 					.run({ task_id: task_id })
-
-				// Compare the document set after extraction to decide whether GenerateRuntime
-				// needs to run. If the user only edited existing operation bodies (no renames,
-				// no adds, no removes), stores and the plugin index are unchanged and we can
-				// stop the pipeline at GenerateDocuments.
-				const currDocNames = new Set<string>(
-					(
-						ctx.db
-							.prepare(
-								`SELECT d.name FROM documents d
-                 JOIN raw_documents rd ON d.raw_document = rd.id
-                 WHERE rd.filepath IN (${placeholders})`
-							)
-							.all(...relativePaths) as Array<{ name: string }>
-					).map((r) => r.name)
-				)
-				const documentSetChanged =
-					prevDocNames.size !== currDocNames.size ||
-					[...currDocNames].some((n) => !prevDocNames.has(n))
 
 				// the task now includes every document that we need to process
 				const results = await run_pipeline(compiler.trigger_hook, {
 					task_id,
 					after: 'AfterValidate',
-					...(documentSetChanged ? {} : { through: 'GenerateDocuments' }),
 				})
-
-				// AfterGenerate must always run — when we stop at GenerateDocuments it is
-				// excluded from run_pipeline's range, so fire it explicitly here.
-				if (!documentSetChanged) {
-					await compiler.trigger_hook('AfterGenerate', { task_id })
-				}
 
 				// the return value of each generate invocation is the list of modules that were updated
 				const updated_modules = Object.values(
-					results.GenerateDocuments || {}
+					results.GenerateDocuments || {},
 				).flat() as Array<string>
 
 				// and finally we can remove the task id association
 				ctx.db
-					.prepare(`UPDATE raw_documents SET current_task = NULL WHERE current_task = ?`)
+					.prepare(
+						`UPDATE raw_documents SET current_task = NULL WHERE current_task = ?`,
+					)
 					.run(task_id)
 
 				// invalidate all of the modules we generated
@@ -287,7 +255,7 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
 
 type BatchCallback = (
 	filesWithContent: Record<string, string>,
-	batchId: string
+	batchId: string,
 ) => void | Promise<void>
 
 export function createDebounceHmr(debounceMs: number = 50) {
@@ -329,15 +297,17 @@ export function createDebounceHmr(debounceMs: number = 50) {
 				// Read all files in parallel
 				const filesWithContent: Record<string, string> = {}
 				await Promise.all(
-					Array.from(filesToProcess.entries()).map(async ([filepath, readFn]) => {
-						try {
-							const content = await readFn()
-							filesWithContent[filepath] = content
-						} catch (error) {
-							// Store empty string or rethrow based on your needs
-							filesWithContent[filepath] = ''
-						}
-					})
+					Array.from(filesToProcess.entries()).map(
+						async ([filepath, readFn]) => {
+							try {
+								const content = await readFn()
+								filesWithContent[filepath] = content
+							} catch (error) {
+								// Store empty string or rethrow based on your needs
+								filesWithContent[filepath] = ''
+							}
+						},
+					),
 				)
 
 				try {
@@ -359,7 +329,7 @@ export function createDebounceHmr(debounceMs: number = 50) {
 							} catch {
 								nextFilesWithContent[filepath] = ''
 							}
-						})
+						}),
 					)
 
 					try {

--- a/plugins/database.go
+++ b/plugins/database.go
@@ -27,9 +27,29 @@ func (db *DatabasePool[PluginConfig]) SetPluginConfig(config PluginConfig) {
 	db._pluginConfig = &config
 }
 
+var connectionPragmas = []string{
+	"PRAGMA journal_mode = WAL",
+	"PRAGMA synchronous = off",
+	"PRAGMA cache_size = 10000",
+	"PRAGMA temp_store = memory",
+	"PRAGMA busy_timeout = 5000",
+	"PRAGMA foreign_key = ON",
+	"PRAGMA defer_foreign_keys = ON",
+}
+
+func prepareConn(conn *sqlite.Conn) error {
+	for _, pragma := range connectionPragmas {
+		if err := sqlitex.ExecuteTransient(conn, pragma, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func NewPool[PluginConfig any]() (DatabasePool[PluginConfig], error) {
 	pool, err := sqlitex.NewPool(databasePath, sqlitex.PoolOptions{
-		Flags: sqlite.OpenWAL | sqlite.OpenReadWrite,
+		Flags:       sqlite.OpenWAL | sqlite.OpenReadWrite,
+		PrepareConn: prepareConn,
 	})
 	if err != nil {
 		return DatabasePool[PluginConfig]{}, err
@@ -107,30 +127,7 @@ func (db DatabasePool[PluginConfig]) BindStatement(stmt *sqlite.Stmt, args map[s
 
 // our wrapper over take needs to time out after 10 seconds
 func (db DatabasePool[PluginConfig]) Take(ctx context.Context) (*sqlite.Conn, error) {
-	conn, err := db.Pool.Take(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if !db.Test {
-		for _, pragma := range []string{
-			"PRAGMA journal_mode = WAL",
-			"PRAGMA synchronous = off",
-			"PRAGMA cache_size = 10000",
-			"PRAGMA temp_store = memory",
-			"PRAGMA busy_timeout = 5000",
-			"PRAGMA foreign_key = ON",
-			"PRAGMA defer_foreign_keys = ON",
-		} {
-			stmt, _, err := conn.PrepareTransient(pragma)
-			if err != nil {
-				return nil, err
-			}
-			db.ExecStatement(stmt, map[string]any{})
-		}
-	}
-
-	return conn, nil
+	return db.Pool.Take(ctx)
 }
 
 func (db DatabasePool[PluginConfig]) ExecQuery(


### PR DESCRIPTION
In a project with 766 documents (426 operations, 340 fragments) these changes brought the compilation time from an average of 11s down to an average of 2.2s (an 80% reduction in time). This was mainly achieved with:

- Parralelizing where possible
- Optimizing indices
- Generating runtime and documents in parallel (and more smartly)
- Improved query caching by the sqlite engine during large batch operations