### PR TITLE
@mask_disable + @include no longer bubbles null to parent

### DIFF
--- a/.changeset/fix-conditional-spread-null-cascade.md
+++ b/.changeset/fix-conditional-spread-null-cascade.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+fix fragment spreads that combine @mask_disable with @include/@skip: the condition is propagated onto the inlined fields so a falsy condition no longer bubbles null up to the parent (#1550), unmasked fragment fields now show up in the generated result types (optional when the spread is conditional), and defaultFragmentMasking: 'disable' is honored by type generation

--- a/.changeset/fix-conditional-spread-null-cascade.md
+++ b/.changeset/fix-conditional-spread-null-cascade.md
@@ -2,4 +2,4 @@
 'houdini': patch
 ---
 
-fix fragment spreads that combine @mask_disable with @include/@skip: the condition is propagated onto the inlined fields so a falsy condition no longer bubbles null up to the parent (#1550), unmasked fragment fields now show up in the generated result types (optional when the spread is conditional), and defaultFragmentMasking: 'disable' is honored by type generation
+fix null cascade when combining @mask_disable with @include/@skip (#1550), and restore correct runtime masking behavior in artifacts

--- a/e2e/kit/src/lib/utils/routes.ts
+++ b/e2e/kit/src/lib/utils/routes.ts
@@ -11,6 +11,7 @@ export const routes = {
 	abstractFragments: '/abstract-fragments',
 	abstractFragments_nestedConnection: '/abstract-fragments/nested-connection',
 	fragment_masking_partial: '/fragment-masking-partial',
+	conditional_fragment_spread: '/conditional-fragment-spread',
 	loading_state: '/loading-state',
 	required_field: '/required-field',
 

--- a/e2e/kit/src/routes/conditional-fragment-spread/+page.svelte
+++ b/e2e/kit/src/routes/conditional-fragment-spread/+page.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+import { graphql } from '$houdini'
+import type { PageData } from './$types'
+
+export let data: PageData
+
+// the fragment selects a non-null field. since the spread above is excluded by
+// @include(if: false), the missing value must not null out the parent
+graphql(`
+    fragment ConditionalFragmentSpreadDetails on User {
+        avatarURL
+    }
+`)
+
+$: ({ ConditionalFragmentSpreadQuery: store } = data)
+</script>
+
+{#if $store.data}
+  <div id="result">{$store.data.user.id}:{$store.data.user.name}</div>
+{:else}
+  <div id="result">no data</div>
+{/if}

--- a/e2e/kit/src/routes/conditional-fragment-spread/+page.ts
+++ b/e2e/kit/src/routes/conditional-fragment-spread/+page.ts
@@ -1,0 +1,21 @@
+import { graphql } from '$houdini'
+import type { PageLoad } from './$types'
+
+const store = graphql(`
+    query ConditionalFragmentSpreadQuery {
+        user(id: "1", snapshot: "conditional-fragment-spread") {
+            id
+            name
+
+            ...ConditionalFragmentSpreadDetails @mask_disable @include(if: false)
+        }
+    }
+`)
+
+export const load: PageLoad = async (event) => {
+	await store.fetch({ event })
+
+	return {
+		ConditionalFragmentSpreadQuery: store,
+	}
+}

--- a/e2e/kit/src/routes/conditional-fragment-spread/spec.ts
+++ b/e2e/kit/src/routes/conditional-fragment-spread/spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test'
+import { routes } from '../../lib/utils/routes.js'
+import { expect_to_be, goto } from '../../lib/utils/testsHelper.js'
+
+test.describe('@include on a fragment spread', () => {
+	test('a falsy condition does not bubble null up to the parent', async ({ page }) => {
+		await goto(page, routes.conditional_fragment_spread)
+
+		await expect_to_be(page, 'conditional-fragment-spread:1:Bruce Willis')
+	})
+})

--- a/packages/houdini-core/plugin/documents/artifacts/merge.go
+++ b/packages/houdini-core/plugin/documents/artifacts/merge.go
@@ -63,6 +63,9 @@ type fieldCollectionField struct {
 	Field      *collected.Selection
 	Selection  *fieldCollection
 	Directives []*collected.Directive
+	// true once the field has been requested through at least one path that isn't
+	// guarded by a conditional directive inherited from a fragment spread
+	Unconditional bool
 }
 
 type fieldCollection struct {
@@ -118,6 +121,16 @@ func (c *fieldCollection) Add(
 			}
 		}
 
+		// figure out if this occurrence of the field is guarded by a conditional
+		// directive inherited from a fragment spread
+		unconditional := true
+		for _, dir := range selection.Directives {
+			if isPropagatedConditional(dir) {
+				unconditional = false
+				break
+			}
+		}
+
 		// if we've seen the field before then we need to make sure some metadata
 		// overlaps correctly
 		if sel, ok := c.Fields[*selection.Alias]; ok {
@@ -125,12 +138,23 @@ func (c *fieldCollection) Add(
 				sel.Visible = true
 			}
 
+			// an occurrence that isn't guarded by a spread conditional means the field
+			// is always requested so drop any conditionals inherited from other spreads
+			if unconditional && !sel.Unconditional {
+				sel.Unconditional = true
+				sel.Directives = withoutPropagatedConditionals(sel.Directives)
+				sel.Field.Directives = withoutPropagatedConditionals(sel.Field.Directives)
+			}
+
 			// only append directives we haven't seen yet
 			// but skip @required directive when merging from external fragments that are masked
 			// to prevent it from affecting parent query
 			for _, dir := range selection.Directives {
 				shouldSkipRequired := external && dir.Name == graphql.RequiredDirective && hidden
-				if !containsDirective(sel.Field.Directives, dir) && !shouldSkipRequired {
+				// an inherited conditional can't override a field that is requested unconditionally
+				shouldSkipConditional := sel.Unconditional && isPropagatedConditional(dir)
+				if !containsDirective(sel.Field.Directives, dir) && !shouldSkipRequired &&
+					!shouldSkipConditional {
 					sel.Directives = append(sel.Field.Directives, dir)
 				}
 			}
@@ -155,7 +179,8 @@ func (c *fieldCollection) Add(
 					selection.FieldType,
 					c.SortKeys,
 				),
-				Visible: !hidden,
+				Visible:       !hidden,
+				Unconditional: unconditional,
 			}
 		}
 
@@ -209,11 +234,24 @@ func (c *fieldCollection) Add(
 			return plugins.WrapError(errors.New("fragment not found"))
 		}
 
+		// if the spread is guarded by @include or @skip then the fields it inlines are
+		// conditional too. clone the fragment's selections and push the condition onto
+		// them so the runtime doesn't treat a missing value as a broken non-null field
+		fragmentSelections := definition.Selections
+		if conditionals := spreadConditionals(selection.Directives); len(conditionals) > 0 {
+			fragmentSelections = make([]*collected.Selection, len(definition.Selections))
+			for i, sel := range definition.Selections {
+				clone := sel.Clone(true)
+				attachConditionals(clone, conditionals)
+				fragmentSelections[i] = clone
+			}
+		}
+
 		_, abstractParent := c.CollectedDocuments.PossibleTypes[c.ParentType]
 		// if the selections parent type is the same as the fragment type condition then
 		// we should just add every field directly
 		if definition.TypeCondition == c.ParentType || !abstractParent {
-			for _, sel := range definition.Selections {
+			for _, sel := range fragmentSelections {
 				err := c.Add(sel, true, visibilityMask)
 				if err != nil {
 					return err
@@ -229,7 +267,7 @@ func (c *fieldCollection) Add(
 			Kind:      "inline_fragment",
 			FieldName: definition.TypeCondition,
 			FieldType: definition.TypeCondition,
-			Children:  definition.Selections,
+			Children:  fragmentSelections,
 			Visible:   !hidden,
 		}
 
@@ -515,4 +553,71 @@ func containsDirective(list []*collected.Directive, dir *collected.Directive) bo
 		}
 	}
 	return false
+}
+
+// spreadConditionals extracts the @include and @skip directives applied to a
+// fragment spread. the copies are marked internal so that merging can tell them
+// apart from conditionals the user wrote on a field directly
+func spreadConditionals(directives []*collected.Directive) []*collected.Directive {
+	result := []*collected.Directive{}
+	for _, directive := range directives {
+		if directive.Name == graphql.IncludeDirective || directive.Name == graphql.SkipDirective {
+			clone := *directive
+			clone.Internal = 1
+			result = append(result, &clone)
+		}
+	}
+	return result
+}
+
+// isPropagatedConditional returns true if the directive is an @include or @skip
+// that was inherited from a fragment spread rather than written on the field
+func isPropagatedConditional(directive *collected.Directive) bool {
+	return directive.Internal == 1 &&
+		(directive.Name == graphql.IncludeDirective || directive.Name == graphql.SkipDirective)
+}
+
+// withoutPropagatedConditionals filters out conditionals inherited from fragment
+// spreads. the original slice is left untouched since it might be shared with the
+// collected document
+func withoutPropagatedConditionals(
+	directives []*collected.Directive,
+) []*collected.Directive {
+	propagated := false
+	for _, dir := range directives {
+		if isPropagatedConditional(dir) {
+			propagated = true
+			break
+		}
+	}
+	if !propagated {
+		return directives
+	}
+
+	result := make([]*collected.Directive, 0, len(directives))
+	for _, dir := range directives {
+		if !isPropagatedConditional(dir) {
+			result = append(result, dir)
+		}
+	}
+	return result
+}
+
+// attachConditionals records the conditional directives from a fragment spread on
+// every selection it inlines so the runtime knows the fields might be missing from
+// the response. fields and nested spreads carry the condition directly while inline
+// fragments pass it through to their children
+func attachConditionals(selection *collected.Selection, conditionals []*collected.Directive) {
+	switch selection.Kind {
+	case "field", "fragment":
+		for _, directive := range conditionals {
+			if !containsDirective(selection.Directives, directive) {
+				selection.Directives = append(selection.Directives, directive)
+			}
+		}
+	case "inline_fragment":
+		for _, child := range selection.Children {
+			attachConditionals(child, conditionals)
+		}
+	}
 }

--- a/packages/houdini-core/plugin/documents/artifacts/merge.go
+++ b/packages/houdini-core/plugin/documents/artifacts/merge.go
@@ -234,6 +234,26 @@ func (c *fieldCollection) Add(
 			return plugins.WrapError(errors.New("fragment not found"))
 		}
 
+		// figure out if the fragment's fields are masked in this document. explicit
+		// mask directives on the spread win, otherwise we fall back to the project's
+		// defaultFragmentMasking setting
+		childHidden := c.DefaultMask
+		for _, directive := range selection.Directives {
+			if directive.Name == graphql.DisableMaskDirective {
+				childHidden = false
+				break
+			}
+			if directive.Name == graphql.EnableMaskDirective {
+				childHidden = true
+				break
+			}
+		}
+		// a spread that is itself in a hidden context (eg inside a masked fragment)
+		// keeps its fields hidden no matter what
+		if external || selection.Internal {
+			childHidden = true
+		}
+
 		// if the spread is guarded by @include or @skip then the fields it inlines are
 		// conditional too. clone the fragment's selections and push the condition onto
 		// them so the runtime doesn't treat a missing value as a broken non-null field
@@ -252,7 +272,7 @@ func (c *fieldCollection) Add(
 		// we should just add every field directly
 		if definition.TypeCondition == c.ParentType || !abstractParent {
 			for _, sel := range fragmentSelections {
-				err := c.Add(sel, true, visibilityMask)
+				err := c.Add(sel, childHidden, visibilityMask)
 				if err != nil {
 					return err
 				}
@@ -271,7 +291,7 @@ func (c *fieldCollection) Add(
 			Visible:   !hidden,
 		}
 
-		return c.Add(inlineFragment, true, visibilityMask)
+		return c.Add(inlineFragment, childHidden, visibilityMask)
 	}
 
 	// its a field we don't recognize, we're done
@@ -458,9 +478,9 @@ func (c *fieldCollection) ToSelectionSet() []*collected.Selection {
 			if f.Selection != nil {
 				field.Children = f.Selection.ToSelectionSet()
 			}
-			if f.Visible {
-				field.Visible = true
-			}
+			// the visibility computed while flattening is authoritative — the flag on
+			// the source selection only says whether a user wrote the field somewhere
+			field.Visible = f.Visible
 			result = append(result, field)
 		}
 
@@ -491,9 +511,9 @@ func (c *fieldCollection) ToSelectionSet() []*collected.Selection {
 			if field.Selection != nil {
 				selectionField.Children = field.Selection.ToSelectionSet()
 			}
-			if field.Visible {
-				selectionField.Visible = true
-			}
+			// the visibility computed while flattening is authoritative — the flag on
+			// the source selection only says whether a user wrote the field somewhere
+			selectionField.Visible = field.Visible
 			result = append(result, selectionField)
 		}
 

--- a/packages/houdini-core/plugin/documents/artifacts/selection_conditional_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_conditional_test.go
@@ -298,6 +298,138 @@ export type TestQuery$artifact = typeof artifact
 "HoudiniHash=2bc145fc0631e7f8e71fa91c1b77afc0b2aba93ca8fe5f39dc4dbfeceb158063"`),
 				},
 			},
+			{
+				Name: "masked spread with @include does not propagate condition to inlined fields",
+				Pass: true,
+				Input: []string{
+					`query TestQuery($show: Boolean!) {
+            user(id: "1") {
+              id
+              ...UserDetails @include(if: $show)
+            }
+          }`,
+					`fragment UserDetails on User {
+            firstName
+          }`,
+				},
+				Extra: map[string]any{
+					"TestQuery": tests.Dedent(`const artifact = {
+    "name": "TestQuery",
+    "kind": "HoudiniQuery",
+    "hash": "4d664747270e4504bff250185fc0abd5a6778f75b203cbc5e8dca84aa8c36d93",
+    "raw": ` + "`" + `query TestQuery($show: Boolean!) {
+    user(id: "1") {
+        id
+        ...UserDetails @include(if: $show)
+        __typename
+    }
+}
+
+fragment UserDetails on User {
+    firstName
+    __typename
+    id
+}
+` + "`" + `,
+
+    "rootType": "Query",
+    "stripVariables": [] as Array<string>,
+
+    "selection": {
+        "fields": {
+            "user": {
+                "type": "User",
+                "keyRaw": "user(id: \"1\")",
+
+                "selection": {
+                    "fields": {
+                        "__typename": {
+                            "type": "String",
+                            "keyRaw": "__typename",
+                        },
+
+                        "firstName": {
+                            "type": "String",
+                            "keyRaw": "firstName",
+
+                            "directives": [{
+                                "name": "include",
+                                "arguments": {
+                                    "if": {
+                                        "kind": "Variable",
+                                        name: {
+                                            "kind": "Name",
+                                            "value": "show",
+                                        },
+                                        "value": "show"
+                                    }
+                                }
+                            }],
+
+                        },
+
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id",
+                            "visible": true,
+                        },
+                    },
+
+                    "fragments": {
+                        "UserDetails": {
+                            "arguments": {}
+                        },
+                    },
+                },
+
+                "visible": true,
+            },
+        },
+    },
+
+    "pluginData": {},
+
+    "input": {
+        "fields": {
+            "show": "Boolean",
+        },
+
+        "types": {},
+
+        "defaults": {},
+
+        "runtimeScalars": {},
+    },
+
+    "policy": "CacheOrNetwork",
+    "partial": false
+} as const
+
+export default artifact
+
+export type TestQuery = {
+	readonly "input": TestQuery$input;
+	readonly "result": TestQuery$result | undefined;
+};
+
+export type TestQuery$result = {
+	readonly user: {
+		readonly id: string;
+		readonly " $fragments": {
+			UserDetails: {};
+		};
+	};
+};
+
+export type TestQuery$input = {
+	show: boolean;
+};
+
+export type TestQuery$artifact = typeof artifact
+
+"HoudiniHash=4d664747270e4504bff250185fc0abd5a6778f75b203cbc5e8dca84aa8c36d93"`),
+				},
+			},
 		},
 	})
 }

--- a/packages/houdini-core/plugin/documents/artifacts/selection_conditional_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_conditional_test.go
@@ -1,0 +1,303 @@
+package artifacts_test
+
+import (
+	"testing"
+
+	"code.houdinigraphql.com/packages/houdini-core/config"
+	"code.houdinigraphql.com/packages/houdini-core/plugin"
+	"code.houdinigraphql.com/plugins/tests"
+)
+
+// when a fragment spread is tagged with @include or @skip, the fields it inlines
+// into the parent selection are conditional: the server might not return them.
+// the condition has to be propagated onto those fields in the artifact so the
+// runtime doesn't treat a missing non-null value as a reason to cascade null up
+// the selection (https://github.com/HoudiniGraphql/houdini/issues/1550)
+func TestConditionalFragmentSpread(t *testing.T) {
+	tests.RunTable(t, tests.Table[config.PluginConfig, *plugin.HoudiniCore]{
+		Schema: `
+      type Query {
+        user(id: ID): User!
+        node(id: ID!): Node
+      }
+
+      interface Node {
+        id: ID!
+      }
+
+      type User implements Node {
+        id: ID!
+        firstName: String!
+      }
+    `,
+		PerformTest: performArtifactTest,
+		Tests: []tests.Test[config.PluginConfig]{
+			{
+				Name: "include on a spread propagates to inlined fields",
+				Pass: true,
+				Input: []string{
+					`query TestQuery {
+            user(id: "1") {
+              id
+              ...UserDetails @mask_disable @include(if: false)
+            }
+          }`,
+					`fragment UserDetails on User {
+            firstName
+          }`,
+				},
+				Extra: map[string]any{
+					"TestQuery": tests.Dedent(`const artifact = {
+    "name": "TestQuery",
+    "kind": "HoudiniQuery",
+    "hash": "c1028fc6e5213fd703e4e3f2138294735428be9437e68eab4d9854ba91f14c0c",
+    "raw": ` + "`" + `query TestQuery {
+    user(id: "1") {
+        id
+        ...UserDetails @include(if: false)
+        __typename
+    }
+}
+
+fragment UserDetails on User {
+    firstName
+    __typename
+    id
+}
+` + "`" + `,
+
+    "rootType": "Query",
+    "stripVariables": [] as Array<string>,
+
+    "selection": {
+        "fields": {
+            "user": {
+                "type": "User",
+                "keyRaw": "user(id: \"1\")",
+
+                "selection": {
+                    "fields": {
+                        "__typename": {
+                            "type": "String",
+                            "keyRaw": "__typename",
+                        },
+
+                        "firstName": {
+                            "type": "String",
+                            "keyRaw": "firstName",
+
+                            "directives": [{
+                                "name": "include",
+                                "arguments": {
+                                    "if": {
+                                        "kind": "BooleanValue",
+                                        "value": false
+                                    }
+                                }
+                            }],
+
+                            "visible": true,
+                        },
+
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id",
+                            "visible": true,
+                        },
+                    },
+
+                    "fragments": {
+                        "UserDetails": {
+                            "arguments": {}
+                        },
+                    },
+                },
+
+                "visible": true,
+            },
+        },
+    },
+
+    "pluginData": {},
+    "policy": "CacheOrNetwork",
+    "partial": false
+} as const
+
+export default artifact
+
+export type TestQuery = {
+	readonly "input"?: TestQuery$input;
+	readonly "result": TestQuery$result | undefined;
+};
+
+export type TestQuery$result = {
+	readonly user: {
+		readonly id: string;
+		readonly firstName?: string;
+		readonly " $fragments": {
+			UserDetails: {};
+		};
+	};
+};
+
+export type TestQuery$input = null | undefined;
+
+export type TestQuery$artifact = typeof artifact
+
+"HoudiniHash=c1028fc6e5213fd703e4e3f2138294735428be9437e68eab4d9854ba91f14c0c"`),
+				},
+			},
+			{
+				Name: "skip on a spread propagates through abstract selections",
+				Pass: true,
+				Input: []string{
+					`query TestQuery($show: Boolean!) {
+            node(id: "1") {
+              id
+              ...UserDetails @mask_disable @skip(if: $show)
+            }
+          }`,
+					`fragment UserDetails on User {
+            firstName
+          }`,
+				},
+				Extra: map[string]any{
+					"TestQuery": tests.Dedent(`const artifact = {
+    "name": "TestQuery",
+    "kind": "HoudiniQuery",
+    "hash": "2bc145fc0631e7f8e71fa91c1b77afc0b2aba93ca8fe5f39dc4dbfeceb158063",
+    "raw": ` + "`" + `query TestQuery($show: Boolean!) {
+    node(id: "1") {
+        id
+        ...UserDetails @skip(if: $show)
+        __typename
+    }
+}
+
+fragment UserDetails on User {
+    firstName
+    __typename
+    id
+}
+` + "`" + `,
+
+    "rootType": "Query",
+    "stripVariables": [] as Array<string>,
+
+    "selection": {
+        "fields": {
+            "node": {
+                "type": "Node",
+                "keyRaw": "node(id: \"1\")",
+                "nullable": true,
+
+                "selection": {
+                    "fields": {
+                        "__typename": {
+                            "type": "String",
+                            "keyRaw": "__typename",
+                        },
+
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id",
+                            "visible": true,
+                        },
+                    },
+                    "abstractFields": {
+                        "fields": {
+                            "User": {
+                                "__typename": {
+                                    "type": "String",
+                                    "keyRaw": "__typename",
+                                },
+                                "firstName": {
+                                    "type": "String",
+                                    "keyRaw": "firstName",
+
+                                    "directives": [{
+                                        "name": "skip",
+                                        "arguments": {
+                                            "if": {
+                                                "kind": "Variable",
+                                                name: {
+                                                    "kind": "Name",
+                                                    "value": "show",
+                                                },
+                                                "value": "show"
+                                            }
+                                        }
+                                    }],
+
+                                    "visible": true,
+                                },
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id",
+                                    "visible": true,
+                                },
+                            },
+                        },
+
+                        "typeMap": {},
+                    },
+
+                    "fragments": {
+                        "UserDetails": {
+                            "arguments": {}
+                        },
+                    },
+                },
+
+                "abstract": true,
+                "visible": true,
+            },
+        },
+    },
+
+    "pluginData": {},
+
+    "input": {
+        "fields": {
+            "show": "Boolean",
+        },
+
+        "types": {},
+
+        "defaults": {},
+
+        "runtimeScalars": {},
+    },
+
+    "policy": "CacheOrNetwork",
+    "partial": false
+} as const
+
+export default artifact
+
+export type TestQuery = {
+	readonly "input": TestQuery$input;
+	readonly "result": TestQuery$result | undefined;
+};
+
+export type TestQuery$result = {
+	readonly node: {
+		readonly id: string;
+		readonly " $fragments": {
+			UserDetails: {};
+		};
+	} | null;
+};
+
+export type TestQuery$input = {
+	show: boolean;
+};
+
+export type TestQuery$artifact = typeof artifact
+
+"HoudiniHash=2bc145fc0631e7f8e71fa91c1b77afc0b2aba93ca8fe5f39dc4dbfeceb158063"`),
+				},
+			},
+		},
+	})
+}

--- a/packages/houdini-core/plugin/documents/artifacts/selection_lists_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_lists_test.go
@@ -1202,7 +1202,6 @@ fragment MonkeyList on MonkeyConnection {
                                                         "hasBanana": {
                                                             "type": "Boolean",
                                                             "keyRaw": "hasBanana",
-                                                            "visible": true,
                                                         },
 
                                                         "id": {
@@ -1213,7 +1212,6 @@ fragment MonkeyList on MonkeyConnection {
                                                         "name": {
                                                             "type": "String",
                                                             "keyRaw": "name",
-                                                            "visible": true,
                                                         },
                                                     },
 
@@ -1224,12 +1222,10 @@ fragment MonkeyList on MonkeyConnection {
                                                     },
                                                 },
 
-                                                "visible": true,
                                             },
                                         },
                                     },
 
-                                    "visible": true,
                                 },
                                 "pageInfo": {
                                     "type": "PageInfo",
@@ -1448,17 +1444,14 @@ fragment MonkeyFragment on Monkey {
                                                         "hasBanana": {
                                                             "type": "Boolean",
                                                             "keyRaw": "hasBanana",
-                                                            "visible": true,
                                                         },
                                                         "id": {
                                                             "type": "ID",
                                                             "keyRaw": "id",
-                                                            "visible": true,
                                                         },
                                                         "name": {
                                                             "type": "String",
                                                             "keyRaw": "name",
-                                                            "visible": true,
                                                         },
                                                     },
                                                 },
@@ -1474,13 +1467,11 @@ fragment MonkeyFragment on Monkey {
                                         },
 
                                         "abstract": true,
-                                        "visible": true,
                                     },
                                 },
                             },
 
                             "abstract": true,
-                            "visible": true,
                         },
                     },
 
@@ -1817,7 +1808,6 @@ fragment UserTest on User {
                                                 "firstName": {
                                                     "type": "String",
                                                     "keyRaw": "firstName",
-                                                    "visible": true,
                                                 },
 
                                                 "id": {

--- a/packages/houdini-core/plugin/documents/artifacts/selection_loading_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_loading_test.go
@@ -191,25 +191,21 @@ query MonkeyListQuery {
                                                 "id": {
                                                     "type": "ID",
                                                     "keyRaw": "id",
-                                                    "visible": true,
                                                 },
 
                                                 "name": {
                                                     "type": "String",
                                                     "keyRaw": "name",
-                                                    "visible": true,
                                                 },
                                             },
                                         },
 
                                         "abstract": true,
-                                        "visible": true,
                                     },
                                 },
                             },
 
                             "abstract": true,
-                            "visible": true,
                         },
 
                         "pageInfo": {
@@ -820,7 +816,6 @@ query Query {
                                     "loading": {
                                         "kind": "value",
                                     },
-                                    "visible": true,
                                 },
                                 "id": {
                                     "type": "ID",

--- a/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
@@ -225,7 +225,6 @@ fragment All_Users_insert on User {
                                     "firstName": {
                                         "type": "String",
                                         "keyRaw": "firstName",
-                                        "visible": true,
                                     },
 
                                     "id": {
@@ -365,13 +364,11 @@ fragment All_Users_insert_kVR6H on User {
                                         "type": "String",
                                         "keyRaw": "field(filter: \"Hello World\")",
                                         "nullable": true,
-                                        "visible": true,
                                     },
 
                                     "firstName": {
                                         "type": "String",
                                         "keyRaw": "firstName",
-                                        "visible": true,
                                     },
 
                                     "id": {
@@ -520,7 +517,6 @@ fragment All_Users_insert on User {
                                     "firstName": {
                                         "type": "String",
                                         "keyRaw": "firstName",
-                                        "visible": true,
                                     },
 
                                     "id": {
@@ -663,7 +659,6 @@ fragment All_Users_insert on User {
                                     "firstName": {
                                         "type": "String",
                                         "keyRaw": "firstName",
-                                        "visible": true,
                                     },
 
                                     "id": {
@@ -809,7 +804,6 @@ fragment All_Users_insert on User {
                                     "firstName": {
                                         "type": "String",
                                         "keyRaw": "firstName",
-                                        "visible": true,
                                     },
 
                                     "id": {
@@ -950,13 +944,11 @@ fragment All_Users_insert_kVR6H on User {
                                         "type": "String",
                                         "keyRaw": "field(filter: \"Hello World\")",
                                         "nullable": true,
-                                        "visible": true,
                                     },
 
                                     "firstName": {
                                         "type": "String",
                                         "keyRaw": "firstName",
-                                        "visible": true,
                                     },
 
                                     "id": {
@@ -1212,7 +1204,6 @@ fragment All_Users_insert on User {
                                     "firstName": {
                                         "type": "String",
                                         "keyRaw": "firstName",
-                                        "visible": true,
                                     },
 
                                     "id": {
@@ -1478,7 +1469,6 @@ fragment All_Users_toggle on User {
                                     "firstName": {
                                         "type": "String",
                                         "keyRaw": "firstName",
-                                        "visible": true,
                                     },
 
                                     "id": {
@@ -1619,13 +1609,11 @@ fragment All_Users_toggle_kVR6H on User {
                                         "type": "String",
                                         "keyRaw": "field(filter: \"Hello World\")",
                                         "nullable": true,
-                                        "visible": true,
                                     },
 
                                     "firstName": {
                                         "type": "String",
                                         "keyRaw": "firstName",
-                                        "visible": true,
                                     },
 
                                     "id": {
@@ -1772,7 +1760,6 @@ fragment All_Users_toggle on User {
                                     "firstName": {
                                         "type": "String",
                                         "keyRaw": "firstName",
-                                        "visible": true,
                                     },
 
                                     "id": {
@@ -1912,7 +1899,6 @@ fragment All_Users_toggle on User {
                                     "firstName": {
                                         "type": "String",
                                         "keyRaw": "firstName",
-                                        "visible": true,
                                     },
 
                                     "id": {
@@ -2503,7 +2489,6 @@ fragment All_Users_insert on User {
                                     "firstName": {
                                         "type": "String",
                                         "keyRaw": "firstName",
-                                        "visible": true,
                                     },
 
                                     "id": {

--- a/packages/houdini-core/plugin/documents/artifacts/selection_requiredDirective_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_requiredDirective_test.go
@@ -162,19 +162,16 @@ query TestQuery($id: ID!) {
                                                 "type": "String",
                                                 "keyRaw": "name",
                                                 "nullable": true,
-                                                "visible": true,
                                             },
                                         },
                                     },
 
                                     "abstract": true,
-                                    "visible": true,
                                 },
                                 "name": {
                                     "type": "String",
                                     "keyRaw": "name",
                                     "nullable": true,
-                                    "visible": true,
                                 },
                             },
                             "Legend": {
@@ -190,7 +187,6 @@ query TestQuery($id: ID!) {
                                     "type": "String",
                                     "keyRaw": "name",
                                     "nullable": true,
-                                    "visible": true,
                                 },
                             },
                         },

--- a/packages/houdini-core/plugin/documents/artifacts/selection_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_test.go
@@ -300,7 +300,6 @@ query TestQuery {
                         "firstName": {
                             "type": "String",
                             "keyRaw": "firstName",
-                            "visible": true,
                         },
 
                         "id": {
@@ -813,12 +812,10 @@ query TestQuery {
                                             "lastName": {
                                                 "type": "String",
                                                 "keyRaw": "lastName",
-                                                "visible": true,
                                             },
                                         },
                                     },
 
-                                    "visible": true,
                                 },
                                 "id": {
                                     "type": "ID",
@@ -1751,7 +1748,6 @@ fragment UserThings on User {
                                 "name": {
                                     "type": "String",
                                     "keyRaw": "name",
-                                    "visible": true,
                                 },
                             },
                         },
@@ -2034,7 +2030,6 @@ query TestQuery() {
                                     "type": "String",
                                     "keyRaw": "field(filter: \"Foo\")",
                                     "nullable": true,
-                                    "visible": true,
                                 },
                                 "id": {
                                     "type": "ID",
@@ -3460,7 +3455,6 @@ query EntityList {
                                               "name": {
                                                   "type": "String",
                                                   "keyRaw": "name",
-                                                  "visible": true,
                                               },
                                           },
                                           "User": {
@@ -3471,7 +3465,6 @@ query EntityList {
                                               "firstName": {
                                                   "type": "String",
                                                   "keyRaw": "firstName",
-                                                  "visible": true,
                                               },
                                               "id": {
                                                   "type": "ID",
@@ -3590,7 +3583,6 @@ query UserWithAvatar {
                                     "firstName": {
                                         "type": "String",
                                         "keyRaw": "firstName",
-                                        "visible": true,
                                     },
 
                                     "id": {
@@ -3743,7 +3735,6 @@ query UserWithAvatar {
 							                            "type": "String",
 							                            "keyRaw": "field",
 							                            "nullable": true,
-							                            "visible": true,
 							                        },
 
 							                        "id": {
@@ -3754,7 +3745,6 @@ query UserWithAvatar {
 							                        "name": {
 							                            "type": "String",
 							                            "keyRaw": "name",
-							                            "visible": true,
 							                        },
 							                    },
 

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
@@ -24,6 +24,124 @@ type DocumentContext struct {
 	ScalarImports map[string]bool // full import statement → true
 }
 
+// spreadDisablesMasking returns true when a fragment spread's fields should be
+// inlined into the surrounding type. @mask_disable and @mask_enable on the spread
+// take priority, otherwise we fall back to the project's defaultFragmentMasking
+func spreadDisablesMasking(projectConfig plugins.ProjectConfig, spread *collected.Selection) bool {
+	for _, directive := range spread.Directives {
+		if directive.Name == graphql.DisableMaskDirective {
+			return true
+		}
+		if directive.Name == graphql.EnableMaskDirective {
+			return false
+		}
+	}
+	return !projectConfig.DefaultFragmentMasking
+}
+
+// spreadIsConditional returns true when the spread carries @include or @skip,
+// meaning the fields it inlines might be missing from the response
+func spreadIsConditional(spread *collected.Selection) bool {
+	for _, directive := range spread.Directives {
+		if directive.Name == graphql.IncludeDirective || directive.Name == graphql.SkipDirective {
+			return true
+		}
+	}
+	return false
+}
+
+// expandMaskedSpreads replaces fragment spreads that disable masking with the
+// selections of the fragment definition. the spread node itself is kept so the
+// " $fragments" marker is still generated. only spreads whose type condition is
+// satisfied by every object of parentType are expanded — anything narrower needs
+// a discriminated union to describe accurately so we leave those masked.
+//
+// the second return value marks the fields that were inlined through a spread
+// guarded by @include or @skip — those might be missing from the response so
+// they have to be typed as optional
+func expandMaskedSpreads(
+	ctx *DocumentContext,
+	collectedDocs *collected.Documents,
+	selections []*collected.Selection,
+	parentType string,
+) ([]*collected.Selection, map[*collected.Selection]bool) {
+	result := make([]*collected.Selection, 0, len(selections))
+	optionalFields := map[*collected.Selection]bool{}
+	seenFields := map[string]*collected.Selection{}
+	seenFragments := map[string]bool{}
+
+	// satisfied returns true when every object of parentType matches the condition
+	satisfied := func(condition string) bool {
+		return condition == "" || condition == parentType ||
+			collectedDocs.PossibleTypes[condition][parentType]
+	}
+
+	var walk func(sels []*collected.Selection, expanded bool, conditional bool)
+	walk = func(sels []*collected.Selection, expanded bool, conditional bool) {
+		for _, sel := range sels {
+			switch sel.Kind {
+			case "fragment":
+				// always keep the spread for the " $fragments" marker
+				result = append(result, sel)
+
+				if !spreadDisablesMasking(ctx.ProjectConfig, sel) {
+					continue
+				}
+				// guard against revisiting a fragment (the spec forbids cycles but
+				// we don't want a malformed document to hang the generator)
+				if seenFragments[sel.FieldName] {
+					continue
+				}
+				seenFragments[sel.FieldName] = true
+
+				definition, ok := collectedDocs.Selections[sel.FieldName]
+				if !ok || !satisfied(definition.TypeCondition) {
+					continue
+				}
+
+				walk(definition.Selections, true, conditional || spreadIsConditional(sel))
+
+			case "inline_fragment":
+				// inline fragments pulled out of an expanded definition can't be
+				// passed through (the flat object type has no way to express them)
+				// so we inline the ones that always match and drop the rest
+				if !expanded {
+					result = append(result, sel)
+				} else if satisfied(sel.FieldName) {
+					walk(sel.Children, true, conditional)
+				}
+
+			case "field":
+				// fields can reach us twice (selected directly and through an
+				// unmasked fragment) but the type can only list them once
+				name := sel.FieldName
+				if sel.Alias != nil {
+					name = *sel.Alias
+				}
+				if kept, ok := seenFields[name]; ok {
+					// an occurrence that is always present wins over a conditional one
+					if !conditional {
+						delete(optionalFields, kept)
+					}
+					continue
+				}
+				seenFields[name] = sel
+				if conditional {
+					optionalFields[sel] = true
+				}
+
+				result = append(result, sel)
+
+			default:
+				result = append(result, sel)
+			}
+		}
+	}
+	walk(selections, false, false)
+
+	return result, optionalFields
+}
+
 func GenerateDocumentTypeDefs(
 	projectConfig plugins.ProjectConfig,
 	rootTypes *RootTypeNames,
@@ -346,6 +464,9 @@ func generateSelectionType(
 		return "{}", nil
 	}
 
+	// inline the fields of any fragment spread that disables masking
+	selections, optionalFields := expandMaskedSpreads(ctx, collectedDocs, selections, parentType)
+
 	var fields []string
 	var fragmentFields []string
 
@@ -473,6 +594,12 @@ func generateSelectionType(
 			readonlyPrefix = "readonly "
 		}
 
+		// fields inlined through a conditionally included spread might be missing
+		// from the response so they are typed as optional
+		if optionalFields[selection] {
+			fieldName += "?"
+		}
+
 		// Add JSDoc comment if this field has a description
 		var fieldDef string
 		indent := strings.Repeat("\t", indentLevel+1)
@@ -584,7 +711,8 @@ func generateInterfaceUnionTypeWithLoading(
 					for concreteType := range possibleTypesMap {
 						fragmentsByType[concreteType] = append(fragmentsByType[concreteType], child)
 						concreteTypesSet[concreteType] = true
-						collectNamedFragments(concreteType, child.Children)
+						expanded, _ := expandMaskedSpreads(ctx, collectedDocs, child.Children, concreteType)
+						collectNamedFragments(concreteType, expanded)
 					}
 					// Also recursively process any nested inline fragments within this abstract fragment
 					processInlineFragments(child.Children)
@@ -593,7 +721,8 @@ func generateInterfaceUnionTypeWithLoading(
 					if fieldPossibleTypes[fragmentTypeName] {
 						fragmentsByType[fragmentTypeName] = append(fragmentsByType[fragmentTypeName], child)
 						concreteTypesSet[fragmentTypeName] = true
-						collectNamedFragments(fragmentTypeName, child.Children)
+						expanded, _ := expandMaskedSpreads(ctx, collectedDocs, child.Children, fragmentTypeName)
+						collectNamedFragments(fragmentTypeName, expanded)
 					}
 				}
 			}
@@ -629,8 +758,10 @@ func generateInterfaceUnionTypeWithLoading(
 
 		// Process all fragments that apply to this type
 		for _, fragment := range fragmentsByType[typeName] {
+			// inline the fields of any fragment spread that disables masking
+			fragmentChildren, optionalFields := expandMaskedSpreads(ctx, collectedDocs, fragment.Children, typeName)
 			// Include fields from this inline fragment
-			for _, fragmentChild := range fragment.Children {
+			for _, fragmentChild := range fragmentChildren {
 				if fragmentChild.Kind == "field" && fragmentChild.FieldName != "__typename" {
 					// Skip __typename fields from fragments - we'll add the discriminated version
 					// Also skip if we've already added this field
@@ -705,12 +836,20 @@ func generateInterfaceUnionTypeWithLoading(
 						}
 					}
 
+					// fields inlined through a conditionally included spread might be
+					// missing from the response so they are typed as optional
+					optional := ""
+					if optionalFields[fragmentChild] {
+						optional = "?"
+					}
+
 					fields = append(
 						fields,
 						fmt.Sprintf(
-							"\t\t%s%s: %s;",
+							"\t\t%s%s%s: %s;",
 							readonlyPrefix,
 							fragmentChild.FieldName,
+							optional,
 							fieldType,
 						),
 					)

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/masking_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/masking_test.go
@@ -1,0 +1,287 @@
+package typescript_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+
+	"code.houdinigraphql.com/packages/houdini-core/config"
+	"code.houdinigraphql.com/packages/houdini-core/plugin"
+	"code.houdinigraphql.com/plugins"
+	"code.houdinigraphql.com/plugins/tests"
+)
+
+// when masking is disabled for a fragment spread (either with @mask_disable or
+// defaultFragmentMasking: 'disable') the fragment's fields are part of the data
+// the runtime returns, so they have to show up in the generated types too
+func TestTypescriptFragmentMasking(t *testing.T) {
+	tests.RunTable(t, tests.Table[config.PluginConfig, *plugin.HoudiniCore]{
+		Schema: `
+			type Query {
+				user(id: ID): User!
+				node(id: ID!): Node
+			}
+
+			interface Node {
+				id: ID!
+			}
+
+			type User implements Node {
+				id: ID!
+				nickname: String
+				age: Int
+			}
+
+			type Ghost implements Node {
+				id: ID!
+				aka: String!
+			}
+		`,
+		VerifyTest: func(t *testing.T, plugin *plugin.HoudiniCore, test tests.Test[config.PluginConfig]) {
+			config, err := plugin.DB.ProjectConfig(context.Background())
+			require.NoError(t, err)
+
+			for docName, expected := range test.Extra {
+				typeDefs, err := afero.ReadFile(plugin.Fs, config.ArtifactTypePath(docName))
+				require.NoError(t, err)
+				require.Contains(t, string(typeDefs), expected)
+			}
+		},
+		Tests: []tests.Test[config.PluginConfig]{
+			{
+				Name: "mask_disable inlines fragment fields",
+				Pass: true,
+				Input: []string{
+					`query MaskQuery {
+						user(id: "1") {
+							id
+							...MaskUserInfo @mask_disable
+						}
+					}`,
+					`fragment MaskUserInfo on User {
+						nickname
+						age
+					}`,
+				},
+				Extra: map[string]any{
+					"MaskQuery": tests.Dedent(`
+						export type MaskQuery$result = {
+							readonly user: {
+								readonly id: string;
+								readonly nickname: string | null;
+								readonly age: number | null;
+								readonly " $fragments": {
+									MaskUserInfo: {};
+								};
+							};
+						};
+					`),
+				},
+			},
+			{
+				Name: "mask_disable dedupes fields selected directly",
+				Pass: true,
+				Input: []string{
+					`query MaskQuery {
+						user(id: "1") {
+							id
+							nickname
+							...MaskUserInfo @mask_disable
+						}
+					}`,
+					`fragment MaskUserInfo on User {
+						nickname
+						age
+					}`,
+				},
+				Extra: map[string]any{
+					"MaskQuery": tests.Dedent(`
+						export type MaskQuery$result = {
+							readonly user: {
+								readonly id: string;
+								readonly nickname: string | null;
+								readonly age: number | null;
+								readonly " $fragments": {
+									MaskUserInfo: {};
+								};
+							};
+						};
+					`),
+				},
+			},
+			{
+				Name: "fragment on an implemented interface is inlined",
+				Pass: true,
+				Input: []string{
+					`query MaskQuery {
+						user(id: "1") {
+							...MaskNodeInfo @mask_disable
+						}
+					}`,
+					`fragment MaskNodeInfo on Node {
+						id
+					}`,
+				},
+				Extra: map[string]any{
+					"MaskQuery": tests.Dedent(`
+						export type MaskQuery$result = {
+							readonly user: {
+								readonly id: string;
+								readonly " $fragments": {
+									MaskNodeInfo: {};
+								};
+							};
+						};
+					`),
+				},
+			},
+			{
+				Name: "narrower fragment on an abstract parent stays masked",
+				Pass: true,
+				Input: []string{
+					`query MaskQuery {
+						node(id: "1") {
+							id
+							...MaskUserInfo @mask_disable
+						}
+					}`,
+					`fragment MaskUserInfo on User {
+						nickname
+					}`,
+				},
+				Extra: map[string]any{
+					"MaskQuery": tests.Dedent(`
+						export type MaskQuery$result = {
+							readonly node: {
+								readonly id: string;
+								readonly " $fragments": {
+									MaskUserInfo: {};
+								};
+							} | null;
+						};
+					`),
+				},
+			},
+			{
+				Name: "spread inside an inline fragment is inlined into the branch",
+				Pass: true,
+				Input: []string{
+					`query MaskQuery {
+						node(id: "1") {
+							... on User {
+								id
+								...MaskUserInfo @mask_disable
+							}
+						}
+					}`,
+					`fragment MaskUserInfo on User {
+						nickname
+					}`,
+				},
+				Extra: map[string]any{
+					"MaskQuery": tests.Dedent(`
+						readonly nickname: string | null;
+					`),
+				},
+			},
+			{
+				Name: "nested spreads inline into fragment data types",
+				Pass: true,
+				Input: []string{
+					`query MaskQuery {
+						user(id: "1") {
+							...MaskUserInfo
+						}
+					}`,
+					`fragment MaskUserInfo on User {
+						nickname
+						...MaskUserAge @mask_disable
+					}`,
+					`fragment MaskUserAge on User {
+						age
+					}`,
+				},
+				Extra: map[string]any{
+					"MaskUserInfo": tests.Dedent(`
+						export type MaskUserInfo$data = {
+							readonly nickname: string | null;
+							readonly age: number | null;
+							readonly " $fragments": {
+								MaskUserAge: {};
+							};
+						};
+					`),
+				},
+			},
+			{
+				Name: "conditionally included spreads are typed optional",
+				Pass: true,
+				Input: []string{
+					`query MaskQuery($show: Boolean!) {
+						user(id: "1") {
+							id
+							nickname
+							...MaskUserInfo @mask_disable @include(if: $show)
+						}
+					}`,
+					`fragment MaskUserInfo on User {
+						nickname
+						age
+					}`,
+				},
+				Extra: map[string]any{
+					"MaskQuery": tests.Dedent(`
+						export type MaskQuery$result = {
+							readonly user: {
+								readonly id: string;
+								readonly nickname: string | null;
+								readonly age?: number | null;
+								readonly " $fragments": {
+									MaskUserInfo: {};
+								};
+							};
+						};
+					`),
+				},
+			},
+			{
+				Name: "defaultFragmentMasking disable inlines without a directive",
+				Pass: true,
+				ProjectConfig: func(config *plugins.ProjectConfig) {
+					config.DefaultFragmentMasking = false
+				},
+				Input: []string{
+					`query MaskQuery {
+						user(id: "1") {
+							id
+							...MaskUserInfo
+							...MaskUserAge @mask_enable
+						}
+					}`,
+					`fragment MaskUserInfo on User {
+						nickname
+					}`,
+					`fragment MaskUserAge on User {
+						age
+					}`,
+				},
+				Extra: map[string]any{
+					"MaskQuery": tests.Dedent(`
+						export type MaskQuery$result = {
+							readonly user: {
+								readonly id: string;
+								readonly nickname: string | null;
+								readonly " $fragments": {
+									MaskUserInfo: {};
+									MaskUserAge: {};
+								};
+							};
+						};
+					`),
+				},
+			},
+		},
+	})
+}

--- a/plugins/graphql/conventions.go
+++ b/plugins/graphql/conventions.go
@@ -38,6 +38,10 @@ const LoadingDirective = "loading"
 
 const RequiredDirective = "required"
 
+const IncludeDirective = "include"
+
+const SkipDirective = "skip"
+
 const ComponentFieldDirective = "componentField"
 
 const RuntimeScalarDirective = "__houdini__runtimeScalar"

--- a/plugins/tests/run.go
+++ b/plugins/tests/run.go
@@ -124,15 +124,17 @@ func RunTable[PluginConfig any, PluginType plugins.HoudiniPlugin[PluginConfig]](
 	for _, test := range table.Tests {
 		t.Run(test.Name, func(t *testing.T) {
 			projectConfig := plugins.ProjectConfig{
-				ProjectRoot:          "/project",
-				SchemaPath:           "schema.graphql",
-				DefaultKeys:          []string{"id"},
-				TypeConfig:           make(map[string]plugins.TypeConfig),
-				DefaultCachePolicy:   "CacheOrNetwork",
-				DefaultPartial:       false,
-				DefaultPaginateMode:  "Infinite",
-				RuntimeDir:           ".houdini",
-				PersistedQueriesPath: "persisted_queries.json",
+				ProjectRoot:         "/project",
+				SchemaPath:          "schema.graphql",
+				DefaultKeys:         []string{"id"},
+				TypeConfig:          make(map[string]plugins.TypeConfig),
+				DefaultCachePolicy:  "CacheOrNetwork",
+				DefaultPartial:      false,
+				DefaultPaginateMode: "Infinite",
+				// match the real-world default of defaultFragmentMasking: 'enable'
+				DefaultFragmentMasking: true,
+				RuntimeDir:             ".houdini",
+				PersistedQueriesPath:   "persisted_queries.json",
 			}
 
 			if table.ProjectConfig.TypeConfig != nil {


### PR DESCRIPTION
Closes #1550

There were actually 3 related bugs in this: 

1. **Null cascade**: A fragment spread with `@mask_disable @include(if: false)` inlined the fragment's fields into the parent selection without the `@include` condition attached. The cache runtime saw a non-null field missing from the response and cascaded null up to the parent.

2. **Unmasked fields missing from types**: When `@mask_disable` (or `defaultFragmentMasking: 'disable'`) was used, the fragment's fields didn't appear in the generated `$result` type — they stayed hidden behind the `$fragments` marker.

3. **Runtime masking regression** (introduced in b226cd86): All fragment-only fields were being marked `visible: true` in artifacts regardless of masking config, so the runtime was returning masked data to components that shouldn't see it.
