### PR TITLE
Implement stdio-based protocol for wasm compatibility

### DIFF
--- a/.changeset/hip-fishes-end.md
+++ b/.changeset/hip-fishes-end.md
@@ -1,0 +1,5 @@
+---
+'houdini': minor
+---
+
+Implemented stdio-based protocol switch for wasm compatability

--- a/packages/houdini/src/lib/codegen.ts
+++ b/packages/houdini/src/lib/codegen.ts
@@ -221,22 +221,30 @@ export async function codegen_setup(
 							spec.order,
 							msg.includeRuntime ?? null,
 							msg.configModule ?? null,
-							msg.clientPlugins ?? null,
+							msg.clientPlugins ?? null
 						)
 						db.prepare('UPDATE plugins SET config = ? WHERE name = ?').run(
-							JSON.stringify(config.plugins.find((p) => p.name === name)?.config ?? {}),
-							spec.name,
+							JSON.stringify(
+								config.plugins.find((p) => p.name === name)?.config ?? {}
+							),
+							spec.name
 						)
 
 						if (msg.configModule) {
-							import(msg.configModule).then((module) => {
-								if (module && typeof module.default === 'function') {
-									config.config_file = module.default(config.config_file)
-								}
-								resolve(spec)
-							}).catch((err: Error) => {
-								reject(new Error(`Failed to load configModule for ${name}: ${err.message}`))
-							})
+							import(msg.configModule)
+								.then((module) => {
+									if (module && typeof module.default === 'function') {
+										config.config_file = module.default(config.config_file)
+									}
+									resolve(spec)
+								})
+								.catch((err: Error) => {
+									reject(
+										new Error(
+											`Failed to load configModule for ${name}: ${err.message}`
+										)
+									)
+								})
 						} else {
 							resolve(spec)
 						}
@@ -265,7 +273,12 @@ export async function codegen_setup(
 						// Go plugin is asking Node.js to call other plugins on its behalf.
 						// triggerHookRef.fn is always set before any hook runs, but guard anyway.
 						if (!triggerHookRef.fn) {
-							const reply = JSON.stringify({ id: msg.id, type: 'invoke_result', error: { message: 'orchestrator not ready' } }) + '\n'
+							const reply =
+								JSON.stringify({
+									id: msg.id,
+									type: 'invoke_result',
+									error: { message: 'orchestrator not ready' },
+								}) + '\n'
 							child.stdin!.write(reply)
 							return
 						}

--- a/packages/houdini/src/lib/codegen.ts
+++ b/packages/houdini/src/lib/codegen.ts
@@ -1,5 +1,6 @@
 import { type ChildProcess, spawn } from 'node:child_process'
 import path from 'node:path'
+import { createInterface } from 'node:readline'
 import sqlite, { type DatabaseSync } from 'node:sqlite'
 import { WebSocket } from 'ws'
 
@@ -97,11 +98,19 @@ export async function codegen_setup(
 	// We need the root dir before we get to the exciting stuff
 	await fs.mkdirpSync(conventions.houdini_root(config))
 
+	const useStdio = config.config_file.pluginTransport === 'stdio'
+
 	const plugins: Record<string, PluginSpec & { process: ChildProcess }> = {}
 
 	// when plugins announce themselves, they provide a port
 	const plugin_specs: Array<PluginSpec> = []
 	const spec_results: Record<string, PluginSpec> = {}
+
+	// stdio transport state — populated for plugins spawned with --transport stdio
+	const stdioStdin = new Map<string, NodeJS.WritableStream>()
+	// invoke messages from Go need to call trigger_hook, which is defined later;
+	// we use a ref so the readline handlers close over a mutable binding
+	const triggerHookRef: { fn: CompilerProxy['trigger_hook'] | null } = { fn: null }
 
 	// we need a function that waits for a plugin to register itself
 	const wait_for_plugin = (name: string) =>
@@ -152,9 +161,6 @@ export async function codegen_setup(
 					} else {
 						resolver(spec)
 					}
-
-					// resolve the promise
-					resolver(spec)
 				}
 			}, 10)
 
@@ -169,6 +175,143 @@ export async function codegen_setup(
 				clearTimeout(timeout)
 				resolve(spec)
 			}
+		})
+
+	// wait_for_plugin_stdio reads the registration JSON line from stdout and sets
+	// up the permanent message handler for response/invoke messages.
+	const wait_for_plugin_stdio = (name: string, child: ChildProcess) =>
+		new Promise<PluginSpec>((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				reject(new Error(`Timeout waiting for plugin ${name} to register`))
+			}, 10000)
+
+			const rl = createInterface({ input: child.stdout! })
+			let registered = false
+
+			rl.on('line', (line) => {
+				try {
+					const msg = JSON.parse(line)
+
+					if (!registered) {
+						if (msg.type !== 'register') {
+							clearTimeout(timeout)
+							reject(new Error(`Plugin ${name} sent ${msg.type} before registering`))
+							return
+						}
+						registered = true
+						clearTimeout(timeout)
+
+						const spec: PluginSpec = {
+							name: msg.name ?? name,
+							port: 0,
+							hooks: new Set(msg.hooks ?? []),
+							order: msg.order as 'before' | 'after' | 'core',
+							directory: config.plugins.find((p) => p.name === name)?.directory || '',
+						}
+						spec_results[name] = spec
+
+						// Mirror what the plugin would write to the DB itself in WebSocket mode so
+						// that PluginConfig() reads succeed when hooks run.
+						db.prepare(
+							`INSERT INTO plugins (name, hooks, port, plugin_order, include_runtime, config_module, client_plugins)
+							 VALUES (?, ?, 0, ?, ?, ?, ?)`
+						).run(
+							spec.name,
+							JSON.stringify([...spec.hooks]),
+							spec.order,
+							msg.includeRuntime ?? null,
+							msg.configModule ?? null,
+							msg.clientPlugins ?? null,
+						)
+						db.prepare('UPDATE plugins SET config = ? WHERE name = ?').run(
+							JSON.stringify(config.plugins.find((p) => p.name === name)?.config ?? {}),
+							spec.name,
+						)
+
+						if (msg.configModule) {
+							import(msg.configModule).then((module) => {
+								if (module && typeof module.default === 'function') {
+									config.config_file = module.default(config.config_file)
+								}
+								resolve(spec)
+							}).catch((err: Error) => {
+								reject(new Error(`Failed to load configModule for ${name}: ${err.message}`))
+							})
+						} else {
+							resolve(spec)
+						}
+						return
+					}
+
+					// subsequent messages: response or invoke
+					if (msg.type === 'response') {
+						const pending = pendingRequests.get(msg.id)
+						if (!pending) return
+						clearTimeout(pending.timeout)
+						pendingRequests.delete(msg.id)
+
+						if (msg.error) {
+							const errors: HookError[] = Array.isArray(msg.error)
+								? msg.error
+								: [msg.error]
+							errors.forEach((error) =>
+								format_hook_error(config.root_dir, error, name, pending.hook)
+							)
+							pending.reject(new Error(`Failed to call ${name}`))
+						} else {
+							pending.resolve(msg.result)
+						}
+					} else if (msg.type === 'invoke') {
+						// Go plugin is asking Node.js to call other plugins on its behalf.
+						// triggerHookRef.fn is always set before any hook runs, but guard anyway.
+						if (!triggerHookRef.fn) {
+							const reply = JSON.stringify({ id: msg.id, type: 'invoke_result', error: { message: 'orchestrator not ready' } }) + '\n'
+							child.stdin!.write(reply)
+							return
+						}
+						triggerHookRef
+							.fn(msg.hook, {
+								parallel_safe: msg.parallel,
+								payload: msg.payload,
+								task_id: msg.taskId,
+							})
+							.then((result) => {
+								const reply =
+									JSON.stringify({ id: msg.id, type: 'invoke_result', result }) +
+									'\n'
+								child.stdin!.write(reply)
+							})
+							.catch((err: Error) => {
+								const reply =
+									JSON.stringify({
+										id: msg.id,
+										type: 'invoke_result',
+										error: { message: err.message },
+									}) + '\n'
+								child.stdin!.write(reply)
+							})
+					}
+				} catch (err: unknown) {
+					if (!registered) {
+						reject(err instanceof Error ? err : new Error(String(err)))
+					}
+				}
+			})
+
+			rl.on('close', () => {
+				if (!registered) {
+					clearTimeout(timeout)
+					reject(new Error(`Plugin ${name} stdout closed before registering`))
+				} else {
+					// reject only in-flight requests belonging to this plugin
+					for (const [id, pending] of pendingRequests.entries()) {
+						if (pending.plugin !== name) continue
+						clearTimeout(pending.timeout)
+						pendingRequests.delete(id)
+						pending.reject(new Error(`Plugin ${name} closed unexpectedly`))
+					}
+				}
+			})
 		})
 
 	// delete existing plugin metadata
@@ -188,16 +331,32 @@ export async function codegen_setup(
 				args.unshift(plugin.executable)
 			}
 
-			console.time(`Spawn ${plugin.name}`)
-			plugins[plugin.name] = {
-				// kick off the plugin process
-				process: spawn(executable, args, {
-					stdio: 'inherit',
-					detached: process.platform !== 'win32',
-				}),
+			if (useStdio) {
+				args.push('--transport', 'stdio')
+			}
 
-				// and wait for the plugin to report back its port
-				...(await wait_for_plugin(plugin.name)),
+			console.time(`Spawn ${plugin.name}`)
+			const child = spawn(executable, args, {
+				// [stdin, stdout, stderr]: stdio plugins need piped stdin/stdout for the
+				// message protocol; stderr is always inherited so plugin logs reach the terminal
+				stdio: useStdio ? ['pipe', 'pipe', 'inherit'] : ['inherit', 'inherit', 'inherit'],
+				detached: process.platform !== 'win32',
+			})
+
+			if (useStdio) {
+				stdioStdin.set(plugin.name, child.stdin!)
+				child.stdin!.on('error', (err: Error) => {
+					if ((err as NodeJS.ErrnoException).code !== 'EPIPE') {
+						console.error(`[${plugin.name}] stdin error:`, err.message)
+					}
+				})
+			}
+
+			plugins[plugin.name] = {
+				process: child,
+				...(await (useStdio
+					? wait_for_plugin_stdio(plugin.name, child)
+					: wait_for_plugin(plugin.name))),
 			}
 			console.timeEnd(`Spawn ${plugin.name}`)
 		})
@@ -218,6 +377,7 @@ export async function codegen_setup(
 			reject: (reason: any) => void
 			timeout: NodeJS.Timeout
 			hook: string
+			plugin: string
 		}
 	>()
 
@@ -308,27 +468,44 @@ export async function codegen_setup(
 			throw new Error(`unknown plugin: ${name}`)
 		}
 		const { port, directory } = plugin
-		const ws = await getOrCreateWS(name, port)
 
-		return new Promise((resolve, reject) => {
-			const messageId = String(++messageCounter)
+		const messageId = String(++messageCounter)
+		const message = {
+			id: messageId,
+			type: 'request',
+			hook,
+			payload,
+			taskId: task_id,
+			pluginDirectory: directory,
+		}
 
-			const timeout = setTimeout(() => {
-				pendingRequests.delete(messageId)
-				reject(new Error(`WebSocket request timeout for ${name}/${hook}`))
-			}, 30000)
-			pendingRequests.set(messageId, { resolve, reject, timeout, hook })
-
-			const message = {
-				id: messageId,
-				type: 'request',
-				hook,
-				payload,
-				taskId: task_id,
-				pluginDirectory: directory,
+		if (useStdio) {
+			// stdio transport: write newline-delimited JSON to the plugin's stdin
+			const stdin = stdioStdin.get(name)
+			if (!stdin) {
+				throw new Error(`No stdio channel for plugin ${name}`)
 			}
-			ws.send(JSON.stringify(message))
-		})
+			return new Promise((resolve, reject) => {
+				const timeout = setTimeout(() => {
+					pendingRequests.delete(messageId)
+					reject(new Error(`Request timeout for ${name}/${hook}`))
+				}, 30000)
+				pendingRequests.set(messageId, { resolve, reject, timeout, hook, plugin: name })
+				stdin.write(JSON.stringify(message) + '\n')
+			})
+		} else {
+			// WebSocket transport: await the connection before registering the pending request
+			// so that a connection failure rejects immediately rather than timing out
+			const ws = await getOrCreateWS(name, port)
+			return new Promise((resolve, reject) => {
+				const timeout = setTimeout(() => {
+					pendingRequests.delete(messageId)
+					reject(new Error(`WebSocket request timeout for ${name}/${hook}`))
+				}, 30000)
+				pendingRequests.set(messageId, { resolve, reject, timeout, hook, plugin: name })
+				ws.send(JSON.stringify(message))
+			})
+		}
 	}
 
 	const trigger_hook = async (
@@ -368,6 +545,9 @@ export async function codegen_setup(
 		return result
 	}
 
+	// expose trigger_hook to the stdio invoke handlers
+	triggerHookRef.fn = trigger_hook
+
 	// write the current config values to the database
 	await write_config(db, config, invoke_hook, plugin_specs, mode)
 
@@ -398,9 +578,18 @@ export async function codegen_setup(
 			}
 			wsConnections.clear()
 
-			// clear pending requests
-			for (const [, { timeout }] of pendingRequests.entries()) {
+			// signal stdio plugins to exit by closing their stdin
+			for (const [, stdin] of stdioStdin.entries()) {
+				try {
+					stdin.end()
+				} catch {}
+			}
+			stdioStdin.clear()
+
+			// reject and clear pending requests
+			for (const [, { timeout, reject }] of pendingRequests.entries()) {
 				clearTimeout(timeout)
+				reject(new Error('codegen closed'))
 			}
 			pendingRequests.clear()
 

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -139,6 +139,13 @@ export type ConfigFile = {
 	runtimeDir?: string
 
 	/**
+	 * Transport used between the Node.js orchestrator and plugin processes.
+	 * 'stdio' routes all communication over stdin/stdout (required for WASI plugins).
+	 * @default 'websocket'
+	 */
+	pluginTransport?: 'websocket' | 'stdio'
+
+	/**
 	 * Configure the router
 	 */
 	router?: RouterConfig

--- a/plugins/hooks.go
+++ b/plugins/hooks.go
@@ -20,6 +20,10 @@ func TriggerHookSerial[PluginConfig any](
 	hook string,
 	payload map[string]any,
 ) (map[string]any, error) {
+	if transportMode == "stdio" {
+		return StdioInvoke(ctx, hook, payload, false)
+	}
+
 	// build up the result of invoking the hook on matching plugins
 	result := map[string]any{}
 
@@ -74,6 +78,10 @@ func TriggerHookParallel[PluginConfig any](
 	hook string,
 	payload map[string]any,
 ) (map[string]any, error) {
+	if transportMode == "stdio" {
+		return StdioInvoke(ctx, hook, payload, true)
+	}
+
 	// build up the result of invoking the hook on matching plugins
 	result := map[string]any{}
 	var resultMu sync.Mutex // to protect concurrent writes
@@ -140,6 +148,10 @@ func TriggerHookParallelWithConn[PluginConfig any](
 	hook string,
 	payload map[string]any,
 ) (map[string]any, error) {
+	if transportMode == "stdio" {
+		return StdioInvoke(ctx, hook, payload, true)
+	}
+
 	// build up the result of invoking the hook on matching plugins
 	result := map[string]any{}
 	var resultMu sync.Mutex // to protect concurrent writes

--- a/plugins/run.go
+++ b/plugins/run.go
@@ -19,12 +19,14 @@ import (
 )
 
 var (
-	configHost   string = ""
-	databasePath string = ""
+	configHost    string = ""
+	databasePath  string = ""
+	transportMode string = "websocket"
 )
 
 func ParseFlags() {
 	flag.StringVar(&databasePath, "database", "", "")
+	flag.StringVar(&transportMode, "transport", "websocket", "transport protocol: websocket or stdio")
 	flag.Parse()
 
 	// make sure a database path is provided
@@ -56,6 +58,10 @@ func Run[PluginConfig any](plugin HoudiniPlugin[PluginConfig]) error {
 	// load both of the config values
 	db.ReloadPluginConfig(ctx)
 	db.ReloadProjectConfig(ctx)
+
+	if transportMode == "stdio" {
+		return runStdio(ctx, plugin)
+	}
 
 	// register hooks for both HTTP and WebSocket together
 	httpRegistered := map[string]struct{}{}

--- a/plugins/stdio.go
+++ b/plugins/stdio.go
@@ -1,0 +1,236 @@
+package plugins
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// StdioInbound covers messages received on stdin: "request" from Node.js and
+// "invoke_result" as responses to our own invoke calls.
+type StdioInbound struct {
+	ID              string         `json:"id"`
+	Type            string         `json:"type"`
+	Hook            string         `json:"hook"`
+	Payload         map[string]any `json:"payload"`
+	TaskID          string         `json:"taskId"`
+	PluginDirectory string         `json:"pluginDirectory"`
+	Result          any            `json:"result"`
+	Error           any            `json:"error"`
+}
+
+// StdioRegister is written to stdout once on startup.
+type StdioRegister struct {
+	Type           string   `json:"type"` // always "register"
+	Name           string   `json:"name"`
+	Hooks          []string `json:"hooks"`
+	Order          string   `json:"order"`
+	IncludeRuntime any      `json:"includeRuntime,omitempty"`
+	ConfigModule   any      `json:"configModule,omitempty"`
+	ClientPlugins  any      `json:"clientPlugins,omitempty"`
+}
+
+// StdioResponse is written to stdout in reply to a "request" message.
+type StdioResponse struct {
+	ID     string `json:"id"`
+	Type   string `json:"type"` // always "response"
+	Result any    `json:"result,omitempty"`
+	Error  any    `json:"error,omitempty"`
+}
+
+// StdioInvokeMsg is written to stdout to ask Node.js to call other plugins.
+type StdioInvokeMsg struct {
+	ID       string         `json:"id"`
+	Type     string         `json:"type"` // always "invoke"
+	Hook     string         `json:"hook"`
+	Payload  map[string]any `json:"payload"`
+	TaskID   string         `json:"taskId,omitempty"`
+	Parallel bool           `json:"parallel,omitempty"`
+}
+
+var (
+	stdioWriteMu     sync.Mutex
+	pendingInvokes   = make(map[string]chan StdioInbound)
+	pendingInvokesMu sync.Mutex
+	stdioIDCounter   atomic.Int64
+)
+
+func writeStdio(msg any) error {
+	stdioWriteMu.Lock()
+	defer stdioWriteMu.Unlock()
+	return json.NewEncoder(os.Stdout).Encode(msg)
+}
+
+// StdioInvoke sends an invoke message to Node.js and waits for the aggregated
+// result. Used by TriggerHookSerial/Parallel when in stdio transport mode so
+// the Go binary can trigger hooks on other plugins without direct networking.
+func StdioInvoke(ctx context.Context, hook string, payload map[string]any, parallel bool) (map[string]any, error) {
+	id := fmt.Sprintf("go-invoke-%d", stdioIDCounter.Add(1))
+
+	ch := make(chan StdioInbound, 1)
+	pendingInvokesMu.Lock()
+	pendingInvokes[id] = ch
+	pendingInvokesMu.Unlock()
+	defer func() {
+		pendingInvokesMu.Lock()
+		delete(pendingInvokes, id)
+		pendingInvokesMu.Unlock()
+	}()
+
+	taskID := ""
+	if tid := TaskIDFromContext(ctx); tid != nil {
+		taskID = *tid
+	}
+
+	if err := writeStdio(StdioInvokeMsg{
+		ID:       id,
+		Type:     "invoke",
+		Hook:     hook,
+		Payload:  payload,
+		TaskID:   taskID,
+		Parallel: parallel,
+	}); err != nil {
+		return nil, err
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(30 * time.Second):
+		return nil, fmt.Errorf("timeout waiting for invoke_result for hook %s", hook)
+	case msg := <-ch:
+		if msg.Error != nil {
+			return nil, fmt.Errorf("invoke %s error: %v", hook, msg.Error)
+		}
+		if result, ok := msg.Result.(map[string]any); ok {
+			return result, nil
+		}
+		return map[string]any{}, nil
+	}
+}
+
+func runStdio[PluginConfig any](ctx context.Context, plugin HoudiniPlugin[PluginConfig]) error {
+	// Collect handlers using the same registration path as the WebSocket flow.
+	handlerMap := make(map[string]HookHandler)
+	hooks := registerPluginHooks(plugin, func(hookName string, handler HookHandler) {
+		handlerMap[hookName] = handler
+	})
+
+	// Gather registration metadata (mirrors what Run writes to the plugins table).
+	var includeRuntime any
+	if inc, ok := plugin.(IncludeRuntime); ok {
+		rt, err := inc.IncludeRuntime(ctx)
+		if err != nil {
+			return err
+		}
+		includeRuntime = rt
+	}
+
+	var configModule any
+	if cfg, ok := plugin.(Config); ok {
+		mod, err := cfg.Config(ctx)
+		if err != nil {
+			return err
+		}
+		configModule = mod
+	}
+
+	var clientPlugins any
+	if cp, ok := plugin.(ClientPlugins); ok {
+		plugs, err := cp.ClientPlugins(ctx)
+		if err != nil {
+			return err
+		}
+		b, err := json.Marshal(plugs)
+		if err != nil {
+			return err
+		}
+		clientPlugins = string(b)
+	}
+
+	if err := writeStdio(StdioRegister{
+		Type:           "register",
+		Name:           plugin.Name(),
+		Hooks:          hooks,
+		Order:          string(plugin.Order()),
+		IncludeRuntime: includeRuntime,
+		ConfigModule:   configModule,
+		ClientPlugins:  clientPlugins,
+	}); err != nil {
+		return err
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 10*1024*1024), 10*1024*1024)
+
+	for scanner.Scan() {
+		var msg StdioInbound
+		if err := json.Unmarshal(scanner.Bytes(), &msg); err != nil {
+			continue
+		}
+
+		switch msg.Type {
+		case "request":
+			go func(m StdioInbound) {
+				defer func() {
+					if r := recover(); r != nil {
+						writeStdio(StdioResponse{
+							ID:    m.ID,
+							Type:  "response",
+							Error: map[string]string{"message": fmt.Sprintf("handler panic: %v", r)},
+						})
+					}
+				}()
+
+				handler, ok := handlerMap[m.Hook]
+				if !ok {
+					writeStdio(StdioResponse{
+						ID:    m.ID,
+						Type:  "response",
+						Error: map[string]string{"message": fmt.Sprintf("no handler for hook %s", m.Hook)},
+					})
+					return
+				}
+
+				handlerCtx := context.Background()
+				handlerCtx = ContextWithTaskID(handlerCtx, m.TaskID)
+				handlerCtx = ContextWithPluginDir(handlerCtx, m.PluginDirectory)
+
+				result, err := handler(handlerCtx, m.Payload)
+				if err != nil {
+					var errVal any
+					switch e := err.(type) {
+					case *ErrorList:
+						errVal = e.GetItems()
+					case *Error:
+						errVal = e
+					default:
+						errVal = map[string]string{"message": e.Error()}
+					}
+					writeStdio(StdioResponse{ID: m.ID, Type: "response", Error: errVal})
+					return
+				}
+
+				writeStdio(StdioResponse{ID: m.ID, Type: "response", Result: result})
+			}(msg)
+
+		case "invoke_result":
+			pendingInvokesMu.Lock()
+			ch, ok := pendingInvokes[msg.ID]
+			pendingInvokesMu.Unlock()
+			if ok {
+				select {
+				case ch <- msg:
+				default:
+				}
+			}
+		}
+	}
+
+	return scanner.Err()
+}

--- a/plugins/stdio_test.go
+++ b/plugins/stdio_test.go
@@ -1,0 +1,350 @@
+package plugins
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// minimalPlugin is a bare-bones HoudiniPlugin used for stdio tests.
+type minimalPlugin struct {
+	Plugin[struct{}]
+}
+
+func (p *minimalPlugin) Name() string       { return "test-plugin" }
+func (p *minimalPlugin) Order() PluginOrder { return PluginOrderAfter }
+
+// schemaHookPlugin implements Schema so request/response tests have a real hook to call.
+type schemaHookPlugin struct {
+	Plugin[struct{}]
+}
+
+func (p *schemaHookPlugin) Name() string       { return "schema-plugin" }
+func (p *schemaHookPlugin) Order() PluginOrder { return PluginOrderAfter }
+func (p *schemaHookPlugin) Schema(ctx context.Context) error {
+	return nil
+}
+
+// invokePlugin calls StdioInvoke from its Schema handler so we can test the
+// invoke round-trip without needing a real orchestrator.
+type invokePlugin struct {
+	Plugin[struct{}]
+}
+
+func (p *invokePlugin) Name() string       { return "invoke-plugin" }
+func (p *invokePlugin) Order() PluginOrder { return PluginOrderAfter }
+func (p *invokePlugin) Schema(ctx context.Context) error {
+	_, err := StdioInvoke(ctx, "Validate", map[string]any{"from": "schema"}, false)
+	return err
+}
+
+// withStdioPipes replaces os.Stdin and os.Stdout with pipes for the duration
+// of fn, then restores them.
+func withStdioPipes(t *testing.T, fn func(stdinW *os.File, stdoutR *os.File)) {
+	t.Helper()
+
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldStdin := os.Stdin
+	oldStdout := os.Stdout
+	os.Stdin = stdinR
+	os.Stdout = stdoutW
+
+	defer func() {
+		os.Stdin = oldStdin
+		os.Stdout = oldStdout
+		stdinR.Close()
+		stdoutW.Close()
+	}()
+
+	fn(stdinW, stdoutR)
+}
+
+func readLine(t *testing.T, r *os.File, timeout time.Duration) string {
+	t.Helper()
+	ch := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(r)
+		if scanner.Scan() {
+			ch <- scanner.Text()
+		}
+	}()
+	select {
+	case line := <-ch:
+		return line
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for output")
+		return ""
+	}
+}
+
+func writeMessage(t *testing.T, w *os.File, msg any) {
+	t.Helper()
+	b, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Write(append(b, '\n'))
+}
+
+// ─── register message ─────────────────────────────────────────────────────────
+
+func TestStdio_RegisterMessage(t *testing.T) {
+	withStdioPipes(t, func(stdinW, stdoutR *os.File) {
+		done := make(chan error, 1)
+		go func() {
+			done <- runStdio(context.Background(), &minimalPlugin{})
+		}()
+
+		line := readLine(t, stdoutR, 2*time.Second)
+		stdinW.Close()
+
+		var msg StdioRegister
+		if err := json.Unmarshal([]byte(line), &msg); err != nil {
+			t.Fatalf("could not parse register message: %v", err)
+		}
+		if msg.Type != "register" {
+			t.Errorf("expected type 'register', got %q", msg.Type)
+		}
+		if msg.Name != "test-plugin" {
+			t.Errorf("expected name 'test-plugin', got %q", msg.Name)
+		}
+		if msg.Order != "after" {
+			t.Errorf("expected order 'after', got %q", msg.Order)
+		}
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("runStdio returned error: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("runStdio did not exit after stdin closed")
+		}
+	})
+}
+
+// ─── request → response round-trip ───────────────────────────────────────────
+
+func TestStdio_RequestResponse(t *testing.T) {
+	withStdioPipes(t, func(stdinW, stdoutR *os.File) {
+		done := make(chan error, 1)
+		go func() {
+			done <- runStdio(context.Background(), &schemaHookPlugin{})
+		}()
+
+		readLine(t, stdoutR, 2*time.Second) // register
+
+		writeMessage(t, stdinW, StdioInbound{ID: "req-1", Type: "request", Hook: "Schema"})
+
+		line := readLine(t, stdoutR, 2*time.Second)
+		stdinW.Close()
+
+		var resp StdioResponse
+		if err := json.Unmarshal([]byte(line), &resp); err != nil {
+			t.Fatalf("could not parse response: %v", err)
+		}
+		if resp.Type != "response" {
+			t.Errorf("expected type 'response', got %q", resp.Type)
+		}
+		if resp.ID != "req-1" {
+			t.Errorf("expected id 'req-1', got %q", resp.ID)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected no error, got %v", resp.Error)
+		}
+
+		<-done
+	})
+}
+
+// ─── unknown hook returns error ───────────────────────────────────────────────
+
+func TestStdio_UnknownHook(t *testing.T) {
+	withStdioPipes(t, func(stdinW, stdoutR *os.File) {
+		done := make(chan error, 1)
+		go func() {
+			done <- runStdio(context.Background(), &minimalPlugin{})
+		}()
+
+		readLine(t, stdoutR, 2*time.Second) // register
+
+		writeMessage(t, stdinW, StdioInbound{ID: "req-x", Type: "request", Hook: "NonExistentHook"})
+
+		line := readLine(t, stdoutR, 2*time.Second)
+		stdinW.Close()
+
+		var resp StdioResponse
+		json.Unmarshal([]byte(line), &resp)
+
+		if resp.Error == nil {
+			t.Error("expected an error for unknown hook")
+		}
+		errStr := ""
+		if m, ok := resp.Error.(map[string]any); ok {
+			errStr, _ = m["message"].(string)
+		}
+		if !strings.Contains(errStr, "NonExistentHook") {
+			t.Errorf("expected hook name in error, got: %q", errStr)
+		}
+
+		<-done
+	})
+}
+
+// readLines starts a background goroutine that drains r into a channel using a
+// single shared scanner, avoiding the buffering problem that arises when
+// multiple bufio.Scanners are created on the same file descriptor.
+func readLines(r *os.File) <-chan string {
+	ch := make(chan string, 16)
+	go func() {
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			ch <- scanner.Text()
+		}
+		close(ch)
+	}()
+	return ch
+}
+
+func recvLine(t *testing.T, ch <-chan string, timeout time.Duration) string {
+	t.Helper()
+	select {
+	case line, ok := <-ch:
+		if !ok {
+			t.Fatal("output channel closed unexpectedly")
+		}
+		return line
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for output")
+		return ""
+	}
+}
+
+// ─── concurrent requests get independent responses ───────────────────────────
+
+func TestStdio_ConcurrentRequests(t *testing.T) {
+	withStdioPipes(t, func(stdinW, stdoutR *os.File) {
+		lines := readLines(stdoutR)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- runStdio(context.Background(), &schemaHookPlugin{})
+		}()
+
+		recvLine(t, lines, 2*time.Second) // register
+
+		writeMessage(t, stdinW, StdioInbound{ID: "r-1", Type: "request", Hook: "Schema"})
+		writeMessage(t, stdinW, StdioInbound{ID: "r-2", Type: "request", Hook: "Schema"})
+
+		responses := map[string]StdioResponse{}
+		for range 2 {
+			var resp StdioResponse
+			json.Unmarshal([]byte(recvLine(t, lines, 2*time.Second)), &resp)
+			responses[resp.ID] = resp
+		}
+		stdinW.Close()
+
+		if _, ok := responses["r-1"]; !ok {
+			t.Error("missing response for r-1")
+		}
+		if _, ok := responses["r-2"]; !ok {
+			t.Error("missing response for r-2")
+		}
+
+		<-done
+	})
+}
+
+// ─── invoke round-trip (Go plugin calls out to Node, gets result back) ────────
+
+func TestStdio_InvokeRoundTrip(t *testing.T) {
+	withStdioPipes(t, func(stdinW, stdoutR *os.File) {
+		done := make(chan error, 1)
+		go func() {
+			done <- runStdio(context.Background(), &invokePlugin{})
+		}()
+
+		readLine(t, stdoutR, 2*time.Second) // register
+
+		// trigger the Schema handler, which internally calls StdioInvoke
+		writeMessage(t, stdinW, StdioInbound{ID: "req-1", Type: "request", Hook: "Schema"})
+
+		// the handler blocks on StdioInvoke — read the invoke message it emits
+		var inv StdioInvokeMsg
+		if err := json.Unmarshal([]byte(readLine(t, stdoutR, 2*time.Second)), &inv); err != nil {
+			t.Fatalf("could not parse invoke message: %v", err)
+		}
+		if inv.Type != "invoke" {
+			t.Errorf("expected type 'invoke', got %q", inv.Type)
+		}
+		if inv.Hook != "Validate" {
+			t.Errorf("expected hook 'Validate', got %q", inv.Hook)
+		}
+
+		// send the invoke_result back — the handler unblocks
+		writeMessage(t, stdinW, StdioInbound{
+			ID:     inv.ID,
+			Type:   "invoke_result",
+			Result: map[string]any{"ok": true},
+		})
+
+		// handler completes and sends its response
+		var resp StdioResponse
+		if err := json.Unmarshal([]byte(readLine(t, stdoutR, 2*time.Second)), &resp); err != nil {
+			t.Fatalf("could not parse response: %v", err)
+		}
+		if resp.Error != nil {
+			t.Errorf("unexpected error: %v", resp.Error)
+		}
+
+		stdinW.Close()
+		<-done
+	})
+}
+
+// ─── invoke_result routes to pending channel ──────────────────────────────────
+
+func TestStdio_InvokeResult_RoutedToPending(t *testing.T) {
+	id := "go-invoke-test-1"
+	ch := make(chan StdioInbound, 1)
+
+	pendingInvokesMu.Lock()
+	pendingInvokes[id] = ch
+	pendingInvokesMu.Unlock()
+
+	msg := StdioInbound{ID: id, Type: "invoke_result", Result: map[string]any{"key": "value"}}
+
+	pendingInvokesMu.Lock()
+	target, ok := pendingInvokes[msg.ID]
+	pendingInvokesMu.Unlock()
+
+	if !ok {
+		t.Fatal("pending channel not found")
+	}
+	target <- msg
+
+	select {
+	case received := <-ch:
+		if received.ID != id {
+			t.Errorf("expected id %q, got %q", id, received.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("invoke_result was not routed to pending channel")
+	}
+
+	pendingInvokesMu.Lock()
+	delete(pendingInvokes, id)
+	pendingInvokesMu.Unlock()
+}


### PR DESCRIPTION
This PR introduces a new wasm-compatible protocol to the go compiler that communicates over stdio by sending newline-delimited JSON payloads in and out of the sub-process 