### PR TITLE
Add record.refresh() to reload a record's documents from the API

### DIFF
--- a/.changeset/refresh-cache-record.md
+++ b/.changeset/refresh-cache-record.md
@@ -3,4 +3,4 @@
 'houdini-core': minor
 ---
 
-Add `refresh()` to cache records: every document whose data contains the record refetches itself from the API, including documents that only contain the record behind a fragment spread. The cache now pushes tagged messages to subscribers (`{ kind: 'update', data }` / `{ kind: 'refetch' }`) and the `set` callback on subscription specs is now called `onMessage`, which is a breaking change for anyone calling `cache.subscribe` directly.
+Add `record.refresh()` to refetch every document that contains a given cache record, including those that reference it only through a fragment spread.

--- a/.changeset/refresh-cache-record.md
+++ b/.changeset/refresh-cache-record.md
@@ -1,0 +1,6 @@
+---
+'houdini': minor
+'houdini-core': minor
+---
+
+Add `refresh()` to cache records: every document whose data contains the record refetches itself from the API, including documents that only contain the record behind a fragment spread. The cache now pushes tagged messages to subscribers (`{ kind: 'update', data }` / `{ kind: 'refetch' }`) and the `set` callback on subscription specs is now called `onMessage`, which is a breaking change for anyone calling `cache.subscribe` directly.

--- a/docs/shared/01-reference/06-cache.mdx
+++ b/docs/shared/01-reference/06-cache.mdx
@@ -239,6 +239,22 @@ const user = cache.get('User', { id: '1' })
 user.delete()
 ```
 
+## Refreshing Records
+
+If you want to reload a record's values from your API (for example, after a mutation
+that you know changed data on the server), you can use the `refresh` method. Every
+document whose data contains the record will refetch itself over the network —
+including documents that only include the record through a fragment spread:
+
+```typescript
+const user = cache.get('User', { id: '1' })
+
+user.refresh()
+```
+
+Unlike `markStale` (which waits for the next fetch to reload the data), `refresh`
+triggers the network requests immediately.
+
 ## Lists
 
 Another primitive provided by the `cache` instance is `List` and it provide a programatic

--- a/e2e/kit/src/lib/utils/routes.ts
+++ b/e2e/kit/src/lib/utils/routes.ts
@@ -14,6 +14,7 @@ export const routes = {
 	conditional_fragment_spread: '/conditional-fragment-spread',
 	loading_state: '/loading-state',
 	required_field: '/required-field',
+	Cache_Refresh: '/cache/refresh',
 
 	Lists_fragment: '/lists/fragment',
 	Lists_mutation_insert: '/lists/mutation-insert',

--- a/e2e/kit/src/routes/cache/refresh/+page.svelte
+++ b/e2e/kit/src/routes/cache/refresh/+page.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+import { cache, graphql } from '$houdini'
+import { onMount } from 'svelte'
+import UserDetails from './UserDetails.svelte'
+
+const store = graphql(`
+	query RefreshCacheQuery {
+		user(id: "1", snapshot: "cache-refresh") {
+			id
+			...RefreshCacheUserDetails
+		}
+	}
+`)
+
+onMount(() => {
+	store.fetch()
+})
+</script>
+
+<h1>Cache Refresh</h1>
+
+{#if $store.data}
+	<UserDetails user={$store.data.user} />
+{/if}
+
+<button
+	id="refresh"
+	on:click={() => {
+		if ($store.data) {
+			cache.get('User', { id: $store.data.user.id }).refresh()
+		}
+	}}>refresh</button
+>

--- a/e2e/kit/src/routes/cache/refresh/UserDetails.svelte
+++ b/e2e/kit/src/routes/cache/refresh/UserDetails.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+import { fragment, graphql, type RefreshCacheUserDetails } from '$houdini'
+
+export let user: RefreshCacheUserDetails | null
+
+$: data = fragment(
+	user,
+	graphql(`
+		fragment RefreshCacheUserDetails on User {
+			name
+		}
+	`)
+)
+</script>
+
+<div id="user-name">{$data?.name}</div>

--- a/e2e/kit/src/routes/cache/refresh/spec.ts
+++ b/e2e/kit/src/routes/cache/refresh/spec.ts
@@ -1,0 +1,21 @@
+import { test } from '@playwright/test'
+import { routes } from '../../../lib/utils/routes.js'
+import { expect_1_gql, expect_to_be, goto_expect_n_gql } from '../../../lib/utils/testsHelper.js'
+
+test.describe('cache refresh', () => {
+	test('refreshing a record refetches the query that contains it', async ({ page }) => {
+		// load the page and wait for the initial query
+		await goto_expect_n_gql(page, routes.Cache_Refresh, 1)
+
+		// the fragment renders the user's name. the query only contains the
+		// user behind the fragment's mask
+		await expect_to_be(page, 'Bruce Willis', 'div[id=user-name]')
+
+		// refreshing the user record triggers exactly one network request:
+		// the query that contains it refetches itself
+		await expect_1_gql(page, 'button[id=refresh]')
+
+		// and the data is still rendered after the round trip
+		await expect_to_be(page, 'Bruce Willis', 'div[id=user-name]')
+	})
+})

--- a/packages/houdini-core/runtime/plugins/fragment.ts
+++ b/packages/houdini-core/runtime/plugins/fragment.ts
@@ -48,9 +48,16 @@ export const fragment = (cache: Cache) =>
 						selection: ctx.artifact.selection,
 						variables: () => variables,
 						parentID: ctx.stuff.parentID,
-						set: (newValue) => {
+						onMessage: (message) => {
+							// fragments can't issue network requests. refetch messages are
+							// handled by the query that owns this data — it holds its own
+							// (silent) subscription on the same records
+							if (message.kind !== 'update') {
+								return
+							}
+
 							resolve(ctx, {
-								data: newValue,
+								data: message.data,
 								errors: null,
 								fetching: false,
 								partial: false,

--- a/packages/houdini-core/runtime/plugins/fragment.ts
+++ b/packages/houdini-core/runtime/plugins/fragment.ts
@@ -51,7 +51,7 @@ export const fragment = (cache: Cache) =>
 						onMessage: (message) => {
 							// fragments can't issue network requests. refetch messages are
 							// handled by the query that owns this data — it holds its own
-							// (silent) subscription on the same records
+							// masked parent subscription on the same records
 							if (message.kind !== 'update') {
 								return
 							}

--- a/packages/houdini-core/runtime/plugins/query.ts
+++ b/packages/houdini-core/runtime/plugins/query.ts
@@ -1,6 +1,6 @@
 import type { RuntimeScalarPayload } from 'houdini'
 import type { Cache } from 'houdini/runtime/cache'
-import { type SubscriptionSpec, ArtifactKind, DataSource } from 'houdini/runtime/types'
+import { type SubscriptionSpec, ArtifactKind, CachePolicy, DataSource } from 'houdini/runtime/types'
 
 import { documentPlugin } from './utils/index.js'
 
@@ -63,9 +63,20 @@ export const query = (cache: Cache) =>
 						rootType: ctx.artifact.rootType,
 						selection: ctx.artifact.selection,
 						variables: () => variables,
-						set: (newValue) => {
+						onMessage: (message) => {
+							// if the cache asked us to refetch, kick off a brand new request
+							// through the full pipeline so the document reloads from the API
+							if (message.kind === 'refetch') {
+								ctx.documentStore.send({
+									policy: CachePolicy.NetworkOnly,
+									session: ctx.session,
+									metadata: ctx.metadata,
+								})
+								return
+							}
+
 							resolve(ctx, {
-								data: newValue,
+								data: message.data,
 								errors: null,
 								fetching: false,
 								partial: false,

--- a/packages/houdini-core/runtime/public/record.ts
+++ b/packages/houdini-core/runtime/public/record.ts
@@ -95,6 +95,14 @@ export class Record<Def extends CacheTypeDef, Type extends ValidTypes<Def>> {
 	}
 
 	/**
+	 * Ask every document whose data contains this record to refetch itself
+	 * so the record's values are reloaded from the API.
+	 */
+	refresh() {
+		this.#cache._internal_unstable.refresh(this.#id)
+	}
+
+	/**
 	 * Mark some elements of the record stale in the cache.
 	 * @param field
 	 * @param when

--- a/packages/houdini-core/runtime/public/tests/list.test.ts
+++ b/packages/houdini-core/runtime/public/tests/list.test.ts
@@ -109,7 +109,7 @@ test('list.append accepts record proxies', () => {
 	// subscribe to the fields
 	cache._internal_unstable.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -134,32 +134,35 @@ test('list.append accepts record proxies', () => {
 
 	// make sure the duplicate has been removed
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: {
-				edges: [
-					{
-						node: {
-							__typename: 'Cat',
-							id: '2',
-							firstName: 'mary',
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: {
+					edges: [
+						{
+							node: {
+								__typename: 'Cat',
+								id: '2',
+								firstName: 'mary',
+							},
 						},
-					},
-					{
-						node: {
-							__typename: 'User',
-							id: '3',
-							firstName: 'jane',
+						{
+							node: {
+								__typename: 'User',
+								id: '3',
+								firstName: 'jane',
+							},
 						},
-					},
-					{
-						node: {
-							__typename: 'User',
-							id: '4',
-							firstName: 'jacob',
+						{
+							node: {
+								__typename: 'User',
+								id: '4',
+								firstName: 'jacob',
+							},
 						},
-					},
-				],
+					],
+				},
 			},
 		},
 	})
@@ -270,7 +273,7 @@ test('list.prepend accepts record proxies', () => {
 	// subscribe to the fields
 	cache._internal_unstable.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -295,32 +298,35 @@ test('list.prepend accepts record proxies', () => {
 
 	// make sure the duplicate has been removed
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: {
-				edges: [
-					{
-						node: {
-							__typename: 'User',
-							id: '4',
-							firstName: 'jacob',
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: {
+					edges: [
+						{
+							node: {
+								__typename: 'User',
+								id: '4',
+								firstName: 'jacob',
+							},
 						},
-					},
-					{
-						node: {
-							__typename: 'Cat',
-							id: '2',
-							firstName: 'mary',
+						{
+							node: {
+								__typename: 'Cat',
+								id: '2',
+								firstName: 'mary',
+							},
 						},
-					},
-					{
-						node: {
-							__typename: 'User',
-							id: '3',
-							firstName: 'jane',
+						{
+							node: {
+								__typename: 'User',
+								id: '3',
+								firstName: 'jane',
+							},
 						},
-					},
-				],
+					],
+				},
 			},
 		},
 	})
@@ -401,7 +407,7 @@ test('list when must', () => {
 	// subscribe to the fields
 	cache._internal_unstable.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -429,18 +435,21 @@ test('list when must', () => {
 
 	// make sure we got the new value
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: [
-				{
-					firstName: 'mary',
-					id: '3',
-				},
-				{
-					firstName: 'jane',
-					id: '2',
-				},
-			],
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						firstName: 'mary',
+						id: '3',
+					},
+					{
+						firstName: 'jane',
+						id: '2',
+					},
+				],
+			},
 		},
 	})
 })
@@ -514,7 +523,7 @@ test('can remove record', () => {
 	// subscribe to the fields
 	cache._internal_unstable.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -528,9 +537,12 @@ test('can remove record', () => {
 	// the first time set was called, a new entry was added.
 	// the second time it's called, we get a new value for mary-prime
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: [],
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: [],
+			},
 		},
 	})
 })
@@ -624,7 +636,7 @@ test('can toggle records', () => {
 				},
 			},
 			parentID: cache._internal_unstable._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -731,7 +743,7 @@ test('can remove record from all lists', () => {
 				},
 			},
 			parentID: cache._internal_unstable._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)

--- a/packages/houdini/src/runtime/cache/gc.ts
+++ b/packages/houdini/src/runtime/cache/gc.ts
@@ -36,12 +36,12 @@ export class GarbageCollector {
 		// look at every field of every record we know about
 		for (const [id, fieldMap] of this.lifetimes.entries()) {
 			for (const [field, lifetime] of fieldMap.entries()) {
-				// if there is an active subscriber for the field move on. silent
+				// if there is an active subscriber for the field move on. masked parent
 				// subscriptions count too — a masked field is still part of some
 				// document's active data even if no one is notified when it changes
 				if (
 					this.cache._internal_unstable.subscriptions.get(id, field).length > 0 ||
-					this.cache._internal_unstable.subscriptions.getSilent(id, field).length > 0
+					this.cache._internal_unstable.subscriptions.getMaskedParents(id, field).length > 0
 				) {
 					continue
 				}

--- a/packages/houdini/src/runtime/cache/gc.ts
+++ b/packages/houdini/src/runtime/cache/gc.ts
@@ -36,8 +36,13 @@ export class GarbageCollector {
 		// look at every field of every record we know about
 		for (const [id, fieldMap] of this.lifetimes.entries()) {
 			for (const [field, lifetime] of fieldMap.entries()) {
-				// if there is an active subscriber for the field move on
-				if (this.cache._internal_unstable.subscriptions.get(id, field).length > 0) {
+				// if there is an active subscriber for the field move on. silent
+				// subscriptions count too — a masked field is still part of some
+				// document's active data even if no one is notified when it changes
+				if (
+					this.cache._internal_unstable.subscriptions.get(id, field).length > 0 ||
+					this.cache._internal_unstable.subscriptions.getSilent(id, field).length > 0
+				) {
 					continue
 				}
 

--- a/packages/houdini/src/runtime/cache/gc.ts
+++ b/packages/houdini/src/runtime/cache/gc.ts
@@ -41,7 +41,8 @@ export class GarbageCollector {
 				// document's active data even if no one is notified when it changes
 				if (
 					this.cache._internal_unstable.subscriptions.get(id, field).length > 0 ||
-					this.cache._internal_unstable.subscriptions.getMaskedParents(id, field).length > 0
+					this.cache._internal_unstable.subscriptions.getMaskedParents(id, field).length >
+						0
 				) {
 					continue
 				}

--- a/packages/houdini/src/runtime/cache/index.ts
+++ b/packages/houdini/src/runtime/cache/index.ts
@@ -198,7 +198,7 @@ export class Cache {
 
 	// ask every document whose data contains the record to refetch itself.
 	// this includes documents that only contain the record behind a masked
-	// boundary (a fragment spread) thanks to their silent subscriptions
+	// boundary (a fragment spread) thanks to their masked parent subscriptions
 	refresh(id: string) {
 		// when an optimistic key resolves we might know the record by two ids
 		const recordIDs = [this._internal_unstable.storage.idMaps[id], id].filter(
@@ -210,7 +210,7 @@ export class Cache {
 		const notified: SubscriptionSpec['onMessage'][] = []
 		for (const recordID of recordIDs) {
 			for (const [spec] of this._internal_unstable.subscriptions.getAll(recordID, {
-				includeSilent: true,
+				includeMaskedParents: true,
 			})) {
 				if (!notified.includes(spec.onMessage)) {
 					notified.push(spec.onMessage)
@@ -525,15 +525,15 @@ class CacheInternal {
 				linkedType = value.__typename as string
 			}
 
-			// the current set of subscribers. the silent ones belong to documents
+			// the current set of subscribers. the masked parent ones belong to documents
 			// whose data contains this record behind a masked boundary — they never
 			// get notified but they do need their subscriptions propagated when
 			// links change so containment lookups (cache.refresh) stay accurate
 			const currentSubscribers = this.subscriptions.get(parent, key)
-			const silentSubscribers = this.subscriptions.getSilent(parent, key)
+			const maskedParentSubscribers = this.subscriptions.getMaskedParents(parent, key)
 			const specs = currentSubscribers
 				.map((sub) => sub[0])
-				.concat(silentSubscribers.map((sub) => sub[0]))
+				.concat(maskedParentSubscribers.map((sub) => sub[0]))
 
 			// look up the previous value
 			const { value: previousValue, displayLayers } = this.storage.get(parent, key)
@@ -662,13 +662,13 @@ class CacheInternal {
 						variables,
 						parentType: linkedType,
 					})
-					if (silentSubscribers.length > 0) {
+					if (maskedParentSubscribers.length > 0) {
 						this.subscriptions.addMany({
 							parent: linkedID,
-							subscribers: silentSubscribers,
+							subscribers: maskedParentSubscribers,
 							variables,
 							parentType: linkedType,
-							silent: true,
+							masked: true,
 						})
 					}
 
@@ -889,13 +889,13 @@ class CacheInternal {
 						variables,
 						parentType: linkedType,
 					})
-					if (silentSubscribers.length > 0) {
+					if (maskedParentSubscribers.length > 0) {
 						this.subscriptions.addMany({
 							parent: id,
-							subscribers: silentSubscribers,
+							subscribers: maskedParentSubscribers,
 							variables,
 							parentType: linkedType,
-							silent: true,
+							masked: true,
 						})
 					}
 				}

--- a/packages/houdini/src/runtime/cache/index.ts
+++ b/packages/houdini/src/runtime/cache/index.ts
@@ -196,6 +196,30 @@ export class Cache {
 		}
 	}
 
+	// ask every document whose data contains the record to refetch itself.
+	// this includes documents that only contain the record behind a masked
+	// boundary (a fragment spread) thanks to their silent subscriptions
+	refresh(id: string) {
+		// when an optimistic key resolves we might know the record by two ids
+		const recordIDs = [this._internal_unstable.storage.idMaps[id], id].filter(
+			Boolean
+		) as string[]
+
+		// a document can be subscribed to multiple fields of the record so make
+		// sure we only send the message once per set
+		const notified: SubscriptionSpec['onMessage'][] = []
+		for (const recordID of recordIDs) {
+			for (const [spec] of this._internal_unstable.subscriptions.getAll(recordID, {
+				includeSilent: true,
+			})) {
+				if (!notified.includes(spec.onMessage)) {
+					notified.push(spec.onMessage)
+					spec.onMessage({ kind: 'refetch' })
+				}
+			}
+		}
+	}
+
 	markRecordStale(id: string, options: { field?: string; when?: {} }) {
 		if (options.field) {
 			const key = computeKey({ field: options.field, args: options.when ?? {} })
@@ -350,20 +374,21 @@ export class Cache {
 		this._internal_unstable.epoch++
 		// the same spec will likely need to be updated multiple times, create the unique list by using the set
 		// function's identity
-		const notified: SubscriptionSpec['set'][] = []
+		const notified: SubscriptionSpec['onMessage'][] = []
 		for (const spec of subs) {
 			// if we haven't added the set yet
-			if (!notified.includes(spec.set)) {
-				notified.push(spec.set)
+			if (!notified.includes(spec.onMessage)) {
+				notified.push(spec.onMessage)
 				// trigger the update
-				spec.set(
-					this._internal_unstable.getSelection({
+				spec.onMessage({
+					kind: 'update',
+					data: this._internal_unstable.getSelection({
 						parent: spec.parentID || rootID,
 						selection: spec.selection,
 						variables: spec.variables?.() || {},
 						ignoreMasking: false,
-					}).data
-				)
+					}).data,
+				})
 			}
 		}
 	}
@@ -500,9 +525,15 @@ class CacheInternal {
 				linkedType = value.__typename as string
 			}
 
-			// the current set of subscribers
+			// the current set of subscribers. the silent ones belong to documents
+			// whose data contains this record behind a masked boundary — they never
+			// get notified but they do need their subscriptions propagated when
+			// links change so containment lookups (cache.refresh) stay accurate
 			const currentSubscribers = this.subscriptions.get(parent, key)
-			const specs = currentSubscribers.map((sub) => sub[0])
+			const silentSubscribers = this.subscriptions.getSilent(parent, key)
+			const specs = currentSubscribers
+				.map((sub) => sub[0])
+				.concat(silentSubscribers.map((sub) => sub[0]))
 
 			// look up the previous value
 			const { value: previousValue, displayLayers } = this.storage.get(parent, key)
@@ -631,6 +662,15 @@ class CacheInternal {
 						variables,
 						parentType: linkedType,
 					})
+					if (silentSubscribers.length > 0) {
+						this.subscriptions.addMany({
+							parent: linkedID,
+							subscribers: silentSubscribers,
+							variables,
+							parentType: linkedType,
+							silent: true,
+						})
+					}
 
 					toNotify.push(...currentSubscribers)
 				}
@@ -849,6 +889,15 @@ class CacheInternal {
 						variables,
 						parentType: linkedType,
 					})
+					if (silentSubscribers.length > 0) {
+						this.subscriptions.addMany({
+							parent: id,
+							subscribers: silentSubscribers,
+							variables,
+							parentType: linkedType,
+							silent: true,
+						})
+					}
 				}
 			}
 

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -450,10 +450,8 @@ export class List {
 
 		// get the list of specs that are subscribing to the list
 		const subscribers = this.cache._internal_unstable.subscriptions.get(this.recordID, this.key)
-		const maskedParentSubscribers = this.cache._internal_unstable.subscriptions.getMaskedParents(
-			this.recordID,
-			this.key
-		)
+		const maskedParentSubscribers =
+			this.cache._internal_unstable.subscriptions.getMaskedParents(this.recordID, this.key)
 
 		// if we are unsubscribing from a connection, the fields we care about
 		// are tucked away under edges

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -450,16 +450,36 @@ export class List {
 
 		// get the list of specs that are subscribing to the list
 		const subscribers = this.cache._internal_unstable.subscriptions.get(this.recordID, this.key)
+		const silentSubscribers = this.cache._internal_unstable.subscriptions.getSilent(
+			this.recordID,
+			this.key
+		)
+
+		// if we are unsubscribing from a connection, the fields we care about
+		// are tucked away under edges
+		const targetSelection = this.connection
+			? this.selection.fields!.edges.selection!
+			: this.selection
 
 		// disconnect record from any subscriptions associated with the list
 		this.cache._internal_unstable.subscriptions.remove(
 			targetID,
-			// if we are unsubscribing from a connection, the fields we care about
-			// are tucked away under edges
-			this.connection ? this.selection.fields!.edges.selection! : this.selection,
+			targetSelection,
 			subscribers.map((sub) => sub[0]),
 			variables
 		)
+		// documents that contain the list behind a masked boundary registered
+		// everything below it silently
+		if (silentSubscribers.length > 0) {
+			this.cache._internal_unstable.subscriptions.remove(
+				targetID,
+				targetSelection,
+				silentSubscribers.map((sub) => sub[0]),
+				variables,
+				[],
+				true
+			)
+		}
 
 		// remove the target from the parent
 		this.cache._internal_unstable.storage.remove(parentID, targetKey, targetID, layer)
@@ -467,14 +487,15 @@ export class List {
 		// notify the subscribers about the change
 		for (const [spec] of subscribers) {
 			// trigger the update
-			spec.set(
-				this.cache._internal_unstable.getSelection({
+			spec.onMessage({
+				kind: 'update',
+				data: this.cache._internal_unstable.getSelection({
 					parent: spec.parentID || this.manager.rootID,
 					selection: spec.selection,
 					variables: spec.variables?.() || {},
 					ignoreMasking: false,
-				}).data
-			)
+				}).data,
+			})
 		}
 
 		// return true if we deleted something

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -450,7 +450,7 @@ export class List {
 
 		// get the list of specs that are subscribing to the list
 		const subscribers = this.cache._internal_unstable.subscriptions.get(this.recordID, this.key)
-		const silentSubscribers = this.cache._internal_unstable.subscriptions.getSilent(
+		const maskedParentSubscribers = this.cache._internal_unstable.subscriptions.getMaskedParents(
 			this.recordID,
 			this.key
 		)
@@ -470,11 +470,11 @@ export class List {
 		)
 		// documents that contain the list behind a masked boundary registered
 		// everything below it silently
-		if (silentSubscribers.length > 0) {
+		if (maskedParentSubscribers.length > 0) {
 			this.cache._internal_unstable.subscriptions.remove(
 				targetID,
 				targetSelection,
-				silentSubscribers.map((sub) => sub[0]),
+				maskedParentSubscribers.map((sub) => sub[0]),
 				variables,
 				[],
 				true

--- a/packages/houdini/src/runtime/cache/subscription.ts
+++ b/packages/houdini/src/runtime/cache/subscription.ts
@@ -177,7 +177,9 @@ export class InMemorySubscriptions {
 
 		// masked parent subscriptions get tracked separately so they never participate
 		// in update notifications
-		const selections = masked ? subscriberField.maskedParentSelections : subscriberField.selections
+		const selections = masked
+			? subscriberField.maskedParentSelections
+			: subscriberField.selections
 		const referenceCounts = masked
 			? subscriberField.maskedParentReferenceCounts
 			: subscriberField.referenceCounts
@@ -500,7 +502,9 @@ export class InMemorySubscriptions {
 		// get the list of subscriptions specs for the id if we didn't provide a specific list
 		if (!targets) {
 			targets = [...(this.subscribers.get(id)?.values() || [])].flatMap((fieldSub) =>
-				fieldSub.selections.concat(fieldSub.maskedParentSelections).flatMap((sel) => sel[0]!)
+				fieldSub.selections
+					.concat(fieldSub.maskedParentSelections)
+					.flatMap((sel) => sel[0]!)
 			)
 		}
 

--- a/packages/houdini/src/runtime/cache/subscription.ts
+++ b/packages/houdini/src/runtime/cache/subscription.ts
@@ -23,7 +23,14 @@ export class InMemorySubscriptions {
 			string,
 			{
 				selections: FieldSelection[]
-				referenceCounts: Map<SubscriptionSpec['set'], number>
+				referenceCounts: Map<SubscriptionSpec['onMessage'], number>
+				// silent subscriptions track documents whose data contains this record
+				// behind a masked boundary (eg a fragment spread). they are never
+				// notified when a value changes but they do participate in containment
+				// lookups (cache.refresh) and write-path propagation so that we always
+				// know every document whose data contains a given record
+				silentSelections: FieldSelection[]
+				silentReferenceCounts: Map<SubscriptionSpec['onMessage'], number>
 			}
 		>
 	>()
@@ -44,12 +51,16 @@ export class InMemorySubscriptions {
 		selection,
 		variables,
 		parentType,
+		silent = false,
 	}: {
 		parent: string
 		parentType?: string
 		spec: SubscriptionSpec
 		selection: SubscriptionSelection
 		variables: { [key: string]: GraphQLValue }
+		// when true, every subscription we register is silent regardless of the
+		// field's visibility. this happens when the walk crosses a masked boundary
+		silent?: boolean
 	}) {
 		// figure out the correct selection
 		const __typename = this.cache._internal_unstable.storage.get(parent, '__typename')
@@ -66,9 +77,9 @@ export class InMemorySubscriptions {
 				filters,
 				visible,
 			} = fieldSelection
-			if (!visible) {
-				continue
-			}
+
+			// once we cross a masked boundary everything below it is silent
+			const fieldSilent = silent || !visible
 
 			const key = evaluateKey(keyRaw, variables)
 
@@ -85,9 +96,10 @@ export class InMemorySubscriptions {
 				key,
 				selection: [spec, targetSelection],
 				type,
+				silent: fieldSilent,
 			})
 
-			if (list) {
+			if (list && !fieldSilent) {
 				this.registerList({
 					list,
 					filters,
@@ -123,6 +135,7 @@ export class InMemorySubscriptions {
 						selection: innerSelection,
 						variables,
 						parentType: type,
+						silent: fieldSilent,
 					})
 				}
 			}
@@ -134,11 +147,13 @@ export class InMemorySubscriptions {
 		key,
 		selection,
 		type: _type,
+		silent = false,
 	}: {
 		id: string
 		key: string
 		selection: FieldSelection
 		type: string
+		silent?: boolean
 	}) {
 		const spec = selection[0]
 
@@ -153,10 +168,19 @@ export class InMemorySubscriptions {
 			subscriber.set(key, {
 				selections: [],
 				referenceCounts: new Map(),
+				silentSelections: [],
+				silentReferenceCounts: new Map(),
 			})
 		}
 
 		const subscriberField = subscriber.get(key)!
+
+		// silent subscriptions get tracked separately so they never participate
+		// in update notifications
+		const selections = silent ? subscriberField.silentSelections : subscriberField.selections
+		const referenceCounts = silent
+			? subscriberField.silentReferenceCounts
+			: subscriberField.referenceCounts
 
 		// if this is the first time we've seen the raw key
 		if (!this.keyVersions[key]) {
@@ -166,15 +190,12 @@ export class InMemorySubscriptions {
 		// add this version of the key if we need to
 		this.keyVersions[key].add(key)
 
-		if (!subscriberField.selections.some(([{ set }]) => set === spec.set)) {
-			subscriberField.selections.push([spec, selection[1]])
+		if (!selections.some(([{ onMessage }]) => onMessage === spec.onMessage)) {
+			selections.push([spec, selection[1]])
 		}
 
 		// we're going to increment the current value by one
-		subscriberField.referenceCounts.set(
-			spec.set,
-			(subscriberField.referenceCounts.get(spec.set) || 0) + 1
-		)
+		referenceCounts.set(spec.onMessage, (referenceCounts.get(spec.onMessage) || 0) + 1)
 
 		// reset the lifetime for the key
 		this.cache._internal_unstable.lifetimes.resetLifetime(id, key)
@@ -222,11 +243,16 @@ export class InMemorySubscriptions {
 		variables,
 		subscribers,
 		parentType,
+		silent = false,
 	}: {
 		parent: string
 		variables: {}
 		subscribers: FieldSelection[]
 		parentType: string
+		// when true, every subscription we register is silent regardless of the
+		// field's visibility. this happens when the batch we are propagating was
+		// already behind a masked boundary
+		silent?: boolean
 	}) {
 		// every subscriber specifies a different selection set to add to the parent
 		for (const [spec, targetSelection] of subscribers) {
@@ -240,9 +266,10 @@ export class InMemorySubscriptions {
 					filters,
 					visible,
 				} = selection
-				if (!visible) {
-					continue
-				}
+
+				// once we cross a masked boundary everything below it is silent
+				const fieldSilent = silent || !visible
+
 				const key = evaluateKey(keyRaw, variables)
 
 				// figure out the selection for the field we are writing
@@ -255,9 +282,10 @@ export class InMemorySubscriptions {
 					key,
 					selection: [spec, fieldSelection],
 					type: linkedType,
+					silent: fieldSilent,
 				})
 
-				if (list) {
+				if (list && !fieldSilent) {
 					this.registerList({
 						list,
 						filters,
@@ -296,6 +324,7 @@ export class InMemorySubscriptions {
 							variables,
 							subscribers: subscribers.map(([sub]) => [sub, targetSelection]),
 							parentType: linkedType,
+							silent: fieldSilent,
 						})
 					}
 				}
@@ -307,9 +336,15 @@ export class InMemorySubscriptions {
 		return this.subscribers.get(id)?.get(field)?.selections || []
 	}
 
-	getAll(id: string): FieldSelection[] {
-		return [...(this.subscribers.get(id)?.values() || [])].flatMap(
-			(fieldSub) => fieldSub.selections
+	getSilent(id: string, field: string): FieldSelection[] {
+		return this.subscribers.get(id)?.get(field)?.silentSelections || []
+	}
+
+	getAll(id: string, { includeSilent = false }: { includeSilent?: boolean } = {}) {
+		return [...(this.subscribers.get(id)?.values() || [])].flatMap((fieldSub) =>
+			includeSilent
+				? fieldSub.selections.concat(fieldSub.silentSelections)
+				: fieldSub.selections
 		)
 	}
 
@@ -318,12 +353,13 @@ export class InMemorySubscriptions {
 		selection: SubscriptionSelection,
 		targets: SubscriptionSpec[],
 		variables: {},
-		visited: string[] = []
+		visited: string[] = [],
+		silent: boolean = false
 	) {
 		visited.push(id)
 
 		// walk down to every record we know about
-		const linkedIDs: [string, SubscriptionSelection][] = []
+		const linkedIDs: [string, SubscriptionSelection, boolean][] = []
 
 		// figure out the correct selection
 		const __typename = this.cache._internal_unstable.storage.get(id, '__typename')
@@ -334,8 +370,12 @@ export class InMemorySubscriptions {
 		for (const fieldSelection of Object.values(targetSelection || {})) {
 			const key = evaluateKey(fieldSelection.keyRaw, variables)
 
+			// mirror the walk that added the subscriptions: once we cross a masked
+			// boundary everything below it was registered silently
+			const fieldSilent = silent || !fieldSelection.visible
+
 			// remove the subscribers for the field
-			this.removeSubscribers(id, key, targets)
+			this.removeSubscribers(id, key, targets, fieldSilent)
 
 			// if there is no subselection it doesn't point to a link, move on
 			if (!fieldSelection.selection) {
@@ -351,13 +391,13 @@ export class InMemorySubscriptions {
 
 			for (const link of links) {
 				if (link !== null) {
-					linkedIDs.push([link, fieldSelection.selection || {}])
+					linkedIDs.push([link, fieldSelection.selection || {}, fieldSilent])
 				}
 			}
 		}
 
-		for (const [linkedRecordID, linkFields] of linkedIDs) {
-			this.remove(linkedRecordID, linkFields, targets, visited)
+		for (const [linkedRecordID, linkFields, linkSilent] of linkedIDs) {
+			this.remove(linkedRecordID, linkFields, targets, variables, visited, linkSilent)
 		}
 	}
 
@@ -378,45 +418,76 @@ export class InMemorySubscriptions {
 		return subscriptionSpecs
 	}
 
-	private removeSubscribers(id: string, fieldName: string, specs: SubscriptionSpec[]) {
+	private removeSubscribers(
+		id: string,
+		fieldName: string,
+		specs: SubscriptionSpec[],
+		preferSilent: boolean = false
+	) {
 		// build up a list of the sets we actually need to remove after
 		// checking reference counts
-		const targets: SubscriptionSpec['set'][] = []
+		const targets: SubscriptionSpec['onMessage'][] = []
+		const silentTargets: SubscriptionSpec['onMessage'][] = []
 
 		const subscriber = this.subscribers.get(id)
 		if (!subscriber) {
 			return
 		}
 		const subscriberField = subscriber.get(fieldName)
+		if (!subscriberField) {
+			return
+		}
+
 		for (const spec of specs) {
-			const counts = subscriberField?.referenceCounts
+			// each removal visit accounts for a single reference that flowed through
+			// this link path. we prefer the count map that matches the visibility of
+			// the walk that got us here but fall back to the other one so that mixed
+			// paths (the same field reached both masked and unmasked) still clean up
+			const ordered: Array<
+				[Map<SubscriptionSpec['onMessage'], number>, SubscriptionSpec['onMessage'][]]
+			> = preferSilent
+				? [
+						[subscriberField.silentReferenceCounts, silentTargets],
+						[subscriberField.referenceCounts, targets],
+					]
+				: [
+						[subscriberField.referenceCounts, targets],
+						[subscriberField.silentReferenceCounts, silentTargets],
+					]
 
 			// if we dont know this field/set combo, there's nothing to do (probably a bug somewhere)
-			if (!counts?.has(spec.set)) {
+			const match = ordered.find(([counts]) => counts.has(spec.onMessage))
+			if (!match) {
 				continue
 			}
-			const newVal = (counts.get(spec.set) || 0) - 1
+			const [counts, removed] = match
+
+			const newVal = (counts.get(spec.onMessage) || 0) - 1
 
 			// decrement the reference of every field
-			counts.set(spec.set, newVal)
+			counts.set(spec.onMessage, newVal)
 			// if that was the last reference we knew of
 			if (newVal <= 0) {
-				targets.push(spec.set)
+				removed.push(spec.onMessage)
 				// remove the reference to the set function
-				counts.delete(spec.set)
-			}
-
-			// if we have no more references to the field, we need to remove it from the map
-			if (counts.size === 0) {
-				subscriber.delete(fieldName)
+				counts.delete(spec.onMessage)
 			}
 		}
 
-		// we do need to remove the set from the list
-		if (subscriberField) {
-			subscriberField.selections = this.get(id, fieldName).filter(
-				([{ set }]) => !targets.includes(set)
-			)
+		// we do need to remove the set from the lists
+		subscriberField.selections = subscriberField.selections.filter(
+			([{ onMessage }]) => !targets.includes(onMessage)
+		)
+		subscriberField.silentSelections = subscriberField.silentSelections.filter(
+			([{ onMessage }]) => !silentTargets.includes(onMessage)
+		)
+
+		// if we have no more references to the field, we need to remove it from the map
+		if (
+			subscriberField.referenceCounts.size === 0 &&
+			subscriberField.silentReferenceCounts.size === 0
+		) {
+			subscriber.delete(fieldName)
 		}
 
 		// if we got this far and there are no subscribers on the field, we need to clean things up
@@ -428,8 +499,8 @@ export class InMemorySubscriptions {
 	removeAllSubscribers(id: string, targets?: SubscriptionSpec[]) {
 		// get the list of subscriptions specs for the id if we didn't provide a specific list
 		if (!targets) {
-			targets = [...(this.subscribers.get(id)?.values() || [])].flatMap((spec) =>
-				spec.selections.flatMap((sel) => sel[0]!)
+			targets = [...(this.subscribers.get(id)?.values() || [])].flatMap((fieldSub) =>
+				fieldSub.selections.concat(fieldSub.silentSelections).flatMap((sel) => sel[0]!)
 			)
 		}
 

--- a/packages/houdini/src/runtime/cache/subscription.ts
+++ b/packages/houdini/src/runtime/cache/subscription.ts
@@ -24,13 +24,13 @@ export class InMemorySubscriptions {
 			{
 				selections: FieldSelection[]
 				referenceCounts: Map<SubscriptionSpec['onMessage'], number>
-				// silent subscriptions track documents whose data contains this record
+				// masked parent subscriptions track documents whose data contains this record
 				// behind a masked boundary (eg a fragment spread). they are never
 				// notified when a value changes but they do participate in containment
 				// lookups (cache.refresh) and write-path propagation so that we always
 				// know every document whose data contains a given record
-				silentSelections: FieldSelection[]
-				silentReferenceCounts: Map<SubscriptionSpec['onMessage'], number>
+				maskedParentSelections: FieldSelection[]
+				maskedParentReferenceCounts: Map<SubscriptionSpec['onMessage'], number>
 			}
 		>
 	>()
@@ -51,16 +51,16 @@ export class InMemorySubscriptions {
 		selection,
 		variables,
 		parentType,
-		silent = false,
+		masked = false,
 	}: {
 		parent: string
 		parentType?: string
 		spec: SubscriptionSpec
 		selection: SubscriptionSelection
 		variables: { [key: string]: GraphQLValue }
-		// when true, every subscription we register is silent regardless of the
+		// when true, every subscription we register is a masked parent regardless of the
 		// field's visibility. this happens when the walk crosses a masked boundary
-		silent?: boolean
+		masked?: boolean
 	}) {
 		// figure out the correct selection
 		const __typename = this.cache._internal_unstable.storage.get(parent, '__typename')
@@ -78,8 +78,8 @@ export class InMemorySubscriptions {
 				visible,
 			} = fieldSelection
 
-			// once we cross a masked boundary everything below it is silent
-			const fieldSilent = silent || !visible
+			// once we cross a masked boundary everything below it is a masked parent
+			const fieldMasked = masked || !visible
 
 			const key = evaluateKey(keyRaw, variables)
 
@@ -96,10 +96,10 @@ export class InMemorySubscriptions {
 				key,
 				selection: [spec, targetSelection],
 				type,
-				silent: fieldSilent,
+				masked: fieldMasked,
 			})
 
-			if (list && !fieldSilent) {
+			if (list && !fieldMasked) {
 				this.registerList({
 					list,
 					filters,
@@ -135,7 +135,7 @@ export class InMemorySubscriptions {
 						selection: innerSelection,
 						variables,
 						parentType: type,
-						silent: fieldSilent,
+						masked: fieldMasked,
 					})
 				}
 			}
@@ -147,13 +147,13 @@ export class InMemorySubscriptions {
 		key,
 		selection,
 		type: _type,
-		silent = false,
+		masked = false,
 	}: {
 		id: string
 		key: string
 		selection: FieldSelection
 		type: string
-		silent?: boolean
+		masked?: boolean
 	}) {
 		const spec = selection[0]
 
@@ -168,18 +168,18 @@ export class InMemorySubscriptions {
 			subscriber.set(key, {
 				selections: [],
 				referenceCounts: new Map(),
-				silentSelections: [],
-				silentReferenceCounts: new Map(),
+				maskedParentSelections: [],
+				maskedParentReferenceCounts: new Map(),
 			})
 		}
 
 		const subscriberField = subscriber.get(key)!
 
-		// silent subscriptions get tracked separately so they never participate
+		// masked parent subscriptions get tracked separately so they never participate
 		// in update notifications
-		const selections = silent ? subscriberField.silentSelections : subscriberField.selections
-		const referenceCounts = silent
-			? subscriberField.silentReferenceCounts
+		const selections = masked ? subscriberField.maskedParentSelections : subscriberField.selections
+		const referenceCounts = masked
+			? subscriberField.maskedParentReferenceCounts
 			: subscriberField.referenceCounts
 
 		// if this is the first time we've seen the raw key
@@ -243,16 +243,16 @@ export class InMemorySubscriptions {
 		variables,
 		subscribers,
 		parentType,
-		silent = false,
+		masked = false,
 	}: {
 		parent: string
 		variables: {}
 		subscribers: FieldSelection[]
 		parentType: string
-		// when true, every subscription we register is silent regardless of the
+		// when true, every subscription we register is a masked parent regardless of the
 		// field's visibility. this happens when the batch we are propagating was
 		// already behind a masked boundary
-		silent?: boolean
+		masked?: boolean
 	}) {
 		// every subscriber specifies a different selection set to add to the parent
 		for (const [spec, targetSelection] of subscribers) {
@@ -267,8 +267,8 @@ export class InMemorySubscriptions {
 					visible,
 				} = selection
 
-				// once we cross a masked boundary everything below it is silent
-				const fieldSilent = silent || !visible
+				// once we cross a masked boundary everything below it is a masked parent
+				const fieldMasked = masked || !visible
 
 				const key = evaluateKey(keyRaw, variables)
 
@@ -282,10 +282,10 @@ export class InMemorySubscriptions {
 					key,
 					selection: [spec, fieldSelection],
 					type: linkedType,
-					silent: fieldSilent,
+					masked: fieldMasked,
 				})
 
-				if (list && !fieldSilent) {
+				if (list && !fieldMasked) {
 					this.registerList({
 						list,
 						filters,
@@ -324,7 +324,7 @@ export class InMemorySubscriptions {
 							variables,
 							subscribers: subscribers.map(([sub]) => [sub, targetSelection]),
 							parentType: linkedType,
-							silent: fieldSilent,
+							masked: fieldMasked,
 						})
 					}
 				}
@@ -336,14 +336,14 @@ export class InMemorySubscriptions {
 		return this.subscribers.get(id)?.get(field)?.selections || []
 	}
 
-	getSilent(id: string, field: string): FieldSelection[] {
-		return this.subscribers.get(id)?.get(field)?.silentSelections || []
+	getMaskedParents(id: string, field: string): FieldSelection[] {
+		return this.subscribers.get(id)?.get(field)?.maskedParentSelections || []
 	}
 
-	getAll(id: string, { includeSilent = false }: { includeSilent?: boolean } = {}) {
+	getAll(id: string, { includeMaskedParents = false }: { includeMaskedParents?: boolean } = {}) {
 		return [...(this.subscribers.get(id)?.values() || [])].flatMap((fieldSub) =>
-			includeSilent
-				? fieldSub.selections.concat(fieldSub.silentSelections)
+			includeMaskedParents
+				? fieldSub.selections.concat(fieldSub.maskedParentSelections)
 				: fieldSub.selections
 		)
 	}
@@ -354,7 +354,7 @@ export class InMemorySubscriptions {
 		targets: SubscriptionSpec[],
 		variables: {},
 		visited: string[] = [],
-		silent: boolean = false
+		masked: boolean = false
 	) {
 		visited.push(id)
 
@@ -372,10 +372,10 @@ export class InMemorySubscriptions {
 
 			// mirror the walk that added the subscriptions: once we cross a masked
 			// boundary everything below it was registered silently
-			const fieldSilent = silent || !fieldSelection.visible
+			const fieldMasked = masked || !fieldSelection.visible
 
 			// remove the subscribers for the field
-			this.removeSubscribers(id, key, targets, fieldSilent)
+			this.removeSubscribers(id, key, targets, fieldMasked)
 
 			// if there is no subselection it doesn't point to a link, move on
 			if (!fieldSelection.selection) {
@@ -391,13 +391,13 @@ export class InMemorySubscriptions {
 
 			for (const link of links) {
 				if (link !== null) {
-					linkedIDs.push([link, fieldSelection.selection || {}, fieldSilent])
+					linkedIDs.push([link, fieldSelection.selection || {}, fieldMasked])
 				}
 			}
 		}
 
-		for (const [linkedRecordID, linkFields, linkSilent] of linkedIDs) {
-			this.remove(linkedRecordID, linkFields, targets, variables, visited, linkSilent)
+		for (const [linkedRecordID, linkFields, linkMasked] of linkedIDs) {
+			this.remove(linkedRecordID, linkFields, targets, variables, visited, linkMasked)
 		}
 	}
 
@@ -422,12 +422,12 @@ export class InMemorySubscriptions {
 		id: string,
 		fieldName: string,
 		specs: SubscriptionSpec[],
-		preferSilent: boolean = false
+		preferMasked: boolean = false
 	) {
 		// build up a list of the sets we actually need to remove after
 		// checking reference counts
 		const targets: SubscriptionSpec['onMessage'][] = []
-		const silentTargets: SubscriptionSpec['onMessage'][] = []
+		const maskedParentTargets: SubscriptionSpec['onMessage'][] = []
 
 		const subscriber = this.subscribers.get(id)
 		if (!subscriber) {
@@ -445,14 +445,14 @@ export class InMemorySubscriptions {
 			// paths (the same field reached both masked and unmasked) still clean up
 			const ordered: Array<
 				[Map<SubscriptionSpec['onMessage'], number>, SubscriptionSpec['onMessage'][]]
-			> = preferSilent
+			> = preferMasked
 				? [
-						[subscriberField.silentReferenceCounts, silentTargets],
+						[subscriberField.maskedParentReferenceCounts, maskedParentTargets],
 						[subscriberField.referenceCounts, targets],
 					]
 				: [
 						[subscriberField.referenceCounts, targets],
-						[subscriberField.silentReferenceCounts, silentTargets],
+						[subscriberField.maskedParentReferenceCounts, maskedParentTargets],
 					]
 
 			// if we dont know this field/set combo, there's nothing to do (probably a bug somewhere)
@@ -478,14 +478,14 @@ export class InMemorySubscriptions {
 		subscriberField.selections = subscriberField.selections.filter(
 			([{ onMessage }]) => !targets.includes(onMessage)
 		)
-		subscriberField.silentSelections = subscriberField.silentSelections.filter(
-			([{ onMessage }]) => !silentTargets.includes(onMessage)
+		subscriberField.maskedParentSelections = subscriberField.maskedParentSelections.filter(
+			([{ onMessage }]) => !maskedParentTargets.includes(onMessage)
 		)
 
 		// if we have no more references to the field, we need to remove it from the map
 		if (
 			subscriberField.referenceCounts.size === 0 &&
-			subscriberField.silentReferenceCounts.size === 0
+			subscriberField.maskedParentReferenceCounts.size === 0
 		) {
 			subscriber.delete(fieldName)
 		}
@@ -500,7 +500,7 @@ export class InMemorySubscriptions {
 		// get the list of subscriptions specs for the id if we didn't provide a specific list
 		if (!targets) {
 			targets = [...(this.subscribers.get(id)?.values() || [])].flatMap((fieldSub) =>
-				fieldSub.selections.concat(fieldSub.silentSelections).flatMap((sel) => sel[0]!)
+				fieldSub.selections.concat(fieldSub.maskedParentSelections).flatMap((sel) => sel[0]!)
 			)
 		}
 

--- a/packages/houdini/src/runtime/cache/tests/availability.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/availability.test.ts
@@ -446,7 +446,7 @@ test('missing cursor of item in connection from operation should not trigger nul
 	})
 
 	cache.subscribe({
-		set: vi.fn(),
+		onMessage: vi.fn(),
 		selection,
 		rootType: 'Query',
 	})

--- a/packages/houdini/src/runtime/cache/tests/gc.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/gc.test.ts
@@ -116,7 +116,7 @@ test("subscribed data shouldn't be garbage collected", () => {
 				},
 			},
 		},
-		set: vi.fn(),
+		onMessage: vi.fn(),
 	})
 
 	// tick the garbage collector enough times to fill up the buffer size
@@ -203,7 +203,7 @@ test('resubscribing to fields marked for garbage collection resets counter', () 
 				},
 			},
 		},
-		set,
+		onMessage: set,
 	})
 
 	// tick the garbage collector enough times to fill up the buffer size
@@ -232,7 +232,7 @@ test('resubscribing to fields marked for garbage collection resets counter', () 
 				},
 			},
 		},
-		set,
+		onMessage: set,
 	})
 
 	// tick the garbage collector enough times to fill up the buffer size
@@ -351,7 +351,7 @@ test('ticks of gc delete list handlers', () => {
 	cache.subscribe(
 		{
 			rootType: 'Query',
-			set,
+			onMessage: set,
 			selection,
 		},
 		{
@@ -362,7 +362,7 @@ test('ticks of gc delete list handlers', () => {
 	cache.unsubscribe(
 		{
 			rootType: 'Query',
-			set,
+			onMessage: set,
 			selection,
 		},
 		{

--- a/packages/houdini/src/runtime/cache/tests/list.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/list.test.ts
@@ -3217,7 +3217,7 @@ test('toggle list survives multiple on-off cycles through mutation layers', () =
 			rootType: 'User',
 			selection: friendsSelection,
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -6365,7 +6365,7 @@ test('@listID operation inserts into the correct list via opaque key', () => {
 			rootType: 'User',
 			selection: friendsSelection,
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)

--- a/packages/houdini/src/runtime/cache/tests/list.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/list.test.ts
@@ -260,7 +260,7 @@ test('append in list', () => {
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -280,18 +280,21 @@ test('append in list', () => {
 
 	// make sure we got the new value
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: [
-				{
-					firstName: 'jane',
-					id: '2',
-				},
-				{
-					firstName: 'mary',
-					id: '3',
-				},
-			],
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						firstName: 'jane',
+						id: '2',
+					},
+					{
+						firstName: 'mary',
+						id: '3',
+					},
+				],
+			},
 		},
 	})
 })
@@ -365,7 +368,7 @@ test('prepend in list', () => {
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -385,18 +388,21 @@ test('prepend in list', () => {
 
 	// make sure we got the new value
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: [
-				{
-					firstName: 'mary',
-					id: '3',
-				},
-				{
-					firstName: 'jane',
-					id: '2',
-				},
-			],
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						firstName: 'mary',
+						id: '3',
+					},
+					{
+						firstName: 'jane',
+						id: '2',
+					},
+				],
+			},
 		},
 	})
 })
@@ -506,7 +512,7 @@ test('remove from connection', () => {
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -518,18 +524,21 @@ test('remove from connection', () => {
 	// the first time set was called, a new entry was added.
 	// the second time it's called, we get a new value for mary-prime
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: {
-				edges: [
-					{
-						node: {
-							__typename: 'User',
-							id: '3',
-							firstName: 'jane',
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: {
+					edges: [
+						{
+							node: {
+								__typename: 'User',
+								id: '3',
+								firstName: 'jane',
+							},
 						},
-					},
-				],
+					],
+				},
 			},
 		},
 	})
@@ -645,7 +654,7 @@ test('element removed from list can be added back', () => {
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -677,25 +686,28 @@ test('element removed from list can be added back', () => {
 	})
 
 	expect(set).toHaveBeenNthCalledWith(2, {
-		viewer: {
-			id: '1',
-			friends: {
-				edges: [
-					{
-						node: {
-							__typename: 'User',
-							id: '3',
-							firstName: 'jane',
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: {
+					edges: [
+						{
+							node: {
+								__typename: 'User',
+								id: '3',
+								firstName: 'jane',
+							},
 						},
-					},
-					{
-						node: {
-							__typename: 'User',
-							id: '2',
-							firstName: 'jane2',
+						{
+							node: {
+								__typename: 'User',
+								id: '2',
+								firstName: 'jane2',
+							},
 						},
-					},
-				],
+					],
+				},
 			},
 		},
 	})
@@ -799,7 +811,7 @@ test('append in connection', () => {
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -819,25 +831,28 @@ test('append in connection', () => {
 
 	// make sure we got the new value
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: {
-				edges: [
-					{
-						node: {
-							__typename: 'User',
-							id: '2',
-							firstName: 'jane',
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: {
+					edges: [
+						{
+							node: {
+								__typename: 'User',
+								id: '2',
+								firstName: 'jane',
+							},
 						},
-					},
-					{
-						node: {
-							__typename: 'User',
-							id: '3',
-							firstName: 'mary',
+						{
+							node: {
+								__typename: 'User',
+								id: '3',
+								firstName: 'mary',
+							},
 						},
-					},
-				],
+					],
+				},
 			},
 		},
 	})
@@ -1693,7 +1708,7 @@ test('append in connection', () => {
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -1713,27 +1728,30 @@ test('append in connection', () => {
 
 	// make sure we got the new value
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: {
-				edges: [
-					{
-						__typename: 'UserEdge',
-						node: {
-							__typename: 'User',
-							id: '2',
-							firstName: 'jane',
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: {
+					edges: [
+						{
+							__typename: 'UserEdge',
+							node: {
+								__typename: 'User',
+								id: '2',
+								firstName: 'jane',
+							},
 						},
-					},
-					{
-						__typename: 'UserEdge',
-						node: {
-							__typename: 'User',
-							id: '3',
-							firstName: 'mary',
+						{
+							__typename: 'UserEdge',
+							node: {
+								__typename: 'User',
+								id: '3',
+								firstName: 'mary',
+							},
 						},
-					},
-				],
+					],
+				},
 			},
 		},
 	})
@@ -1872,7 +1890,7 @@ test('inserting data with an update overwrites a record inserted with list.appen
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -1986,25 +2004,28 @@ test('inserting data with an update overwrites a record inserted with list.appen
 
 	// make sure the duplicate has been removed
 	expect(set).toHaveBeenNthCalledWith(2, {
-		viewer: {
-			id: '1',
-			friends: {
-				edges: [
-					{
-						node: {
-							__typename: 'User',
-							id: '2',
-							firstName: 'jane',
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: {
+					edges: [
+						{
+							node: {
+								__typename: 'User',
+								id: '2',
+								firstName: 'jane',
+							},
 						},
-					},
-					{
-						node: {
-							__typename: 'User',
-							id: '3',
-							firstName: 'mary',
+						{
+							node: {
+								__typename: 'User',
+								id: '3',
+								firstName: 'mary',
+							},
 						},
-					},
-				],
+					],
+				},
 			},
 		},
 	})
@@ -2117,7 +2138,7 @@ test('list filter - must_not positive', () => {
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -2140,18 +2161,21 @@ test('list filter - must_not positive', () => {
 
 	// make sure we got the new value
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: [
-				{
-					firstName: 'mary',
-					id: '3',
-				},
-				{
-					firstName: 'jane',
-					id: '2',
-				},
-			],
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						firstName: 'mary',
+						id: '3',
+					},
+					{
+						firstName: 'jane',
+						id: '2',
+					},
+				],
+			},
 		},
 	})
 })
@@ -2231,7 +2255,7 @@ test('list filter - must_not negative', () => {
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -2331,7 +2355,7 @@ test('list filter - must positive', () => {
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -2354,18 +2378,21 @@ test('list filter - must positive', () => {
 
 	// make sure we got the new value
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: [
-				{
-					firstName: 'mary',
-					id: '3',
-				},
-				{
-					firstName: 'jane',
-					id: '2',
-				},
-			],
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						firstName: 'mary',
+						id: '3',
+					},
+					{
+						firstName: 'jane',
+						id: '2',
+					},
+				],
+			},
 		},
 	})
 })
@@ -2445,7 +2472,7 @@ test('list filter - must negative', () => {
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -2539,7 +2566,7 @@ test('remove from list', () => {
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -2551,9 +2578,12 @@ test('remove from list', () => {
 	// the first time set was called, a new entry was added.
 	// the second time it's called, we get a new value for mary-prime
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: [],
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: [],
+			},
 		},
 	})
 
@@ -2630,7 +2660,7 @@ test('delete node', () => {
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -2643,9 +2673,12 @@ test('delete node', () => {
 
 	// we should have been updated with an empty list
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: [],
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: [],
+			},
 		},
 	})
 
@@ -2751,7 +2784,7 @@ test('delete node from connection', () => {
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -2764,10 +2797,13 @@ test('delete node from connection', () => {
 
 	// we should have been updated with an empty list
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: {
-				edges: [],
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: {
+					edges: [],
+				},
 			},
 		},
 	})
@@ -2840,7 +2876,7 @@ test('append operation', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -2947,7 +2983,7 @@ test('append from list', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -3077,7 +3113,7 @@ test('toggle list', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -3285,7 +3321,7 @@ test('append when operation', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -3403,7 +3439,7 @@ test('prepend when operation', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -3541,7 +3577,7 @@ test('prepend operation', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -3669,7 +3705,7 @@ test('remove operation', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -3799,7 +3835,7 @@ test('remove operation from list', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -3924,7 +3960,7 @@ test('delete operation', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -4053,7 +4089,7 @@ test('delete operation with non-string id', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', 1)!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -4185,7 +4221,7 @@ test('delete operation from list', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -4370,7 +4406,7 @@ test('delete operation from connection', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -5060,7 +5096,7 @@ test('when conditions look for all matching lists', () => {
 	cache.subscribe(
 		{
 			rootType: 'Query',
-			set,
+			onMessage: set,
 			selection,
 		},
 		{
@@ -5070,7 +5106,7 @@ test('when conditions look for all matching lists', () => {
 	cache.subscribe(
 		{
 			rootType: 'Query',
-			set,
+			onMessage: set,
 			selection,
 		},
 		{
@@ -5188,7 +5224,7 @@ test('parentID must be passed if there are multiple instances of a list handler'
 			rootType: 'User',
 			selection: friendsSelection,
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -5199,7 +5235,7 @@ test('parentID must be passed if there are multiple instances of a list handler'
 			rootType: 'User',
 			selection: friendsSelection,
 			parentID: cache._internal_unstable.id('User', '2')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -5368,7 +5404,7 @@ test('append in abstract list', () => {
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -5389,21 +5425,24 @@ test('append in abstract list', () => {
 
 	// make sure we got the new value
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			__typename: 'User',
-			friends: [
-				{
-					firstName: 'jane',
-					id: '2',
-					__typename: 'User',
-				},
-				{
-					firstName: 'mary',
-					id: '3',
-					__typename: 'User',
-				},
-			],
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				__typename: 'User',
+				friends: [
+					{
+						firstName: 'jane',
+						id: '2',
+						__typename: 'User',
+					},
+					{
+						firstName: 'mary',
+						id: '3',
+						__typename: 'User',
+					},
+				],
+			},
 		},
 	})
 })
@@ -5527,7 +5566,7 @@ test('list operations on interface fields without a well defined parent update t
 	// subscribe to the fields (create the list handler)
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -5560,38 +5599,41 @@ test('list operations on interface fields without a well defined parent update t
 	})
 
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			__typename: 'User',
-			friends: [
-				{
-					id: '2',
-					__typename: 'User',
-					notFriends: [
-						{
-							id: '3',
-							firstName: 'jane',
-							__typename: 'User',
-						},
-					],
-				},
-				{
-					id: '3',
-					__typename: 'User',
-					notFriends: [
-						{
-							id: '4',
-							firstName: 'jane',
-							__typename: 'User',
-						},
-						{
-							id: '5',
-							firstName: 'Billy',
-							__typename: 'User',
-						},
-					],
-				},
-			],
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				__typename: 'User',
+				friends: [
+					{
+						id: '2',
+						__typename: 'User',
+						notFriends: [
+							{
+								id: '3',
+								firstName: 'jane',
+								__typename: 'User',
+							},
+						],
+					},
+					{
+						id: '3',
+						__typename: 'User',
+						notFriends: [
+							{
+								id: '4',
+								firstName: 'jane',
+								__typename: 'User',
+							},
+							{
+								id: '5',
+								firstName: 'Billy',
+								__typename: 'User',
+							},
+						],
+					},
+				],
+			},
 		},
 	})
 })
@@ -5660,7 +5702,7 @@ test("parentID ignores single lists that don't match", () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -5771,7 +5813,7 @@ test('inserting in list at a specific layer affects just that layer', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -5920,7 +5962,7 @@ test("two operations referencing the same list don't commit twice", () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -5958,7 +6000,7 @@ test("two operations referencing the same list don't commit twice", () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)

--- a/packages/houdini/src/runtime/cache/tests/refresh.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/refresh.test.ts
@@ -1,0 +1,410 @@
+import { test, expect, vi } from 'vitest'
+
+import { testConfigFile } from '../../../test/index.js'
+import type { SubscriptionSelection } from '../../types.js'
+import { Cache } from '../index.js'
+import { rootID } from '../stuff.js'
+
+const config = testConfigFile()
+
+// a selection where every field of the user is visible to the document
+const visibleSelection: SubscriptionSelection = {
+	fields: {
+		viewer: {
+			type: 'User',
+			visible: true,
+			keyRaw: 'viewer',
+			selection: {
+				fields: {
+					id: {
+						type: 'ID',
+						visible: true,
+						keyRaw: 'id',
+					},
+					firstName: {
+						type: 'String',
+						visible: true,
+						keyRaw: 'firstName',
+					},
+				},
+			},
+		},
+	},
+}
+
+// a selection that mirrors a query holding a fragment spread: the viewer field
+// is visible but everything on the user (including its keys) is masked
+const maskedSelection: SubscriptionSelection = {
+	fields: {
+		viewer: {
+			type: 'User',
+			visible: true,
+			keyRaw: 'viewer',
+			selection: {
+				fields: {
+					id: {
+						type: 'ID',
+						keyRaw: 'id',
+					},
+					firstName: {
+						type: 'String',
+						keyRaw: 'firstName',
+					},
+					friend: {
+						type: 'User',
+						keyRaw: 'friend',
+						selection: {
+							fields: {
+								id: {
+									type: 'ID',
+									keyRaw: 'id',
+								},
+								firstName: {
+									type: 'String',
+									keyRaw: 'firstName',
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+test('refresh notifies documents subscribed to the record', () => {
+	const cache = new Cache(config)
+
+	cache.write({
+		selection: visibleSelection,
+		data: {
+			viewer: {
+				id: '1',
+				firstName: 'bob',
+			},
+		},
+	})
+
+	const set = vi.fn()
+	cache.subscribe({
+		rootType: 'Query',
+		selection: visibleSelection,
+		onMessage: set,
+	})
+
+	cache.refresh('User:1')
+
+	// the document subscribes to multiple fields of the user but only gets one message
+	expect(set).toHaveBeenCalledTimes(1)
+	expect(set).toHaveBeenCalledWith({ kind: 'refetch' })
+
+	// refreshing the root sends the message too (the document subscribes to viewer)
+	set.mockClear()
+	cache.refresh(rootID)
+	expect(set).toHaveBeenCalledTimes(1)
+	expect(set).toHaveBeenCalledWith({ kind: 'refetch' })
+})
+
+test('refresh reaches documents that only contain the record behind a mask', () => {
+	const cache = new Cache(config)
+
+	cache.write({
+		selection: maskedSelection,
+		data: {
+			viewer: {
+				id: '1',
+				firstName: 'bob',
+				friend: {
+					id: '2',
+					firstName: 'jane',
+				},
+			},
+		},
+	})
+
+	const set = vi.fn()
+	cache.subscribe({
+		rootType: 'Query',
+		selection: maskedSelection,
+		onMessage: set,
+	})
+
+	// writing to a masked field must not notify the document
+	cache.write({
+		selection: maskedSelection,
+		data: {
+			viewer: {
+				id: '1',
+				firstName: 'bob',
+				friend: {
+					id: '2',
+					firstName: 'jane-prime',
+				},
+			},
+		},
+	})
+	expect(set).not.toHaveBeenCalled()
+
+	// but refreshing the masked records still finds the document
+	cache.refresh('User:1')
+	expect(set).toHaveBeenCalledTimes(1)
+	expect(set).toHaveBeenCalledWith({ kind: 'refetch' })
+
+	set.mockClear()
+	cache.refresh('User:2')
+	expect(set).toHaveBeenCalledTimes(1)
+	expect(set).toHaveBeenCalledWith({ kind: 'refetch' })
+})
+
+test('refresh notifies every document that contains the record', () => {
+	const cache = new Cache(config)
+
+	cache.write({
+		selection: maskedSelection,
+		data: {
+			viewer: {
+				id: '1',
+				firstName: 'bob',
+				friend: {
+					id: '2',
+					firstName: 'jane',
+				},
+			},
+		},
+	})
+
+	// a query that contains the user behind a mask
+	const querySet = vi.fn()
+	cache.subscribe({
+		rootType: 'Query',
+		selection: maskedSelection,
+		onMessage: querySet,
+	})
+
+	// a fragment mounted directly on the user
+	const fragmentSet = vi.fn()
+	cache.subscribe({
+		rootType: 'User',
+		parentID: 'User:1',
+		selection: {
+			fields: {
+				firstName: {
+					type: 'String',
+					visible: true,
+					keyRaw: 'firstName',
+				},
+			},
+		},
+		onMessage: fragmentSet,
+	})
+
+	cache.refresh('User:1')
+
+	expect(querySet).toHaveBeenCalledTimes(1)
+	expect(querySet).toHaveBeenCalledWith({ kind: 'refetch' })
+	expect(fragmentSet).toHaveBeenCalledTimes(1)
+	expect(fragmentSet).toHaveBeenCalledWith({ kind: 'refetch' })
+})
+
+test('link changes keep masked containment up to date', () => {
+	const cache = new Cache(config)
+
+	cache.write({
+		selection: maskedSelection,
+		data: {
+			viewer: {
+				id: '1',
+				firstName: 'bob',
+				friend: {
+					id: '2',
+					firstName: 'jane',
+				},
+			},
+		},
+	})
+
+	const set = vi.fn()
+	cache.subscribe({
+		rootType: 'Query',
+		selection: maskedSelection,
+		onMessage: set,
+	})
+
+	// swap the masked friend link to a new record
+	cache.write({
+		selection: maskedSelection,
+		data: {
+			viewer: {
+				id: '1',
+				firstName: 'bob',
+				friend: {
+					id: '3',
+					firstName: 'mark',
+				},
+			},
+		},
+	})
+	// the link lives behind the mask so the document was not notified
+	expect(set).not.toHaveBeenCalled()
+
+	// the new friend is part of the document's data now
+	cache.refresh('User:3')
+	expect(set).toHaveBeenCalledTimes(1)
+	expect(set).toHaveBeenCalledWith({ kind: 'refetch' })
+
+	// and the old one isn't anymore
+	set.mockClear()
+	cache.refresh('User:2')
+	expect(set).not.toHaveBeenCalled()
+})
+
+test('list membership keeps masked containment up to date', () => {
+	const cache = new Cache(config)
+
+	const listSelection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						id: {
+							type: 'ID',
+							keyRaw: 'id',
+						},
+						friends: {
+							type: 'User',
+							keyRaw: 'friends',
+							selection: {
+								fields: {
+									id: {
+										type: 'ID',
+										keyRaw: 'id',
+									},
+									firstName: {
+										type: 'String',
+										keyRaw: 'firstName',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cache.write({
+		selection: listSelection,
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{ id: '2', firstName: 'jane' },
+					{ id: '3', firstName: 'mark' },
+				],
+			},
+		},
+	})
+
+	const set = vi.fn()
+	cache.subscribe({
+		rootType: 'Query',
+		selection: listSelection,
+		onMessage: set,
+	})
+
+	// replace the masked list contents
+	cache.write({
+		selection: listSelection,
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{ id: '3', firstName: 'mark' },
+					{ id: '4', firstName: 'sally' },
+				],
+			},
+		},
+	})
+	expect(set).not.toHaveBeenCalled()
+
+	// the new member is contained, the removed one isn't
+	cache.refresh('User:4')
+	expect(set).toHaveBeenCalledTimes(1)
+	expect(set).toHaveBeenCalledWith({ kind: 'refetch' })
+
+	set.mockClear()
+	cache.refresh('User:2')
+	expect(set).not.toHaveBeenCalled()
+})
+
+test('unsubscribing removes masked containment', () => {
+	const cache = new Cache(config)
+
+	cache.write({
+		selection: maskedSelection,
+		data: {
+			viewer: {
+				id: '1',
+				firstName: 'bob',
+				friend: {
+					id: '2',
+					firstName: 'jane',
+				},
+			},
+		},
+	})
+
+	const set = vi.fn()
+	const spec = {
+		rootType: 'Query',
+		selection: maskedSelection,
+		onMessage: set,
+	}
+	cache.subscribe(spec)
+	cache.unsubscribe(spec)
+
+	cache.refresh('User:1')
+	cache.refresh('User:2')
+	expect(set).not.toHaveBeenCalled()
+})
+
+test('deleting a record removes its containment', () => {
+	const cache = new Cache(config)
+
+	cache.write({
+		selection: maskedSelection,
+		data: {
+			viewer: {
+				id: '1',
+				firstName: 'bob',
+				friend: {
+					id: '2',
+					firstName: 'jane',
+				},
+			},
+		},
+	})
+
+	const set = vi.fn()
+	cache.subscribe({
+		rootType: 'Query',
+		selection: maskedSelection,
+		onMessage: set,
+	})
+
+	cache.delete('User:2')
+	set.mockClear()
+
+	cache.refresh('User:2')
+	expect(set).not.toHaveBeenCalled()
+})
+
+test('refresh on an unknown record is a no-op', () => {
+	const cache = new Cache(config)
+
+	// nothing to assert beyond it not throwing
+	cache.refresh('User:999')
+})

--- a/packages/houdini/src/runtime/cache/tests/reset.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/reset.test.ts
@@ -122,7 +122,7 @@ test('make sure the cache lists were reset', () => {
 	const set = vi.fn()
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -186,7 +186,7 @@ test('make sure the cache subscribers were reset', () => {
 	const set = vi.fn()
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 

--- a/packages/houdini/src/runtime/cache/tests/subscriptions.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/subscriptions.test.ts
@@ -60,7 +60,7 @@ test('root subscribe - field change', () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection,
-		set,
+		onMessage: set,
 	})
 
 	// somehow write a user to the cache with the same id, but a different name
@@ -76,10 +76,13 @@ test('root subscribe - field change', () => {
 
 	// make sure that set got called with the full response
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			firstName: 'mary',
-			favoriteColors: ['red', 'green', 'blue'],
-			id: '1',
+		kind: 'update',
+		data: {
+			viewer: {
+				firstName: 'mary',
+				favoriteColors: ['red', 'green', 'blue'],
+				id: '1',
+			},
 		},
 	})
 })
@@ -137,7 +140,7 @@ test('root subscribe - linked object changed', () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection,
-		set,
+		onMessage: set,
 	})
 
 	// somehow write a user to the cache with a different id
@@ -153,11 +156,14 @@ test('root subscribe - linked object changed', () => {
 
 	// make sure that set got called with the full response
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			firstName: 'mary',
-			// this is a sanity-check. the cache wasn't written with that value
-			favoriteColors: null,
-			id: '2',
+		kind: 'update',
+		data: {
+			viewer: {
+				firstName: 'mary',
+				// this is a sanity-check. the cache wasn't written with that value
+				favoriteColors: null,
+				id: '2',
+			},
 		},
 	})
 
@@ -182,10 +188,13 @@ test('root subscribe - linked object changed', () => {
 
 	// make sure that set got called with the full response
 	expect(set).toHaveBeenLastCalledWith({
-		viewer: {
-			firstName: 'Michelle',
-			id: '2',
-			favoriteColors: null,
+		kind: 'update',
+		data: {
+			viewer: {
+				firstName: 'Michelle',
+				id: '2',
+				favoriteColors: null,
+			},
 		},
 	})
 
@@ -242,7 +251,7 @@ test("subscribing to null object doesn't explode", () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection,
-		set,
+		onMessage: set,
 	})
 
 	// somehow write a user to the cache with a different id
@@ -258,10 +267,13 @@ test("subscribing to null object doesn't explode", () => {
 
 	// make sure that set got called with the full response
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			firstName: 'mary',
-			favoriteColors: null,
-			id: '2',
+		kind: 'update',
+		data: {
+			viewer: {
+				firstName: 'mary',
+				favoriteColors: null,
+				id: '2',
+			},
 		},
 	})
 })
@@ -318,7 +330,7 @@ test('overwriting a reference with null clears its subscribers', () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection,
-		set,
+		onMessage: set,
 	})
 
 	// start off associated with one object
@@ -331,7 +343,10 @@ test('overwriting a reference with null clears its subscribers', () => {
 
 	// make sure that set got called with the full response
 	expect(set).toHaveBeenCalledWith({
-		viewer: null,
+		kind: 'update',
+		data: {
+			viewer: null,
+		},
 	})
 
 	// we shouldn't be subscribing to user 3 any more
@@ -388,7 +403,7 @@ test('overwriting a linked list with null clears its subscribers', () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection,
-		set,
+		onMessage: set,
 	})
 
 	// add some users that we will subscribe to
@@ -431,9 +446,12 @@ test('overwriting a linked list with null clears its subscribers', () => {
 
 	// make sure that set got called with the full response
 	expect(set).toHaveBeenNthCalledWith(2, {
-		viewer: {
-			id: '1',
-			friends: null,
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: null,
+			},
 		},
 	})
 
@@ -511,7 +529,7 @@ test('root subscribe - linked list lost entry', () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection,
-		set,
+		onMessage: set,
 	})
 
 	// somehow write a user to the cache with a new friends list
@@ -531,14 +549,17 @@ test('root subscribe - linked list lost entry', () => {
 
 	// make sure that set got called with the full response
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: [
-				{
-					firstName: 'jane',
-					id: '2',
-				},
-			],
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						firstName: 'jane',
+						id: '2',
+					},
+				],
+			},
 		},
 	})
 
@@ -612,7 +633,7 @@ test("subscribing to list with null values doesn't explode", () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection,
-		set,
+		onMessage: set,
 	})
 
 	// somehow write a user to the cache with a new friends list
@@ -632,14 +653,17 @@ test("subscribing to list with null values doesn't explode", () => {
 
 	// make sure that set got called with the full response
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: [
-				{
-					firstName: 'jane',
-					id: '2',
-				},
-			],
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						firstName: 'jane',
+						id: '2',
+					},
+				],
+			},
 		},
 	})
 })
@@ -712,7 +736,7 @@ test('root subscribe - linked list reorder', () => {
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -736,18 +760,21 @@ test('root subscribe - linked list reorder', () => {
 
 	// make sure that set got called with the full response
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: [
-				{
-					id: '3',
-					firstName: 'mary',
-				},
-				{
-					id: '2',
-					firstName: 'jane',
-				},
-			],
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						id: '3',
+						firstName: 'mary',
+					},
+					{
+						id: '2',
+						firstName: 'jane',
+					},
+				],
+			},
 		},
 	})
 
@@ -805,7 +832,7 @@ test('unsubscribe', () => {
 	const spec = {
 		rootType: 'Query',
 		selection,
-		set: vi.fn(),
+		onMessage: vi.fn(),
 	}
 
 	// subscribe to the fields
@@ -874,7 +901,7 @@ test('subscribe to new list nodes', () => {
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -920,14 +947,17 @@ test('subscribe to new list nodes', () => {
 	// the first time set was called, a new entry was added.
 	// the second time it's called, we get a new value for jane
 	expect(set).toHaveBeenNthCalledWith(2, {
-		viewer: {
-			id: '1',
-			friends: [
-				{
-					firstName: 'jane-prime',
-					id: '2',
-				},
-			],
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						firstName: 'jane-prime',
+						id: '2',
+					},
+				],
+			},
 		},
 	})
 
@@ -977,18 +1007,21 @@ test('subscribe to new list nodes', () => {
 	// the third time set was called, a new entry was added.
 	// the fourth time it's called, we get a new value for mary
 	expect(set).toHaveBeenNthCalledWith(4, {
-		viewer: {
-			id: '1',
-			friends: [
-				{
-					firstName: 'jane-prime',
-					id: '2',
-				},
-				{
-					firstName: 'mary-prime',
-					id: '3',
-				},
-			],
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						firstName: 'jane-prime',
+						id: '2',
+					},
+					{
+						firstName: 'mary-prime',
+						id: '3',
+					},
+				],
+			},
 		},
 	})
 })
@@ -1071,7 +1104,7 @@ test('variables in query and subscription', () => {
 		{
 			rootType: 'Query',
 			selection,
-			set,
+			onMessage: set,
 			variables: () => ({ filter: 'foo' }),
 		},
 		{
@@ -1102,14 +1135,17 @@ test('variables in query and subscription', () => {
 
 	// make sure that set got called with the full response
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: [
-				{
-					firstName: 'jane',
-					id: '2',
-				},
-			],
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						firstName: 'jane',
+						id: '2',
+					},
+				],
+			},
 		},
 	})
 
@@ -1199,7 +1235,7 @@ test('deleting a node removes nested subscriptions', () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection,
-		set,
+		onMessage: set,
 	})
 
 	// sanity check
@@ -1655,7 +1691,7 @@ test('same record twice in a query survives one unsubscribe (reference counting)
 		{
 			rootType: 'Query',
 			selection,
-			set,
+			onMessage: set,
 		},
 		{
 			filter: 'foo',
@@ -1766,7 +1802,7 @@ test('embedded references', () => {
 		{
 			rootType: 'Query',
 			selection,
-			set,
+			onMessage: set,
 		},
 		{
 			filter: 'foo',
@@ -1808,23 +1844,26 @@ test('embedded references', () => {
 
 	// make sure we got the updated data
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: {
-				edges: [
-					{
-						node: {
-							id: '2',
-							firstName: 'not-jane',
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: {
+					edges: [
+						{
+							node: {
+								id: '2',
+								firstName: 'not-jane',
+							},
 						},
-					},
-					{
-						node: {
-							id: '3',
-							firstName: 'mary',
+						{
+							node: {
+								id: '3',
+								firstName: 'mary',
+							},
 						},
-					},
-				],
+					],
+				},
 			},
 		},
 	})
@@ -1921,7 +1960,7 @@ test('self-referencing linked lists can be unsubscribed (avoid infinite recursio
 
 	// subscribe to the list
 	const spec = {
-		set: vi.fn(),
+		onMessage: vi.fn(),
 		selection,
 		rootType: 'Query',
 	}
@@ -2042,7 +2081,7 @@ test('self-referencing links can be unsubscribed (avoid infinite recursion)', ()
 
 	// subscribe to the list
 	const spec = {
-		set: vi.fn(),
+		onMessage: vi.fn(),
 		selection,
 		rootType: 'Query',
 	}
@@ -2105,7 +2144,7 @@ test('overwriting a value in an optimistic layer triggers subscribers', () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection,
-		set,
+		onMessage: set,
 	})
 
 	// create an optimistic layer on top
@@ -2125,10 +2164,13 @@ test('overwriting a value in an optimistic layer triggers subscribers', () => {
 
 	// make sure that set got called with the full response
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			firstName: 'mary',
-			favoriteColors: ['red', 'green', 'blue'],
-			id: '1',
+		kind: 'update',
+		data: {
+			viewer: {
+				firstName: 'mary',
+				favoriteColors: ['red', 'green', 'blue'],
+				id: '1',
+			},
 		},
 	})
 })
@@ -2185,7 +2227,7 @@ test('clearing a display layer updates subscribers', () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection,
-		set,
+		onMessage: set,
 	})
 
 	// create an optimistic layer on top
@@ -2205,10 +2247,13 @@ test('clearing a display layer updates subscribers', () => {
 
 	// make sure that set got called with the full response
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			firstName: 'mary',
-			favoriteColors: ['red', 'green', 'blue'],
-			id: '1',
+		kind: 'update',
+		data: {
+			viewer: {
+				firstName: 'mary',
+				favoriteColors: ['red', 'green', 'blue'],
+				id: '1',
+			},
 		},
 	})
 
@@ -2229,10 +2274,13 @@ test('clearing a display layer updates subscribers', () => {
 	})
 
 	expect(set).toHaveBeenNthCalledWith(2, {
-		viewer: {
-			firstName: 'mary',
-			favoriteColors: ['red', 'green', 'blue'],
-			id: '1',
+		kind: 'update',
+		data: {
+			viewer: {
+				firstName: 'mary',
+				favoriteColors: ['red', 'green', 'blue'],
+				id: '1',
+			},
 		},
 	})
 })
@@ -2343,7 +2391,7 @@ test('optimistic layer & lists & add ok', () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection: selectionList,
-		set: setOnQuery,
+		onMessage: setOnQuery,
 	})
 
 	// create an optimistic layer on top
@@ -2363,20 +2411,23 @@ test('optimistic layer & lists & add ok', () => {
 
 	// make sure that set got called with the full response
 	expect(setOnQuery).toHaveBeenCalledWith({
-		usersList: [
-			{
-				id: 'mutation-opti-list:1',
-				name: 'Bruce Willis',
-			},
-			{
-				id: 'mutation-opti-list:2',
-				name: 'Samuel Jackson',
-			},
-			{
-				id: '??? id ???',
-				name: '...optimisticResponse... I could have guessed JYC!',
-			},
-		],
+		kind: 'update',
+		data: {
+			usersList: [
+				{
+					id: 'mutation-opti-list:1',
+					name: 'Bruce Willis',
+				},
+				{
+					id: 'mutation-opti-list:2',
+					name: 'Samuel Jackson',
+				},
+				{
+					id: '??? id ???',
+					name: '...optimisticResponse... I could have guessed JYC!',
+				},
+			],
+		},
 	})
 
 	// clear the layer
@@ -2395,20 +2446,23 @@ test('optimistic layer & lists & add ok', () => {
 	})
 
 	expect(setOnQuery).toHaveBeenNthCalledWith(2, {
-		usersList: [
-			{
-				id: 'mutation-opti-list:1',
-				name: 'Bruce Willis',
-			},
-			{
-				id: 'mutation-opti-list:2',
-				name: 'Samuel Jackson',
-			},
-			{
-				id: 'mutation-opti-list:9',
-				name: 'Alec',
-			},
-		],
+		kind: 'update',
+		data: {
+			usersList: [
+				{
+					id: 'mutation-opti-list:1',
+					name: 'Bruce Willis',
+				},
+				{
+					id: 'mutation-opti-list:2',
+					name: 'Samuel Jackson',
+				},
+				{
+					id: 'mutation-opti-list:9',
+					name: 'Alec',
+				},
+			],
+		},
 	})
 })
 
@@ -2518,7 +2572,7 @@ test('optimistic layer & lists & add null (optimistic will revert)', () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection: selectionList,
-		set: setOnQuery,
+		onMessage: setOnQuery,
 	})
 
 	// create an optimistic layer on top
@@ -2538,20 +2592,23 @@ test('optimistic layer & lists & add null (optimistic will revert)', () => {
 
 	// make sure that set got called with the full response
 	expect(setOnQuery).toHaveBeenCalledWith({
-		usersList: [
-			{
-				id: 'mutation-opti-list:1',
-				name: 'Bruce Willis',
-			},
-			{
-				id: 'mutation-opti-list:2',
-				name: 'Samuel Jackson',
-			},
-			{
-				id: '??? id ???',
-				name: '...optimisticResponse... I could have guessed JYC!',
-			},
-		],
+		kind: 'update',
+		data: {
+			usersList: [
+				{
+					id: 'mutation-opti-list:1',
+					name: 'Bruce Willis',
+				},
+				{
+					id: 'mutation-opti-list:2',
+					name: 'Samuel Jackson',
+				},
+				{
+					id: '??? id ???',
+					name: '...optimisticResponse... I could have guessed JYC!',
+				},
+			],
+		},
 	})
 
 	// clear the layer
@@ -2582,16 +2639,19 @@ test('optimistic layer & lists & add null (optimistic will revert)', () => {
 
 	// Subscription should be call with the right data (element removed from the list)
 	expect(setOnQuery).toHaveBeenNthCalledWith(2, {
-		usersList: [
-			{
-				id: 'mutation-opti-list:1',
-				name: 'Bruce Willis',
-			},
-			{
-				id: 'mutation-opti-list:2',
-				name: 'Samuel Jackson',
-			},
-		],
+		kind: 'update',
+		data: {
+			usersList: [
+				{
+					id: 'mutation-opti-list:1',
+					name: 'Bruce Willis',
+				},
+				{
+					id: 'mutation-opti-list:2',
+					name: 'Samuel Jackson',
+				},
+			],
+		},
 	})
 })
 
@@ -2684,7 +2744,7 @@ test('ensure parent type is properly passed for nested lists', () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection,
-		set,
+		onMessage: set,
 	})
 
 	// add a city to the list by hand since using the list util adds type information
@@ -2806,7 +2866,7 @@ test('subscribe to abstract fields of matching type', () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection,
-		set,
+		onMessage: set,
 	})
 
 	// somehow write a user to the cache with the same id, but a different name
@@ -2823,11 +2883,14 @@ test('subscribe to abstract fields of matching type', () => {
 
 	// make sure that set got called with the full response
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			__typename: 'User',
-			firstName: 'bob',
-			favoriteColors: ['red', 'green', 'blue'],
-			id: '1',
+		kind: 'update',
+		data: {
+			viewer: {
+				__typename: 'User',
+				firstName: 'bob',
+				favoriteColors: ['red', 'green', 'blue'],
+				id: '1',
+			},
 		},
 	})
 })
@@ -2903,7 +2966,7 @@ test('overlapping subscriptions', () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection: selection1,
-		set: set1,
+		onMessage: set1,
 	})
 
 	// a function to spy on that will play the role of set
@@ -2913,7 +2976,7 @@ test('overlapping subscriptions', () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection: selection2,
-		set: set2,
+		onMessage: set2,
 	})
 
 	// write to the first selection
@@ -3026,7 +3089,7 @@ test('ignore hidden fields', () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection,
-		set,
+		onMessage: set,
 	})
 
 	// write to the favoriteColors field to make sure we didn't get an update
@@ -3101,14 +3164,14 @@ test('clearing a layer should notify subscribers of displayed values', () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection,
-		set,
+		onMessage: set,
 	})
 
 	// clear the layer
 	cache.clearLayer(layer.id)
 
 	// make sure our callback was invoked
-	expect(set).toHaveBeenCalledWith({ viewer: null })
+	expect(set).toHaveBeenCalledWith({ kind: 'update', data: { viewer: null } })
 })
 
 test('reverting optimistic remove notifies subscribers', () => {
@@ -3218,7 +3281,7 @@ test('reverting optimistic remove notifies subscribers', () => {
 	// subscribe to the fields
 	cache.subscribe({
 		rootType: 'Query',
-		set,
+		onMessage: set,
 		selection,
 	})
 
@@ -3233,21 +3296,24 @@ test('reverting optimistic remove notifies subscribers', () => {
 
 	// make sure our callback was invoked
 	expect(set).toHaveBeenCalledWith({
-		viewer: {
-			id: '1',
-			friends: {
-				edges: [
-					{
-						node: {
-							__typename: 'User',
-							id: '2',
-							firstName: 'jane',
+		kind: 'update',
+		data: {
+			viewer: {
+				id: '1',
+				friends: {
+					edges: [
+						{
+							node: {
+								__typename: 'User',
+								id: '2',
+								firstName: 'jane',
+							},
 						},
-					},
-					{
-						node: user3,
-					},
-				],
+						{
+							node: user3,
+						},
+					],
+				},
 			},
 		},
 	})
@@ -3300,7 +3366,7 @@ test('overwrite null value with list', () => {
 	cache.subscribe({
 		rootType: 'Query',
 		selection: selection,
-		set: set,
+		onMessage: set,
 	})
 
 	// add some data to the cache
@@ -3312,7 +3378,10 @@ test('overwrite null value with list', () => {
 	})
 
 	expect(set).toHaveBeenCalledWith({
-		friends: [],
+		kind: 'update',
+		data: {
+			friends: [],
+		},
 	})
 })
 
@@ -3357,7 +3426,7 @@ test('removing all subscribers of a field cleans up reference count object', () 
 
 	// subscribe to the list
 	const spec = {
-		set: vi.fn(),
+		onMessage: vi.fn(),
 		selection,
 		rootType: 'Query',
 	}
@@ -3433,7 +3502,7 @@ test('reference count garbage collection requires totally empty garbage', () => 
 
 	// subscribe to selection 1
 	const spec1 = {
-		set: vi.fn(),
+		onMessage: vi.fn(),
 		selection: selection1,
 		rootType: 'Query',
 	}
@@ -3441,7 +3510,7 @@ test('reference count garbage collection requires totally empty garbage', () => 
 
 	// subscribe to selection 2
 	const spec2 = {
-		set: vi.fn(),
+		onMessage: vi.fn(),
 		selection: selection2,
 		rootType: 'Query',
 	}
@@ -3498,7 +3567,7 @@ test('addMany skips external (visible: false) fields on new linked records', () 
 	})
 
 	const set = vi.fn()
-	cache.subscribe({ rootType: 'Query', selection, set })
+	cache.subscribe({ rootType: 'Query', selection, onMessage: set })
 
 	// change viewer to User:2 — this triggers addMany to propagate subscribers onto User:2
 	cache.write({

--- a/packages/houdini/src/runtime/documentStore.test.ts
+++ b/packages/houdini/src/runtime/documentStore.test.ts
@@ -1163,6 +1163,48 @@ test('track variable changes for fragments', async () => {
 	expect(spy).toHaveBeenNthCalledWith(4, false)
 })
 
+test('plugins can kick off a brand new request through ctx.documentStore', async () => {
+	let count = 0
+	let captured: DocumentStore<GraphQLObject, Record<string, any>> | null = null
+
+	const fakeFetch: ClientPlugin = () => ({
+		network(ctx, { resolve }) {
+			// hold onto the document store reference like the cache's refetch
+			// handling does
+			captured = ctx.documentStore
+			count++
+			resolve(ctx, {
+				data: { count },
+				errors: null,
+				fetching: false,
+				partial: false,
+				stale: false,
+				source: DataSource.Network,
+				variables: null,
+			})
+		},
+	})
+
+	const store = createStore([fakeFetch])
+	const fn = vi.fn()
+	store.subscribe(fn)
+
+	await store.send()
+	expect(count).toBe(1)
+
+	// a plugin holding the reference can restart the pipeline from the very beginning
+	const result = await captured!.send()
+	expect(count).toBe(2)
+	expect(result.data).toEqual({ count: 2 })
+
+	// and the store's subscribers see the new value
+	expect(fn).toHaveBeenLastCalledWith(
+		expect.objectContaining({
+			data: { count: 2 },
+		})
+	)
+})
+
 export function createStore(
 	plugins: ClientPlugin[],
 	fetching: boolean | undefined = undefined

--- a/packages/houdini/src/runtime/documentStore.ts
+++ b/packages/houdini/src/runtime/documentStore.ts
@@ -182,7 +182,7 @@ export class DocumentStore<
 		let context = new ClientPluginContextWrapper({
 			abortController,
 			config: this.#configFile,
-			documentStore: this as unknown as DocumentStore<GraphQLObject, GraphQLVariables>,
+			documentStore: this,
 			name: this.artifact.name,
 			text: this.artifact.raw,
 			hash: this.artifact.hash,
@@ -701,7 +701,7 @@ export type ClientPluginContext = {
 	hash: string
 	// a reference to the document store driving the pipeline so that plugins
 	// can kick off a brand new request (eg when the cache asks for a refetch)
-	documentStore: DocumentStore<GraphQLObject, GraphQLVariables>
+	documentStore: DocumentStore<any, any>
 	artifact: DocumentArtifact
 	policy?: CachePolicies
 	fetch?: Fetch

--- a/packages/houdini/src/runtime/documentStore.ts
+++ b/packages/houdini/src/runtime/documentStore.ts
@@ -182,6 +182,7 @@ export class DocumentStore<
 		let context = new ClientPluginContextWrapper({
 			abortController,
 			config: this.#configFile,
+			documentStore: this as unknown as DocumentStore<GraphQLObject, GraphQLVariables>,
 			name: this.artifact.name,
 			text: this.artifact.raw,
 			hash: this.artifact.hash,
@@ -698,6 +699,9 @@ export type ClientPluginContext = {
 	name: string
 	text: string
 	hash: string
+	// a reference to the document store driving the pipeline so that plugins
+	// can kick off a brand new request (eg when the cache asks for a refetch)
+	documentStore: DocumentStore<GraphQLObject, GraphQLVariables>
 	artifact: DocumentArtifact
 	policy?: CachePolicies
 	fetch?: Fetch

--- a/packages/houdini/src/runtime/types.ts
+++ b/packages/houdini/src/runtime/types.ts
@@ -262,10 +262,22 @@ export type SubscriptionSelection = Readonly<{
 	}
 }>
 
+// the cache communicates with subscribers using tagged messages so that
+// it can push more than just new data (for example, asking the document
+// to refetch itself)
+export type CacheMessage<_Data = any> =
+	| {
+			kind: 'update'
+			data: _Data
+	  }
+	| {
+			kind: 'refetch'
+	  }
+
 export type SubscriptionSpec = Readonly<{
 	rootType: string
 	selection: SubscriptionSelection
-	set: (data: any) => void
+	onMessage: (message: CacheMessage) => void
 	parentID?: string
 	variables?: () => any
 }>


### PR DESCRIPTION
Closes #891.

Implements `cache.get('User', { id }).refresh()` which tells the cache to reload every document whose data contains that record including documents that only reach the record through a fragment spread.
