### PR TITLE
Improve logging in go compiler

### DIFF
--- a/legacy/houdini/lib/config.ts
+++ b/legacy/houdini/lib/config.ts
@@ -132,7 +132,7 @@ export class Config {
 		}
 
 		// validate the log level value
-		if (logLevel && !Object.values(LogLevel).includes(logLevel.toLowerCase() as LogLevels)) {
+		if (logLevel && typeof logLevel === 'string' && !Object.values(LogLevel).includes(logLevel.toLowerCase() as LogLevels)) {
 			console.warn(
 				`! Invalid log level provided. Valid values are: ${JSON.stringify(
 					Object.values(LogLevel)
@@ -158,7 +158,7 @@ export class Config {
 		this.defaultListTarget = defaultListTarget
 		this.defaultPaginateMode = defaultPaginateMode
 		this.definitionsFolder = definitionsPath
-		this.logLevel = ((logLevel as LogLevels) || LogLevel.Summary).toLowerCase() as LogLevels
+		this.logLevel = (typeof logLevel === 'string' ? logLevel : LogLevel.Summary) || LogLevel.Summary
 		this.defaultFragmentMasking = defaultFragmentMasking
 		this.routesDir = path.join(this.projectRoot, 'src', 'routes')
 		this.schemaPollInterval = watchSchema?.interval === undefined ? 2000 : watchSchema.interval

--- a/packages/houdini/src/cmd/generate.ts
+++ b/packages/houdini/src/cmd/generate.ts
@@ -96,7 +96,9 @@ export async function generate(
 		}
 
 		// kick off the codegen pipeline (the pipeline through Schema is run in codegen_setup)
-		await run_pipeline(trigger_hook, pipelineOptions)
+		const results = await run_pipeline(trigger_hook, pipelineOptions)
+		const docCount = Object.values(results.GenerateDocuments ?? {}).flat().length
+		console.log(`🎩 Generated ${docCount} ${docCount === 1 ? 'document' : 'documents'}`)
 
 		// we're done, close everything
 		await on_close()

--- a/packages/houdini/src/lib/codegen.ts
+++ b/packages/houdini/src/lib/codegen.ts
@@ -10,7 +10,9 @@ import { create_schema, write_config } from './database.js'
 import type { HookError } from './error.js'
 import { format_hook_error } from './error.js'
 import * as fs from './fs.js'
+import { Logger } from './logger.js'
 import type { ProjectManifest } from './types'
+import { LogLevel } from './types.js'
 
 export type PluginSpec = {
 	name: string
@@ -95,6 +97,8 @@ export async function codegen_setup(
 	db: DatabaseSync,
 	db_file: string
 ): Promise<CompilerProxy> {
+	const logger = new Logger(config.config_file.logLevel ?? LogLevel.Summary)
+
 	// We need the root dir before we get to the exciting stuff
 	await fs.mkdirpSync(conventions.houdini_root(config))
 
@@ -331,7 +335,7 @@ export async function codegen_setup(
 	db.prepare('DELETE FROM plugins').run()
 
 	// start each plugin
-	console.time('Start Plugins')
+	logger.time('Start Plugins')
 	await Promise.all(
 		config.plugins.map(async (plugin) => {
 			let executable = plugin.executable
@@ -348,7 +352,7 @@ export async function codegen_setup(
 				args.push('--transport', 'stdio')
 			}
 
-			console.time(`Spawn ${plugin.name}`)
+			logger.time(`Spawn ${plugin.name}`)
 			const child = spawn(executable, args, {
 				// [stdin, stdout, stderr]: stdio plugins need piped stdin/stdout for the
 				// message protocol; stderr is always inherited so plugin logs reach the terminal
@@ -371,7 +375,7 @@ export async function codegen_setup(
 					? wait_for_plugin_stdio(plugin.name, child)
 					: wait_for_plugin(plugin.name))),
 			}
-			console.timeEnd(`Spawn ${plugin.name}`)
+			logger.timeEnd(`Spawn ${plugin.name}`, LogLevel.Verbose)
 		})
 	)
 
@@ -379,7 +383,7 @@ export async function codegen_setup(
 		plugin_specs.push(spec_results[plugin.name])
 	}
 
-	console.timeEnd('Start Plugins')
+	logger.timeEnd('Start Plugins', LogLevel.Summary)
 
 	const wsConnections = new Map<string, WebSocket>()
 	let messageCounter = 0
@@ -534,26 +538,30 @@ export async function codegen_setup(
 		} = {}
 	) => {
 		const timeName = hook + (task_id ? ` (${task_id})` : '')
-		console.time(timeName)
+		logger.time(timeName)
 		// look for all of the plugins that have registered for this hook
 		const plugins = plugin_specs.filter(({ hooks }) => hooks.has(hook))
 
 		const result: Record<string, any> = {}
 
-		// if the hook is parallel safe, we can run all of the plugins in parallel
-		if (parallel_safe) {
-			await Promise.all(
-				plugins.map(async (plugin) => {
-					result[plugin.name] = await invoke_hook(plugin.name, hook, payload, task_id)
-				})
-			)
-		} else {
-			// if the hook isn't parallel safe, we need to run the plugins in order
-			for (const { name } of plugins) {
-				result[name] = await invoke_hook(name, hook, payload, task_id)
+		try {
+			// if the hook is parallel safe, we can run all of the plugins in parallel
+			if (parallel_safe) {
+				await Promise.all(
+					plugins.map(async (plugin) => {
+						result[plugin.name] = await invoke_hook(plugin.name, hook, payload, task_id)
+					})
+				)
+			} else {
+				// if the hook isn't parallel safe, we need to run the plugins in order
+				for (const { name } of plugins) {
+					result[name] = await invoke_hook(name, hook, payload, task_id)
+				}
 			}
+		} finally {
+			// task-scoped hook calls are HMR partial runs — only show at full
+			logger.timeEnd(timeName, task_id ? LogLevel.Verbose : LogLevel.Summary)
 		}
-		console.timeEnd(timeName)
 
 		return result
 	}
@@ -562,7 +570,7 @@ export async function codegen_setup(
 	triggerHookRef.fn = trigger_hook
 
 	// write the current config values to the database
-	await write_config(db, config, invoke_hook, plugin_specs, mode)
+	await write_config(db, config, invoke_hook, plugin_specs, mode, logger)
 
 	// now we should load the config hook so other plugins can set their defaults
 	await trigger_hook('Config')

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -100,10 +100,10 @@ export type ConfigFile = {
 	types?: TypeConfig
 
 	/**
-	 * Specifies the style of logging houdini will use when generating your file. One of “quiet”, “full”, “summary”, or “short-summary”.
+	 * Controls how much houdini logs during codegen. One of "quiet", "summary",
+	 * "short-summary", or "full". Defaults to "summary".
 	 */
-
-	logLevel?: string
+	logLevel?: import('./types.js').LogLevel
 
 	/**
 	 * A flag to specify the default fragment masking behavior.

--- a/packages/houdini/src/lib/database.ts
+++ b/packages/houdini/src/lib/database.ts
@@ -4,8 +4,8 @@ import type sqlite from 'node:sqlite'
 import type { PluginSpec } from './codegen.js'
 import type { Config } from './config.js'
 import { Logger } from './logger.js'
-import { LogLevel } from './types.js'
 import { default_config } from './project.js'
+import { LogLevel } from './types.js'
 
 export const create_schema = `
 CREATE TABLE IF NOT EXISTS plugins (

--- a/packages/houdini/src/lib/database.ts
+++ b/packages/houdini/src/lib/database.ts
@@ -3,6 +3,8 @@ import type sqlite from 'node:sqlite'
 
 import type { PluginSpec } from './codegen.js'
 import type { Config } from './config.js'
+import { Logger } from './logger.js'
+import { LogLevel } from './types.js'
 import { default_config } from './project.js'
 
 export const create_schema = `
@@ -494,14 +496,15 @@ export async function write_config(
 		args: Record<string, any>
 	) => Promise<Record<string, any>>,
 	plugins: Array<PluginSpec>,
-	mode: string
+	mode: string,
+	logger: Logger = new Logger(LogLevel.Summary)
 ) {
 	// in order to know our configuration values, we need to load the current environment
 	// to do this we need to look at each plugin that supports the environment hook
 	// and invoke it
 	const env = {}
 
-	console.time('Environment')
+	logger.time('Environment')
 	// look at each plugin
 	await Promise.all(
 		plugins.map(async (plugin) => {
@@ -512,7 +515,7 @@ export async function write_config(
 			}
 		})
 	)
-	console.timeEnd('Environment')
+	logger.timeEnd('Environment', LogLevel.Summary)
 
 	// now that we have the environment, we can write our config values to the database
 	const config_file = {
@@ -575,7 +578,7 @@ export async function write_config(
 		config_file.defaultListTarget ?? null,
 		config_file.defaultPaginateMode ?? 'Infinite',
 		config_file.supressPaginationDeduplication ? 1 : 0,
-		config_file.logLevel ?? null,
+		config_file.logLevel?.toUpperCase().replace(/-/g, '_') ?? null,
 		config_file.defaultFragmentMasking === 'enable' ? 1 : 0,
 		JSON.stringify(config_file.defaultKeys ?? []),
 		config_file.persistedQueriesPath ?? path.join(config_file.runtimeDir!, 'queries.json'),

--- a/packages/houdini/src/lib/error.ts
+++ b/packages/houdini/src/lib/error.ts
@@ -114,7 +114,7 @@ export function format_hook_error(rootDir: string, error: HookError, plugin: str
 	if (error.detail) {
 		message += `\n${error.detail}`
 	}
-	console.log(message)
+	console.error(message)
 }
 
 export function format_codeblock(code: string[], lineNrStart: number): string {

--- a/packages/houdini/src/lib/fs.ts
+++ b/packages/houdini/src/lib/fs.ts
@@ -218,8 +218,7 @@ export async function readdir(
 	try {
 		// @ts-ignore
 		return memfs.readdirSync(filepath, opts) as string[]
-	} catch (e) {
-		console.log(e)
+	} catch {
 		return []
 	}
 }

--- a/packages/houdini/src/lib/index.ts
+++ b/packages/houdini/src/lib/index.ts
@@ -1,3 +1,4 @@
+export * from './logger.js'
 export * from './project.js'
 export * from './codegen.js'
 export * as path from './path.js'

--- a/packages/houdini/src/lib/logger.test.ts
+++ b/packages/houdini/src/lib/logger.test.ts
@@ -58,7 +58,7 @@ describe('Logger', () => {
 		test('returns true when level is sufficient', () => {
 			const log = new Logger(LogLevel.Summary)
 			expect(log.at(LogLevel.Summary)).toBe(true)
-			expect(log.at(LogLevel.PluginDetail)).toBe(true)  // PluginDetail < Summary
+			expect(log.at(LogLevel.PluginDetail)).toBe(true) // PluginDetail < Summary
 		})
 
 		test('returns false when level is insufficient', () => {

--- a/packages/houdini/src/lib/logger.test.ts
+++ b/packages/houdini/src/lib/logger.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { Logger } from './logger.js'
+import { LogLevel } from './types.js'
+
+describe('Logger', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {})
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+		vi.spyOn(console, 'warn').mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	describe('info level gating', () => {
+		test('prints when level matches', () => {
+			const log = new Logger(LogLevel.Summary)
+			log.info('hello', LogLevel.Summary)
+			expect(console.log).toHaveBeenCalledWith('hello')
+		})
+
+		test('prints when logger level exceeds minLevel', () => {
+			const log = new Logger(LogLevel.Verbose)
+			log.info('hello', LogLevel.PluginDetail)
+			expect(console.log).toHaveBeenCalledWith('hello')
+		})
+
+		test('suppresses when logger level is below minLevel', () => {
+			const log = new Logger(LogLevel.Summary)
+			log.info('hello', LogLevel.Verbose)
+			expect(console.log).not.toHaveBeenCalled()
+		})
+
+		test('quiet level suppresses summary messages', () => {
+			const log = new Logger(LogLevel.Quiet)
+			log.info('hello', LogLevel.Summary)
+			expect(console.log).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('error and warn always print', () => {
+		test('error prints regardless of level', () => {
+			const log = new Logger(LogLevel.Quiet)
+			log.error('boom')
+			expect(console.error).toHaveBeenCalledWith('boom')
+		})
+
+		test('warn prints regardless of level', () => {
+			const log = new Logger(LogLevel.Quiet)
+			log.warn('careful')
+			expect(console.warn).toHaveBeenCalledWith('careful')
+		})
+	})
+
+	describe('at', () => {
+		test('returns true when level is sufficient', () => {
+			const log = new Logger(LogLevel.Summary)
+			expect(log.at(LogLevel.Summary)).toBe(true)
+			expect(log.at(LogLevel.PluginDetail)).toBe(true)  // PluginDetail < Summary
+		})
+
+		test('returns false when level is insufficient', () => {
+			const log = new Logger(LogLevel.Summary)
+			expect(log.at(LogLevel.Verbose)).toBe(false)
+		})
+	})
+
+	describe('time / timeEnd', () => {
+		test('prints elapsed time when level is sufficient', async () => {
+			const log = new Logger(LogLevel.Summary)
+			log.time('my-label')
+			await new Promise((r) => setTimeout(r, 5))
+			log.timeEnd('my-label', LogLevel.Summary)
+
+			expect(console.log).toHaveBeenCalledOnce()
+			const msg = (console.log as any).mock.calls[0][0] as string
+			expect(msg).toMatch(/my-label/)
+			expect(msg).toMatch(/ms/)
+		})
+
+		test('suppresses elapsed time when level is insufficient', () => {
+			const log = new Logger(LogLevel.Quiet)
+			log.time('my-label')
+			log.timeEnd('my-label', LogLevel.Summary)
+			expect(console.log).not.toHaveBeenCalled()
+		})
+
+		test('is a no-op timeEnd for unknown label', () => {
+			const log = new Logger(LogLevel.Verbose)
+			log.timeEnd('never-started', LogLevel.Quiet)
+			expect(console.log).not.toHaveBeenCalled()
+		})
+	})
+})

--- a/packages/houdini/src/lib/logger.ts
+++ b/packages/houdini/src/lib/logger.ts
@@ -1,0 +1,49 @@
+import { LogLevel } from './types.js'
+
+const LEVEL_ORDER: Record<string, number> = {
+	quiet: 0,
+	'short-summary': 1,
+	summary: 2,
+	full: 3,
+}
+
+export class Logger {
+	private timers = new Map<string, number>()
+	private order: number
+
+	constructor(public readonly level: string = LogLevel.Summary) {
+		this.order = LEVEL_ORDER[level] ?? 1
+	}
+
+	error(msg: string, ...args: unknown[]) {
+		console.error(msg, ...args)
+	}
+
+	warn(msg: string, ...args: unknown[]) {
+		console.warn(msg, ...args)
+	}
+
+	info(msg: string, minLevel: string = LogLevel.Summary) {
+		if (this.order >= (LEVEL_ORDER[minLevel] ?? 1)) {
+			console.log(msg)
+		}
+	}
+
+	time(label: string) {
+		this.timers.set(label, performance.now())
+	}
+
+	timeEnd(label: string, minLevel: string) {
+		const start = this.timers.get(label)
+		if (start === undefined) return
+		this.timers.delete(label)
+		if (this.order >= (LEVEL_ORDER[minLevel] ?? 1)) {
+			const ms = (performance.now() - start).toFixed(1)
+			console.log(`  ${label}: ${ms}ms`)
+		}
+	}
+
+	at(minLevel: string): boolean {
+		return this.order >= (LEVEL_ORDER[minLevel] ?? 1)
+	}
+}

--- a/packages/houdini/src/lib/types.ts
+++ b/packages/houdini/src/lib/types.ts
@@ -3,6 +3,15 @@ import type { SourceMapInput } from 'rollup'
 
 import type { Config } from './config.js'
 
+export const LogLevel = {
+	Quiet: 'quiet',
+	Summary: 'summary',
+	PluginDetail: 'short-summary',
+	Verbose: 'full',
+} as const
+
+export type LogLevel = (typeof LogLevel)[keyof typeof LogLevel]
+
 // the correct component tree for a given url
 export type ProjectManifest = {
 	/** All of the pages in the project */

--- a/packages/houdini/src/runtime/client.ts
+++ b/packages/houdini/src/runtime/client.ts
@@ -89,7 +89,6 @@ export class HoudiniClient {
 		fetching = false,
 		...rest
 	}: ObserveParams<_Data, DocumentArtifact, _Input>): DocumentStore<_Data, _Input> {
-		console.log(this.config)
 		return new DocumentStore<_Data, _Input>({
 			client: this,
 			plugins: createPluginHooks(this.plugins),

--- a/packages/houdini/src/vite/hmr.ts
+++ b/packages/houdini/src/vite/hmr.ts
@@ -43,10 +43,12 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
 
 			// before we do anyting we neeed to make sure everything has run
 			try {
-				await compiler.run_pipeline({
+				const results = await compiler.run_pipeline({
 					// the pipeline through schema is run as part of codegen_setup
 					after: 'Schema',
 				})
+				const docCount = Object.values(results.GenerateDocuments ?? {}).flat().length
+				console.log(`🎩 Generated ${docCount} ${docCount === 1 ? 'document' : 'documents'}`)
 			} catch {}
 		},
 
@@ -74,6 +76,9 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
 				if (filepaths.length === 0) {
 					return
 				}
+
+				const fileCount = filepaths.length
+				console.log(`🎩 Detected ${fileCount} file ${fileCount === 1 ? 'change' : 'changes'}, re-running compiler`)
 
 				// ideally we would be able to check if the file's content has changed before we re-run but there could
 				// be abitrary extraction logic in a plugin that means we have to instead defer to them to extract documents

--- a/packages/houdini/src/vite/hmr.ts
+++ b/packages/houdini/src/vite/hmr.ts
@@ -78,7 +78,11 @@ export function document_hmr(ctx: VitePluginContext): VitePlugin {
 				}
 
 				const fileCount = filepaths.length
-				console.log(`🎩 Detected ${fileCount} file ${fileCount === 1 ? 'change' : 'changes'}, re-running compiler`)
+				console.log(
+					`🎩 Detected ${fileCount} file ${
+						fileCount === 1 ? 'change' : 'changes'
+					}, re-running compiler`
+				)
 
 				// ideally we would be able to check if the file's content has changed before we re-run but there could
 				// be abitrary extraction logic in a plugin that means we have to instead defer to them to extract documents

--- a/packages/houdini/src/vite/houdini.ts
+++ b/packages/houdini/src/vite/houdini.ts
@@ -100,8 +100,13 @@ export function houdini(ctx: VitePluginContext): VitePlugin {
 					// the pipeline through schema is run as part of codegen_setup
 					after: 'Schema',
 				})
-				const buildDocCount = Object.values(buildResults.GenerateDocuments ?? {}).flat().length
-				console.log(`🎩 Generated ${buildDocCount} ${buildDocCount === 1 ? 'document' : 'documents'}`)
+				const buildDocCount = Object.values(buildResults.GenerateDocuments ?? {}).flat()
+					.length
+				console.log(
+					`🎩 Generated ${buildDocCount} ${
+						buildDocCount === 1 ? 'document' : 'documents'
+					}`
+				)
 
 				// make sure we don't build twice
 				alreadyBuilt = true

--- a/packages/houdini/src/vite/houdini.ts
+++ b/packages/houdini/src/vite/houdini.ts
@@ -96,10 +96,12 @@ export function houdini(ctx: VitePluginContext): VitePlugin {
 				!alreadyBuilt
 			) {
 				// run the codegen
-				await compiler.run_pipeline({
+				const buildResults = await compiler.run_pipeline({
 					// the pipeline through schema is run as part of codegen_setup
 					after: 'Schema',
 				})
+				const buildDocCount = Object.values(buildResults.GenerateDocuments ?? {}).flat().length
+				console.log(`🎩 Generated ${buildDocCount} ${buildDocCount === 1 ? 'document' : 'documents'}`)
 
 				// make sure we don't build twice
 				alreadyBuilt = true

--- a/packages/houdini/src/vite/index.ts
+++ b/packages/houdini/src/vite/index.ts
@@ -110,7 +110,7 @@ async function load_vite_plugins(ctx: VitePluginContext): Promise<Array<PluginOp
 
 						pluginModule = await import(viteFileUrl)
 					} catch (resolveError) {
-						console.log(
+						console.warn(
 							'skipping plugin',
 							plugin.name,
 							'due to resolution error:',

--- a/packages/houdini/src/vite/schema.ts
+++ b/packages/houdini/src/vite/schema.ts
@@ -60,7 +60,7 @@ export function refresh_on_schema(ctx: VitePluginContext): PluginOption {
 				// load the schema
 				await run_pipeline(compiler.trigger_hook, { start: 'Schema' })
 			} catch (e) {
-				console.log(e)
+				console.error(e)
 			}
 		},
 	}

--- a/plugins/logger.go
+++ b/plugins/logger.go
@@ -1,0 +1,98 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+const (
+	LogLevelQuiet        = 0 // errors and doc-change info only
+	LogLevelPluginDetail = 1 // short-summary — less than summary
+	LogLevelSummary      = 2 // + pipeline phase timing totals
+	LogLevelVerbose      = 3 // + per-plugin spawn and per-hook timing
+)
+
+type Logger struct {
+	level  int
+	mu     sync.Mutex
+	timers map[string]time.Time
+}
+
+func NewLogger(level int) *Logger {
+	return &Logger{
+		level:  level,
+		timers: make(map[string]time.Time),
+	}
+}
+
+// parseLogLevel converts a DB log level string (e.g. "SUMMARY") to its integer constant.
+func parseLogLevel(s string) int {
+	switch s {
+	case "QUIET":
+		return LogLevelQuiet
+	case "SUMMARY":
+		return LogLevelSummary
+	case "SHORT_SUMMARY":
+		return LogLevelPluginDetail
+	case "FULL":
+		return LogLevelVerbose
+	default:
+		return LogLevelSummary
+	}
+}
+
+// Logger returns a logger seeded from the project's configured log level.
+func (db DatabasePool[PluginConfig]) Logger(ctx context.Context) (*Logger, error) {
+	config, err := db.ProjectConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return NewLogger(parseLogLevel(config.LogLevel)), nil
+}
+
+// Error always prints to stderr regardless of log level.
+func (l *Logger) Error(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+}
+
+// Warn always prints to stderr regardless of log level.
+func (l *Logger) Warn(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+}
+
+// Info prints to stderr only when the logger's level is >= minLevel.
+func (l *Logger) Info(minLevel int, format string, args ...any) {
+	if l.level >= minLevel {
+		fmt.Fprintf(os.Stderr, format+"\n", args...)
+	}
+}
+
+// Time starts a named timer.
+func (l *Logger) Time(label string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.timers[label] = time.Now()
+}
+
+// TimeEnd stops the named timer and prints the elapsed time if level >= minLevel.
+func (l *Logger) TimeEnd(label string, minLevel int) {
+	l.mu.Lock()
+	start, ok := l.timers[label]
+	if ok {
+		delete(l.timers, label)
+	}
+	l.mu.Unlock()
+
+	if ok && l.level >= minLevel {
+		ms := float64(time.Since(start).Nanoseconds()) / 1e6
+		fmt.Fprintf(os.Stderr, "  %s: %.1fms\n", label, ms)
+	}
+}
+
+// At reports whether the logger's level is at or above minLevel.
+func (l *Logger) At(minLevel int) bool {
+	return l.level >= minLevel
+}

--- a/plugins/logger_test.go
+++ b/plugins/logger_test.go
@@ -1,0 +1,122 @@
+package plugins
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+
+	fn()
+
+	w.Close()
+	os.Stderr = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	return buf.String()
+}
+
+func TestLogger_Info_LevelGating(t *testing.T) {
+	out := captureStderr(t, func() {
+		l := NewLogger(LogLevelSummary)
+		l.Info(LogLevelSummary, "should print")
+		l.Info(LogLevelVerbose, "should not print")
+	})
+
+	if !strings.Contains(out, "should print") {
+		t.Errorf("expected 'should print' in output, got: %q", out)
+	}
+	if strings.Contains(out, "should not print") {
+		t.Errorf("expected 'should not print' to be suppressed, got: %q", out)
+	}
+}
+
+func TestLogger_Info_Quiet(t *testing.T) {
+	out := captureStderr(t, func() {
+		l := NewLogger(LogLevelQuiet)
+		l.Info(LogLevelSummary, "suppressed")
+	})
+
+	if strings.Contains(out, "suppressed") {
+		t.Errorf("quiet logger should suppress summary messages, got: %q", out)
+	}
+}
+
+func TestLogger_ErrorAndWarn_AlwaysPrint(t *testing.T) {
+	out := captureStderr(t, func() {
+		l := NewLogger(LogLevelQuiet)
+		l.Error("error message")
+		l.Warn("warn message")
+	})
+
+	if !strings.Contains(out, "error message") {
+		t.Errorf("Error should always print, got: %q", out)
+	}
+	if !strings.Contains(out, "warn message") {
+		t.Errorf("Warn should always print, got: %q", out)
+	}
+}
+
+func TestLogger_At(t *testing.T) {
+	l := NewLogger(LogLevelSummary)
+
+	if !l.At(LogLevelSummary) {
+		t.Error("expected At(Summary) to be true for Summary logger")
+	}
+	if !l.At(LogLevelPluginDetail) {
+		t.Error("expected At(PluginDetail) to be true for Summary logger (PluginDetail < Summary)")
+	}
+	if l.At(LogLevelVerbose) {
+		t.Error("expected At(Verbose) to be false for Summary logger")
+	}
+}
+
+func TestLogger_TimeEnd_PrintsElapsed(t *testing.T) {
+	out := captureStderr(t, func() {
+		l := NewLogger(LogLevelSummary)
+		l.Time("my-op")
+		time.Sleep(5 * time.Millisecond)
+		l.TimeEnd("my-op", LogLevelSummary)
+	})
+
+	if !strings.Contains(out, "my-op") {
+		t.Errorf("expected label in output, got: %q", out)
+	}
+	if !strings.Contains(out, "ms") {
+		t.Errorf("expected 'ms' in timing output, got: %q", out)
+	}
+}
+
+func TestLogger_TimeEnd_Suppressed(t *testing.T) {
+	out := captureStderr(t, func() {
+		l := NewLogger(LogLevelQuiet)
+		l.Time("my-op")
+		l.TimeEnd("my-op", LogLevelSummary)
+	})
+
+	if strings.Contains(out, "my-op") {
+		t.Errorf("expected timing to be suppressed at Quiet level, got: %q", out)
+	}
+}
+
+func TestLogger_TimeEnd_UnknownLabel(t *testing.T) {
+	out := captureStderr(t, func() {
+		l := NewLogger(LogLevelVerbose)
+		l.TimeEnd("never-started", LogLevelQuiet)
+	})
+
+	if strings.Contains(out, "never-started") {
+		t.Errorf("TimeEnd for unknown label should be a no-op, got: %q", out)
+	}
+}


### PR DESCRIPTION
This PR splits the current logging infrastructure into the pre-defined levels so users do not have to see phase timings if they dont want to