### PR TITLE
Fix: The Go compiler incorrectly assumes the root mutation is always called Mutation #1594

### DIFF
--- a/.changeset/cyan-sheep-compare.md
+++ b/.changeset/cyan-sheep-compare.md
@@ -1,0 +1,5 @@
+---
+'houdini-core': patch
+---
+
+Fix documents validation for schema that use custom operation types names for query/mutaiton/subscription

--- a/packages/houdini-core/plugin/documents/loadDocuments.go
+++ b/packages/houdini-core/plugin/documents/loadDocuments.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"github.com/vektah/gqlparser/v2/parser"
 	"golang.org/x/sync/errgroup"
+	"os"
 	"zombiezen.com/go/sqlite"
 	"zombiezen.com/go/sqlite/sqlitex"
 
@@ -562,11 +563,12 @@ func LoadPendingQuery(
 		}
 
 		// figure out the name of the root type for the operation.
-		operationType := "Query"
-		if operation.Operation == ast.Mutation {
-			operationType = "Mutation"
-		} else if operation.Operation == ast.Subscription {
-			operationType = "Subscription"
+		operationType := typeCache.RootTypes.Query
+		switch operation.Operation {
+		case ast.Mutation:
+			operationType = typeCache.RootTypes.Mutation
+		case ast.Subscription:
+			operationType = typeCache.RootTypes.Subscription
 		}
 
 		// walk the selection set for the operation.
@@ -1564,10 +1566,17 @@ type TypeWithModifiers struct {
 	Modifiers string
 }
 
+type RootTypeNames struct {
+	Query        string
+	Mutation     string
+	Subscription string
+}
+
 type TypeCache struct {
 	TypeFields         map[string]TypeWithModifiers
 	FieldArguments     map[string]TypeWithModifiers
 	DirectiveArguments map[string]TypeWithModifiers
+	RootTypes          RootTypeNames
 }
 
 func LoadTypeCache[PluginConfig any](
@@ -1580,16 +1589,47 @@ func LoadTypeCache[PluginConfig any](
 	}
 	defer db.Put(conn)
 
+	rootTypes := RootTypeNames{}
+
+	// Look up the actual operation & name from the types table
+	typeNamesQuery, err := conn.Prepare(`
+		SELECT name, operation
+		FROM types
+		WHERE operation IN ('query', 'mutation', 'subscription')
+	`)
+
+	if err != nil {
+		return TypeCache{}, err
+	}
+	defer typeNamesQuery.Finalize()
+	err = db.StepStatement(ctx, typeNamesQuery, func() {
+		name := typeNamesQuery.ColumnText(0)
+		operation := typeNamesQuery.ColumnText(1)
+
+		switch operation {
+		case "query":
+			rootTypes.Query = name
+		case "mutation":
+			rootTypes.Mutation = name
+		case "subscription":
+			rootTypes.Subscription = name
+		}
+	})
+	if err != nil {
+		return TypeCache{}, err
+	}
 	caches := TypeCache{
 		TypeFields:         map[string]TypeWithModifiers{},
 		FieldArguments:     map[string]TypeWithModifiers{},
 		DirectiveArguments: map[string]TypeWithModifiers{},
+		RootTypes:          rootTypes,
 	}
 
 	// we need to know the type and mofiifers for a given type field
 	typeFieldTypeQuery, err := conn.Prepare(`
 		SELECT type_fields.id, type_fields.type, type_fields.type_modifiers FROM type_fields
 	`)
+
 	if err != nil {
 		return TypeCache{}, err
 	}

--- a/packages/houdini-core/plugin/documents/loadDocuments.go
+++ b/packages/houdini-core/plugin/documents/loadDocuments.go
@@ -11,7 +11,6 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"github.com/vektah/gqlparser/v2/parser"
 	"golang.org/x/sync/errgroup"
-	"os"
 	"zombiezen.com/go/sqlite"
 	"zombiezen.com/go/sqlite/sqlitex"
 

--- a/packages/houdini-core/plugin/documents/loadDocuments_test.go
+++ b/packages/houdini-core/plugin/documents/loadDocuments_test.go
@@ -1697,6 +1697,89 @@ func TestAfterExtract_loadsExtractedQueries(t *testing.T) {
 	}
 }
 
+func TestAfterExtract_usesCustomRootMutationType(t *testing.T) {
+	schema := `
+		schema {
+			query: Query
+			mutation: RootMutation
+		}
+
+		type Query {
+			user: User
+		}
+
+		type RootMutation {
+			updateUser(id: ID, name: String): User
+		}
+
+		type User {
+			id: ID!
+			name: String
+		}
+	`
+	rawQuery := `
+		mutation UpdateUser($id: ID, $name: String) {
+			updateUser(id: $id, name: $name) {
+				id
+				name
+			}
+		}
+	`
+
+	db, err := plugins.NewTestPool[config.PluginConfig]()
+	require.Nil(t, err)
+	defer db.Close()
+
+	plugin := &plugin.HoudiniCore{}
+	plugin.SetFilesystem(afero.NewMemMapFs())
+
+	db.SetProjectConfig(plugins.ProjectConfig{
+		ProjectRoot: "/project",
+		SchemaPath:  "schema.graphql",
+	})
+	plugin.SetDatabase(db)
+
+	conn, err := db.Take(context.Background())
+	require.Nil(t, err)
+	defer db.Put(conn)
+
+	err = tests.WriteDatabaseSchema(conn)
+	require.Nil(t, err)
+
+	err = afero.WriteFile(plugin.Fs, filepath.Join("/project", "schema.graphql"), []byte(schema), 0644)
+	require.Nil(t, err)
+
+	err = plugin.Schema(context.Background())
+	require.Nil(t, err)
+
+	insertRaw, err := conn.Prepare(
+		"insert into raw_documents (content, filepath) values ($content, 'foo')",
+	)
+	require.Nil(t, err)
+	defer insertRaw.Finalize()
+	err = db.ExecStatement(insertRaw, map[string]any{"content": rawQuery})
+	require.Nil(t, err)
+
+	statements, err, finalize := documents.PrepareDocumentInsertStatements(conn)
+	require.Nil(t, err)
+	defer finalize()
+
+	typeCaches, err := documents.LoadTypeCache(context.Background(), db)
+
+	require.Nil(t, err)
+	require.Equal(t, "RootMutation", typeCaches.RootTypes.Mutation)
+
+	pendingErr := documents.LoadPendingQuery(
+		context.Background(),
+		db,
+		conn,
+		documents.PendingQuery{Query: rawQuery, ID: 1},
+		statements,
+		typeCaches,
+	)
+	require.Nil(t, pendingErr)
+}
+
 // testCase defines a test scenario.
 type testCase struct {
 	name                     string


### PR DESCRIPTION
Fixes #1579 

Earlier we assumed that the operation names will always be `query,mutation, subscription` but you can change those in graphql schema defs. we stored this properly but while loading documents we had a hardcoded match so it failed if someone setup their custom operation
names like below

```
schema {
	query: CustomQuery
	mutation: RootMutation
	subscription: Subscription
}

```

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Ensure your code is formatted to conform to standard style with `pnpm run format:write` (or `format:check` if you want to preview changes) and linted `pnpm run lint`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`
