### PR TITLE
fix: genrate archifacts deadlock and timeout

### DIFF
--- a/.changeset/large-countries-fetch.md
+++ b/.changeset/large-countries-fetch.md
@@ -1,0 +1,5 @@
+---
+'houdini-core': patch
+---
+
+generate artifacts pipeline deadlock condition resolve

--- a/packages/houdini-core/plugin/documents/artifacts/artifacts.go
+++ b/packages/houdini-core/plugin/documents/artifacts/artifacts.go
@@ -25,7 +25,7 @@ func GenerateDocumentArtifacts(
 	sortKeys bool,
 ) ([]string, error) {
 	// load the project config to look up the default masking
-	config, err := db.ProjectConfig(ctx)
+	projectConfig, err := db.ProjectConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func GenerateDocumentArtifacts(
 	// we need to build up the filepaths we generate
 	filepaths := plugins.ThreadSafeSlice[string]{}
 
-	typeRoots, err := typescript.GetRootTypes(ctx, db)
+	typeRoots, err := typescript.GetRootTypes(ctx, db, conn)
 	if err != nil {
 		return nil, plugins.WrapError(err)
 	}
@@ -79,7 +79,7 @@ func GenerateDocumentArtifacts(
 					ctx,
 					collectedDefinitions,
 					name,
-					config.DefaultFragmentMasking,
+					projectConfig.DefaultFragmentMasking,
 					sortKeys,
 				)
 				if err != nil {
@@ -93,6 +93,7 @@ func GenerateDocumentArtifacts(
 					fs,
 					db,
 					conn,
+					projectConfig,
 					collectedDefinitions,
 					name,
 					selection,
@@ -139,7 +140,7 @@ func GenerateDocumentArtifacts(
 			// as the $houdini alias
 			strings.Replace(
 				fp,
-				filepath.Join(config.ProjectRoot, config.RuntimeDir),
+				filepath.Join(projectConfig.ProjectRoot, projectConfig.RuntimeDir),
 				"$houdini",
 				1,
 			),

--- a/packages/houdini-core/plugin/documents/artifacts/selection.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection.go
@@ -26,20 +26,19 @@ func writeSelectionDocument(
 	fs afero.Fs,
 	db plugins.DatabasePool[config.PluginConfig],
 	conn *sqlite.Conn,
+	projectConfig plugins.ProjectConfig,
 	docs *collected.Documents,
 	name string,
 	selection []*collected.Selection,
 	sortKeys bool,
 	typeRoots *typescript.RootTypeNames,
 ) (string, error) {
-	// load the project config
-	projectConfig, _ := db.ProjectConfig(ctx)
-
 	// generate the artifact content
 	artifact, err := GenerateSelectionDocument(
 		ctx,
 		db,
 		conn,
+		projectConfig,
 		docs,
 		name,
 		selection,
@@ -78,6 +77,7 @@ func GenerateSelectionDocument(
 	ctx context.Context,
 	db plugins.DatabasePool[config.PluginConfig],
 	conn *sqlite.Conn,
+	projectConfig plugins.ProjectConfig,
 	docs *collected.Documents,
 	name string,
 	selection []*collected.Selection,
@@ -123,9 +123,10 @@ func GenerateSelectionDocument(
 	}
 
 	// collect plugin data
-	pluginData, err := plugins.TriggerHookParallel(
+	pluginData, err := plugins.TriggerHookParallelWithConn(
 		ctx,
 		db,
+		conn,
 		"PluginData",
 		map[string]any{"document": name},
 	)
@@ -141,10 +142,6 @@ func GenerateSelectionDocument(
 	dedupe := ""
 
 	// we need to compute the cache policy for the document
-	projectConfig, err := db.ProjectConfig(ctx)
-	if err != nil {
-		return "", err
-	}
 	cachePolicy := projectConfig.DefaultCachePolicy
 	partial := projectConfig.DefaultPartial
 	for _, directive := range doc.Directives {
@@ -411,9 +408,7 @@ func GenerateSelectionDocument(
 
 	// compute the type definitions
 	typeDefs, imports, err := typescript.GenerateDocumentTypeDefs(
-		ctx,
-		db,
-		conn,
+		projectConfig,
 		rootTypes,
 		docs,
 		doc,

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
@@ -24,19 +24,11 @@ type DocumentContext struct {
 }
 
 func GenerateDocumentTypeDefs(
-	ctx context.Context,
-	db plugins.DatabasePool[config.PluginConfig],
-	conn *sqlite.Conn,
+	projectConfig plugins.ProjectConfig,
 	rootTypes *RootTypeNames,
 	collectedDefinitions *collected.Documents,
 	doc *collected.Document,
 ) (string, []string, error) {
-	// Get project config
-	projectConfig, err := db.ProjectConfig(ctx)
-	if err != nil {
-		return "", nil, err
-	}
-
 	// Calculate root type name once per document
 	rootTypeName := getRootTypeName(doc, rootTypes)
 
@@ -1247,15 +1239,22 @@ type RootTypeNames struct {
 func GetRootTypes(
 	ctx context.Context,
 	db plugins.DatabasePool[config.PluginConfig],
+	conn *sqlite.Conn,
 ) (*RootTypeNames, error) {
 	rootTypes := &RootTypeNames{}
 
 	// Look up the actual root type names from the types table
-	err := db.StepQuery(ctx, `
+	stmt, err := conn.Prepare(`
 		SELECT name, operation
 		FROM types
 		WHERE operation IN ('query', 'mutation', 'subscription')
-	`, map[string]any{}, func(stmt *sqlite.Stmt) {
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Finalize()
+
+	err = db.StepStatement(ctx, stmt, func() {
 		typeName := stmt.ColumnText(0)
 		operation := stmt.ColumnText(1)
 

--- a/plugins/hooks.go
+++ b/plugins/hooks.go
@@ -133,6 +133,76 @@ func TriggerHookParallel[PluginConfig any](
 	return result, nil
 }
 
+func TriggerHookParallelWithConn[PluginConfig any](
+	ctx context.Context,
+	db DatabasePool[PluginConfig],
+	conn *sqlite.Conn,
+	hook string,
+	payload map[string]any,
+) (map[string]any, error) {
+	// build up the result of invoking the hook on matching plugins
+	result := map[string]any{}
+	var resultMu sync.Mutex // to protect concurrent writes
+
+	stmt, err := conn.Prepare(`
+    SELECT * FROM plugins
+    WHERE EXISTS (
+      SELECT 1
+      FROM json_each(plugins.hooks)
+      WHERE value = $hook
+    )
+  `)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Finalize()
+	stmt.SetText("$hook", hook)
+
+	pluginPorts := map[string]int64{}
+	err = db.StepStatement(ctx, stmt, func() {
+		pluginPorts[stmt.GetText("name")] = stmt.GetInt64("port")
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(pluginPorts) == 0 {
+		return map[string]any{}, nil
+	}
+
+	errs := &ErrorList{}
+	var wg sync.WaitGroup
+
+	for name, port := range pluginPorts {
+		wg.Add(1)
+
+		go func(name string, port int64) {
+			defer wg.Done()
+			if port == 0 {
+				return
+			}
+
+			pluginResult, err := invokeHook(ctx, name, port, hook, payload)
+			if err != nil {
+				errs.Append(WrapError(err))
+				return
+			}
+
+			// merge result safely
+			resultMu.Lock()
+			maps.Copy(result, map[string]any{name: pluginResult})
+			resultMu.Unlock()
+		}(name, port)
+	}
+
+	wg.Wait()
+
+	if errs.Len() > 0 {
+		return result, errs
+	}
+
+	return result, nil
+}
+
 func invokeHook(
 	ctx context.Context,
 	name string,
@@ -140,7 +210,7 @@ func invokeHook(
 	hook string,
 	payload map[string]any,
 ) (map[string]any, error) {
-	// hook url is just name of hook 
+	// hook url is just name of hook
 	endpoint := "/" + strings.ToLower(hook)
 	url := fmt.Sprintf("http://localhost:%d%s", port, endpoint)
 


### PR DESCRIPTION
generate artifacts pipeline has a deadlock in some cases when the worker threads > allowed sqlitex pool size(default 10), since artifacts generation spawn as many workers as possible and they try to obtrain db connection that is fine but some of the operations were trying to take up a new connection in pool, but since we exhausted pool when we spawned these workers its essentially a deadlock, timeout.

just passing conn down to the functions that needs it from artifacts, bit of decoupling.

We could have also limited the workers to be less than poolsize but that is not utilizing resources properly 

Fixes #TICKET

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x] Ensure your code is formatted to conform to standard style with `pnpm run format:write` (or`format:check` if you want to preview changes) and linted `pnpm run lint`
- [x] Includes a changeset if your fix affects the user with `pnpm changeset`
