### PR TITLE
Support object-based filters for lists

### DIFF
--- a/.changeset/fix-list-filter-object-variables.md
+++ b/.changeset/fix-list-filter-object-variables.md
@@ -1,0 +1,6 @@
+---
+'houdini-core': patch
+'houdini': patch
+---
+
+fix list filters and @when conditions that contain object values or variable references nested inside objects

--- a/packages/houdini-core/plugin/documents/artifacts/selection.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection.go
@@ -1237,15 +1237,8 @@ func stringifyFieldSelection(
 
 		// we also need to record which filters are currently being applied to the list field
 		for _, arg := range selection.Arguments {
-			value := stringifyValue(arg.Value, map[string]bool{})
-			if arg.Value.Kind == "Variable" {
-				value = `"` + arg.Value.Raw + `"`
-			}
 			filters += fmt.Sprintf(`
-%s"%s": {
-%s"kind": "%s",
-%s"value": %s
-%s},`, indent5, arg.Name, indent6, arg.Value.Kind, indent6, value, indent5)
+%s"%s": %s,`, indent5, arg.Name, serializeListFilter(arg.Value, level+4))
 		}
 
 		if filters != "" {
@@ -1466,7 +1459,7 @@ func extractOperation(
 %s"%s": %s,`,
 					indent2,
 					arg.Name,
-					stringifyValue(arg.Value, map[string]bool{}),
+					serializeListFilter(arg.Value, level+1),
 				)
 			}
 			when += fmt.Sprintf(`
@@ -1483,7 +1476,7 @@ func extractOperation(
 %s"%s": %s,`,
 					indent2,
 					arg.Name,
-					stringifyValue(arg.Value, map[string]bool{}),
+					serializeListFilter(arg.Value, level+1),
 				)
 			}
 			when += fmt.Sprintf(`
@@ -1597,6 +1590,52 @@ func stripSuffix(s string, suffix string) string {
 		return s[:i]
 	}
 	return s
+}
+
+// serializeListFilter generates the {kind, value} entry for an argument applied
+// to a @list field. object and list values nest their children as filter entries
+// so that variable references stay structured instead of being printed as raw
+// graphql text (which isn't valid javascript)
+func serializeListFilter(value *collected.ArgumentValue, level int) string {
+	indent0 := strings.Repeat(spacing, level)
+	indent1 := strings.Repeat(spacing, level+1)
+
+	serialized := ""
+	switch value.Kind {
+	case "Variable":
+		serialized = fmt.Sprintf("%q", value.Raw)
+	case "Object":
+		indent2 := strings.Repeat(spacing, level+2)
+		fields := ""
+		for i, child := range value.Children {
+			if i > 0 {
+				fields += ","
+			}
+			fields += fmt.Sprintf(
+				"\n%s%q: %s",
+				indent2,
+				child.Name,
+				serializeListFilter(child.Value, level+2),
+			)
+		}
+		serialized = fmt.Sprintf("{%s\n%s}", fields, indent1)
+	case "List":
+		values := ""
+		for i, child := range value.Children {
+			if i > 0 {
+				values += ", "
+			}
+			values += serializeListFilter(child.Value, level+1)
+		}
+		serialized = "[" + values + "]"
+	default:
+		serialized = stringifyValue(value, map[string]bool{})
+	}
+
+	return fmt.Sprintf(`{
+%s"kind": "%s",
+%s"value": %s
+%s}`, indent1, value.Kind, indent1, serialized, indent0)
 }
 
 func serializeFragmentArgument(arg *collected.ArgumentValue, level int) string {

--- a/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
@@ -436,6 +436,167 @@ export type A$artifact = typeof artifact
 				},
 			},
 			{
+				Name: "Insert operations with variable condition",
+				Pass: true,
+				Input: []string{
+					`mutation B($name: String!) {
+              addFriend {
+                friend {
+                  ...All_Users_insert @when(stringValue: $name)
+                }
+              }
+            }`,
+					`query TestQuery {
+              users @list(name: "All_Users") {
+                firstName
+              }
+            }`,
+				},
+				Extra: map[string]any{
+					"B": tests.Dedent(`const artifact = {
+    "name": "B",
+    "kind": "HoudiniMutation",
+    "hash": "680082591789d4a74f7136909b1e6349e6561f44b777de23138d5dda947e4150",
+    "raw": ` + "`" + `fragment All_Users_insert on User {
+    firstName
+    __typename
+    id
+}
+
+mutation B {
+    addFriend {
+        friend {
+            ...All_Users_insert
+            __typename
+            id
+        }
+        __typename
+    }
+}
+` + "`" + `,
+
+    "rootType": "Mutation",
+    "stripVariables": ["name"] as Array<string>,
+
+    "selection": {
+        "fields": {
+            "addFriend": {
+                "type": "AddFriendOutput",
+                "keyRaw": "addFriend",
+
+                "selection": {
+                    "fields": {
+                        "__typename": {
+                            "type": "String",
+                            "keyRaw": "__typename",
+                        },
+
+                        "friend": {
+                            "type": "User",
+                            "keyRaw": "friend",
+
+                            "operations": [{
+                                "action": "insert",
+                                "list": "All_Users",
+                                "position": "last",
+
+                                "when": {
+                                    "must": {
+                                        "stringValue": {
+                                            "kind": "Variable",
+                                            "value": "name"
+                                        },
+                                    },
+                                },
+                            }],
+
+                            "selection": {
+                                "fields": {
+                                    "__typename": {
+                                        "type": "String",
+                                        "keyRaw": "__typename",
+                                    },
+
+                                    "firstName": {
+                                        "type": "String",
+                                        "keyRaw": "firstName",
+                                        "visible": true,
+                                    },
+
+                                    "id": {
+                                        "type": "ID",
+                                        "keyRaw": "id",
+                                    },
+                                },
+
+                                "fragments": {
+                                    "All_Users_insert": {
+                                        "arguments": {}
+                                    },
+                                },
+                            },
+
+                            "visible": true,
+                        },
+                    },
+                },
+
+                "visible": true,
+            },
+        },
+    },
+
+    "pluginData": {},
+
+    "input": {
+        "fields": {
+            "name": "String",
+        },
+
+        "types": {},
+
+        "defaults": {},
+
+        "runtimeScalars": {},
+    },
+
+} as const
+
+export default artifact
+
+export type B = {
+	readonly "input": B$input;
+	readonly "result": B$result;
+};
+
+export type B$result = {
+	readonly addFriend: {
+		readonly friend: {
+			readonly " $fragments": {
+				All_Users_insert: {};
+			};
+		};
+	};
+};
+
+export type B$input = {
+	name: string;
+};
+
+export type B$optimistic = {
+	readonly addFriend?: {
+		readonly friend?: {
+			readonly firstName?: string;
+		};
+	};
+};
+
+export type B$artifact = typeof artifact
+
+"HoudiniHash=680082591789d4a74f7136909b1e6349e6561f44b777de23138d5dda947e4150"`),
+				},
+			},
+			{
 				Name: "Insert operations with condition",
 				Pass: true,
 				Input: []string{
@@ -502,7 +663,10 @@ fragment All_Users_insert on User {
 
                                 "when": {
                                     "must": {
-                                        "stringValue": "foo",
+                                        "stringValue": {
+                                            "kind": "String",
+                                            "value": "foo"
+                                        },
                                     },
                                 },
                             }],
@@ -644,7 +808,10 @@ fragment All_Users_insert on User {
 
                                 "when": {
                                     "must_not": {
-                                        "stringValue": "foo",
+                                        "stringValue": {
+                                            "kind": "String",
+                                            "value": "foo"
+                                        },
                                     },
                                 },
                             }],
@@ -786,10 +953,16 @@ fragment All_Users_insert on User {
 
                                 "when": {
                                     "must": {
-                                        "stringValue": "foo",
+                                        "stringValue": {
+                                            "kind": "String",
+                                            "value": "foo"
+                                        },
                                     },
                                     "must_not": {
-                                        "a": "foo",
+                                        "a": {
+                                            "kind": "String",
+                                            "value": "foo"
+                                        },
                                     },
                                 },
                             }],
@@ -2253,7 +2426,10 @@ export type A$artifact = typeof artifact
 
                                 "when": {
                                     "must": {
-                                        "stringValue": "foo",
+                                        "stringValue": {
+                                            "kind": "String",
+                                            "value": "foo"
+                                        },
                                     },
                                 },
                             }],
@@ -2365,7 +2541,10 @@ export type A$artifact = typeof artifact
 
                                 "when": {
                                     "must_not": {
-                                        "stringValue": "foo",
+                                        "stringValue": {
+                                            "kind": "String",
+                                            "value": "foo"
+                                        },
                                     },
                                 },
                             }],

--- a/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
@@ -520,7 +520,6 @@ mutation B {
                                     "firstName": {
                                         "type": "String",
                                         "keyRaw": "firstName",
-                                        "visible": true,
                                     },
 
                                     "id": {

--- a/packages/houdini-core/plugin/documents/artifacts/selection_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_test.go
@@ -1333,7 +1333,7 @@ export type Friends$artifact = typeof artifact
 					"TestQuery": tests.Dedent(`const artifact = {
     "name": "TestQuery",
     "kind": "HoudiniQuery",
-    "hash": "dc502dd533f31553a3c311a7aaa782d82f81d7f7a8816d5095f96584a7600004",
+    "hash": "cf9a1b37522817318bc0893e797a289dc9ff66bee13544171839bd1b685ad514",
 
     "refetch": {
         "path": ["users"],
@@ -1408,7 +1408,7 @@ export type Friends$artifact = typeof artifact
                     "filter": {
                         "kind": "Object",
                         "value": {
-                            name: {
+                            "name": {
                                 "kind": "Variable",
                                 "value": "value"
                             }
@@ -1469,7 +1469,7 @@ export type TestQuery$input = {
 
 export type TestQuery$artifact = typeof artifact
 
-"HoudiniHash=dc502dd533f31553a3c311a7aaa782d82f81d7f7a8816d5095f96584a7600004"`),
+"HoudiniHash=cf9a1b37522817318bc0893e797a289dc9ff66bee13544171839bd1b685ad514"`),
 				},
 			},
 			{

--- a/packages/houdini-core/plugin/documents/artifacts/selection_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_test.go
@@ -1323,6 +1323,7 @@ export type Friends$artifact = typeof artifact
               boolValue: true,
               floatValue: 1.2,
               intValue: 1,
+              filter: { name: $value }
             ) @list(name: "All_Users") {
               firstName
             }
@@ -1346,7 +1347,7 @@ export type Friends$artifact = typeof artifact
     },
 
     "raw": ` + "`" + `query TestQuery($value: String!) {
-    users(boolValue: true, floatValue: 1.2, intValue: 1, stringValue: $value) {
+    users(boolValue: true, filter: {name: $value}, floatValue: 1.2, intValue: 1, stringValue: $value) {
         firstName
         __typename
         id
@@ -1361,7 +1362,7 @@ export type Friends$artifact = typeof artifact
         "fields": {
             "users": {
                 "type": "User",
-                "keyRaw": "users(boolValue: true, floatValue: 1.2, intValue: 1, stringValue: $value)",
+                "keyRaw": "users(boolValue: true, filter: {name: $value}, floatValue: 1.2, intValue: 1, stringValue: $value)",
 
                 "directives": [{
                     "name": "list",
@@ -1403,6 +1404,15 @@ export type Friends$artifact = typeof artifact
                     "boolValue": {
                         "kind": "Boolean",
                         "value": true
+                    },
+                    "filter": {
+                        "kind": "Object",
+                        "value": {
+                            name: {
+                                "kind": "Variable",
+                                "value": "value"
+                            }
+                        }
                     },
                     "floatValue": {
                         "kind": "Float",

--- a/packages/houdini-core/plugin/documents/assignability.go
+++ b/packages/houdini-core/plugin/documents/assignability.go
@@ -42,6 +42,12 @@ func validArgumentValue(value argumentValueCheck) bool {
 		return true
 	}
 
+	// @when/@when_not arguments match against list filters, not schema types —
+	// there is nothing to validate them against
+	if value.ExpectedType == whenPassthroughType {
+		return true
+	}
+
 	switch value.Kind {
 	case "Variable":
 		// undefined variables are reported by ValidateUndefinedVariables

--- a/packages/houdini-core/plugin/documents/loadDocuments.go
+++ b/packages/houdini-core/plugin/documents/loadDocuments.go
@@ -20,6 +20,13 @@ import (
 	"code.houdinigraphql.com/plugins/graphql"
 )
 
+// whenPassthroughType marks the expected_type of @when/@when_not arguments.
+// those directives accept whatever filters the target @list field defines, so
+// there is no schema type to validate their values against. the double
+// underscore prefix is reserved by graphql for introspection, which guarantees
+// the sentinel can never collide with a user-defined type
+const whenPassthroughType = "__HOUDINI__PASSTHROUGH__"
+
 func LoadDocuments(
 	ctx context.Context,
 	db plugins.DatabasePool[config.PluginConfig],
@@ -1301,7 +1308,7 @@ func processDirectives[PluginConfig any](
 				} else if directive.Name == graphql.WhenDirective ||
 					directive.Name == graphql.WhenNotDirective {
 					dArgType = TypeWithModifiers{
-						Type: "__HOUDINI__PASSTHROUGH__",
+						Type: whenPassthroughType,
 					}
 				} else {
 					return &plugins.Error{

--- a/packages/houdini-core/runtime/plugins/query.test.ts
+++ b/packages/houdini-core/runtime/plugins/query.test.ts
@@ -1,4 +1,5 @@
 import { Cache } from 'houdini/runtime/cache'
+import { CachePolicy } from 'houdini/runtime/types'
 import { beforeEach, expect, test, vi } from 'vitest'
 
 import { testConfigFile } from '../../test'
@@ -9,6 +10,69 @@ import { createStore, fakeFetch } from './test.js'
 const config = testConfigFile()
 beforeEach(async () => {
 	setMockConfig(config)
+})
+
+test('refetch triggered by cache.refresh uses the most recent session, not the subscription-time session', async () => {
+	const cache = new Cache()
+
+	// write a record so the subscription has something to attach to
+	const selection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						id: { type: 'ID', visible: true, keyRaw: 'id' },
+						firstName: { type: 'String', visible: true, keyRaw: 'firstName' },
+					},
+				},
+			},
+		},
+	}
+
+	cache._internal_unstable.write({
+		selection,
+		data: { viewer: { id: '1', firstName: 'bob' } },
+	})
+
+	// spy to capture every network request and the session it carries
+	const fetchSpy = vi.fn()
+
+	const store = createStore({
+		artifact: {
+			kind: 'HoudiniQuery',
+			hash: '7777',
+			raw: 'RAW_TEXT',
+			name: 'TestArtifact',
+			rootType: 'Query',
+			pluginData: {},
+			stripVariables: [],
+			selection,
+		},
+		pipeline: [query(cache), fakeFetch({ spy: fetchSpy })],
+	})
+
+	// first send — establishes the cache subscription with session 'old'
+	await store.send({ session: { token: 'old' }, variables: {} })
+
+	// second send with the same variables but a new session — no new subscription is created
+	// but lastSession in the closure must be updated to 'new'
+	await store.send({ session: { token: 'new' }, variables: {} })
+
+	// reset the spy so we only see the refetch request
+	fetchSpy.mockClear()
+
+	// trigger a refetch via the cache
+	cache._internal_unstable.refresh('User:1')
+
+	// give the async send a tick to run
+	await new Promise((r) => setTimeout(r, 0))
+
+	// the refetch must carry the new session, not the stale one from subscription time
+	expect(fetchSpy).toHaveBeenCalledOnce()
+	expect(fetchSpy.mock.calls[0][0].session).toEqual({ token: 'new' })
 })
 
 test('query plugin evaluates runtime scalars', async () => {

--- a/packages/houdini-core/runtime/plugins/query.ts
+++ b/packages/houdini-core/runtime/plugins/query.ts
@@ -12,6 +12,11 @@ export const query = (cache: Cache) =>
 		// remember the last variables we were called with
 		let lastVariables: Record<string, any> | null = null
 
+		// track the most recent session so that refetch requests triggered by
+		// record.refresh() use the current auth token, not the one from when the
+		// subscription was first created
+		let lastSession: App.Session | null | undefined = null
+
 		// the function to call when a query is sent
 		return {
 			start(ctx, { next }) {
@@ -46,6 +51,10 @@ export const query = (cache: Cache) =>
 			// patch subscriptions on the way out so that we don't get a cache update
 			// before the promise resolves
 			end(ctx, { resolve, marshalVariables, variablesChanged }) {
+				// always keep the session current so that a later record.refresh() call
+				// uses the auth token from the most recent send(), not from subscription time
+				lastSession = ctx.session
+
 				// if the variables have changed we need to setup a new subscription with the cache
 				if (variablesChanged(ctx) && !ctx.cacheParams?.disableSubscriptions) {
 					// if the variables changed we need to unsubscribe from the old fields and
@@ -69,7 +78,7 @@ export const query = (cache: Cache) =>
 							if (message.kind === 'refetch') {
 								ctx.documentStore.send({
 									policy: CachePolicy.NetworkOnly,
-									session: ctx.session,
+									session: lastSession,
 									metadata: ctx.metadata,
 								})
 								return

--- a/packages/houdini/src/runtime/cache/index.ts
+++ b/packages/houdini/src/runtime/cache/index.ts
@@ -1018,7 +1018,9 @@ class CacheInternal {
 									operation.target === 'all',
 									processedOperations
 								)
-						removeList.when(resolveWhen(operation.when, variables)).remove(target, variables, layer)
+						removeList
+							.when(resolveWhen(operation.when, variables))
+							.remove(target, variables, layer)
 					}
 
 					// delete the target

--- a/packages/houdini/src/runtime/cache/index.ts
+++ b/packages/houdini/src/runtime/cache/index.ts
@@ -210,13 +210,13 @@ export class Cache {
 
 		// a document can be subscribed to multiple fields of the record so make
 		// sure we only send the message once per set
-		const notified: SubscriptionSpec['onMessage'][] = []
+		const notified = new Set<SubscriptionSpec['onMessage']>()
 		for (const recordID of recordIDs) {
 			for (const [spec] of this._internal_unstable.subscriptions.getAll(recordID, {
 				includeMaskedParents: true,
 			})) {
-				if (!notified.includes(spec.onMessage)) {
-					notified.push(spec.onMessage)
+				if (!notified.has(spec.onMessage)) {
+					notified.add(spec.onMessage)
 					spec.onMessage({ kind: 'refetch' })
 				}
 			}
@@ -377,11 +377,11 @@ export class Cache {
 		this._internal_unstable.epoch++
 		// the same spec will likely need to be updated multiple times, create the unique list by using the set
 		// function's identity
-		const notified: SubscriptionSpec['onMessage'][] = []
+		const notified = new Set<SubscriptionSpec['onMessage']>()
 		for (const spec of subs) {
 			// if we haven't added the set yet
-			if (!notified.includes(spec.onMessage)) {
-				notified.push(spec.onMessage)
+			if (!notified.has(spec.onMessage)) {
+				notified.add(spec.onMessage)
 				// trigger the update
 				spec.onMessage({
 					kind: 'update',

--- a/packages/houdini/src/runtime/cache/index.ts
+++ b/packages/houdini/src/runtime/cache/index.ts
@@ -9,6 +9,9 @@ import { PendingValue } from '../types.js'
 import type {
 	GraphQLObject,
 	GraphQLValue,
+	ListFilter,
+	ListWhen,
+	MutationOperation,
 	NestedList,
 	SubscriptionSelection,
 	SubscriptionSpec,
@@ -23,7 +26,7 @@ import { StaleManager } from './staleManager.js'
 import type { Layer, LayerID } from './storage.js'
 import { InMemoryStorage } from './storage.js'
 import { evaluateKey, rootID } from './stuff.js'
-import { InMemorySubscriptions, type FieldSelection } from './subscription.js'
+import { filterValue, InMemorySubscriptions, type FieldSelection } from './subscription.js'
 
 export class Cache {
 	// the internal implementation for a lot of the cache's methods are moved into
@@ -966,7 +969,7 @@ class CacheInternal {
 									processedOperations
 								)
 						insertList
-							.when(operation.when)
+							.when(resolveWhen(operation.when, variables))
 							.addToList(
 								fieldSelection,
 								target,
@@ -991,7 +994,7 @@ class CacheInternal {
 									operation.target === 'all',
 									processedOperations
 								)
-						toggleList.when(operation.when).toggleElement({
+						toggleList.when(resolveWhen(operation.when, variables)).toggleElement({
 							selection: fieldSelection,
 							data: target,
 							variables,
@@ -1015,7 +1018,7 @@ class CacheInternal {
 									operation.target === 'all',
 									processedOperations
 								)
-						removeList.when(operation.when).remove(target, variables, layer)
+						removeList.when(resolveWhen(operation.when, variables)).remove(target, variables, layer)
 					}
 
 					// delete the target
@@ -1689,6 +1692,27 @@ export function variableValue(value: ValueNode, args: GraphQLObject): GraphQLVal
 			}),
 			{}
 		)
+	}
+}
+
+// resolve the variable references inside of an operation's when conditions
+// so they can be compared against the list's filters
+function resolveWhen(
+	when: MutationOperation['when'],
+	variables: Record<string, GraphQLValue>
+): ListWhen | undefined {
+	if (!when) {
+		return undefined
+	}
+
+	const resolve = (conditions: Record<string, ListFilter>) =>
+		Object.fromEntries(
+			Object.entries(conditions).map(([key, value]) => [key, filterValue(value, variables)])
+		)
+
+	return {
+		...(when.must ? { must: resolve(when.must) } : {}),
+		...(when.must_not ? { must_not: resolve(when.must_not) } : {}),
 	}
 }
 

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -1,6 +1,12 @@
 import { deepEquals } from '../deepEquals.js'
 import { flatten } from '../flatten.js'
-import type { Filter, SubscriptionSelection, ListWhen, SubscriptionSpec, NestedList } from '../types.js'
+import type {
+	Filter,
+	SubscriptionSelection,
+	ListWhen,
+	SubscriptionSpec,
+	NestedList,
+} from '../types.js'
 import type { Cache } from './index.js'
 import type { Layer } from './storage.js'
 import { rootID } from './stuff.js'

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -1,5 +1,6 @@
+import { deepEquals } from '../deepEquals.js'
 import { flatten } from '../flatten.js'
-import type { SubscriptionSelection, ListWhen, SubscriptionSpec, NestedList } from '../types.js'
+import type { Filter, SubscriptionSelection, ListWhen, SubscriptionSpec, NestedList } from '../types.js'
 import type { Cache } from './index.js'
 import type { Layer } from './storage.js'
 import { rootID } from './stuff.js'
@@ -204,7 +205,7 @@ export class List {
 	private cache: Cache
 	readonly selection: SubscriptionSelection
 	private _when?: ListWhen
-	private filters?: { [key: string]: number | boolean | string }
+	private filters?: Filter
 	readonly name: string
 	private connection: boolean
 	private manager: ListManager
@@ -527,7 +528,7 @@ export class List {
 			// check must's first
 			if (filters.must && targets) {
 				ok = Object.entries(filters.must).reduce<boolean>(
-					(prev, [key, value]) => Boolean(prev && targets[key] === value),
+					(prev, [key, value]) => Boolean(prev && deepEquals(targets[key], value)),
 					ok
 				)
 			}
@@ -536,7 +537,7 @@ export class List {
 				ok =
 					!targets ||
 					Object.entries(filters.must_not).reduce<boolean>(
-						(prev, [key, value]) => Boolean(prev && targets[key] !== value),
+						(prev, [key, value]) => Boolean(prev && !deepEquals(targets[key], value)),
 						ok
 					)
 			}

--- a/packages/houdini/src/runtime/cache/subscription.ts
+++ b/packages/houdini/src/runtime/cache/subscription.ts
@@ -604,10 +604,7 @@ export function filterValue(filter: ListFilter, variables: Record<string, any>):
 	}
 	if (filter.kind === 'Object') {
 		return Object.fromEntries(
-			Object.entries(filter.value).map(([key, value]) => [
-				key,
-				filterValue(value, variables),
-			])
+			Object.entries(filter.value).map(([key, value]) => [key, filterValue(value, variables)])
 		)
 	}
 	if (filter.kind === 'List') {

--- a/packages/houdini/src/runtime/cache/subscription.ts
+++ b/packages/houdini/src/runtime/cache/subscription.ts
@@ -1,6 +1,12 @@
 import { flatten } from '../flatten.js'
 import { getFieldsForType } from '../selection.js'
-import type { GraphQLValue, SubscriptionSelection, SubscriptionSpec, NestedList } from '../types.js'
+import type {
+	GraphQLValue,
+	ListFilter,
+	SubscriptionSelection,
+	SubscriptionSpec,
+	NestedList,
+} from '../types.js'
 import type { Cache } from './index.js'
 import { evaluateKey, rootID } from './stuff.js'
 
@@ -230,10 +236,10 @@ export class InMemorySubscriptions {
 			listType: list.type,
 			key,
 			selection: selection,
-			filters: Object.entries(filters || {}).reduce((acc, [key, { kind, value }]) => {
+			filters: Object.entries(filters || {}).reduce((acc, [key, filter]) => {
 				return {
 					...acc,
-					[key]: kind !== 'Variable' ? value : variables[value as string],
+					[key]: filterValue(filter, variables),
 				}
 			}, {}),
 		})
@@ -588,4 +594,24 @@ export class InMemorySubscriptions {
 
 		return selections
 	}
+}
+
+// resolve a list filter to its concrete value, looking up variables
+// (including ones nested inside object and list values)
+export function filterValue(filter: ListFilter, variables: Record<string, any>): any {
+	if (filter.kind === 'Variable') {
+		return variables[filter.value as string]
+	}
+	if (filter.kind === 'Object') {
+		return Object.fromEntries(
+			Object.entries(filter.value).map(([key, value]) => [
+				key,
+				filterValue(value, variables),
+			])
+		)
+	}
+	if (filter.kind === 'List') {
+		return filter.value.map((value) => filterValue(value, variables))
+	}
+	return filter.value
 }

--- a/packages/houdini/src/runtime/cache/subscription.ts
+++ b/packages/houdini/src/runtime/cache/subscription.ts
@@ -198,7 +198,7 @@ export class InMemorySubscriptions {
 		// add this version of the key if we need to
 		this.keyVersions[key].add(key)
 
-		if (!selections.some(([{ onMessage }]) => onMessage === spec.onMessage)) {
+		if (!referenceCounts.has(spec.onMessage)) {
 			selections.push([spec, selection[1]])
 		}
 
@@ -418,9 +418,12 @@ export class InMemorySubscriptions {
 			this.subscribers.delete(id)
 		}
 
-		// Get list of all SubscriptionSpecs of subscribers
+		// Get list of all SubscriptionSpecs of subscribers (including masked parents so
+		// that documents holding records only behind fragment boundaries are also notified)
 		const subscriptionSpecs = subscribers.flatMap(([_id, fields]) =>
-			[...fields.values()].flatMap((field) => field.selections.map(([spec]) => spec))
+			[...fields.values()].flatMap((field) =>
+				field.selections.concat(field.maskedParentSelections).map(([spec]) => spec)
+			)
 		)
 
 		return subscriptionSpecs

--- a/packages/houdini/src/runtime/cache/tests/list.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/list.test.ts
@@ -2579,7 +2579,9 @@ test('list filter - object value with nested variable', () => {
 	cache.subscribe(
 		{
 			rootType: 'Query',
-			set,
+			onMessage: (msg) => {
+				if (msg.kind === 'update') set(msg.data)
+			},
 			selection,
 		},
 		{ value: 'bar' }
@@ -3566,7 +3568,7 @@ test('when operation with variable condition', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)

--- a/packages/houdini/src/runtime/cache/tests/list.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/list.test.ts
@@ -2497,6 +2497,135 @@ test('list filter - must negative', () => {
 	expect(set).not.toHaveBeenCalled()
 })
 
+test('list filter - object value with nested variable', () => {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						id: {
+							type: 'ID',
+							visible: true,
+							keyRaw: 'id',
+						},
+						friends: {
+							type: 'User',
+							visible: true,
+							keyRaw: 'friends',
+							list: {
+								name: 'All_Users',
+								connection: false,
+								type: 'User',
+							},
+							filters: {
+								filter: {
+									kind: 'Object',
+									value: {
+										name: {
+											kind: 'Variable',
+											value: 'value',
+										},
+									},
+								},
+							},
+							selection: {
+								fields: {
+									id: {
+										type: 'ID',
+										visible: true,
+										keyRaw: 'id',
+									},
+									firstName: {
+										type: 'String',
+										visible: true,
+										keyRaw: 'firstName',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// start off associated with one object
+	cache.write({
+		selection,
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{
+						id: '2',
+						firstName: 'jane',
+					},
+				],
+			},
+		},
+		variables: { value: 'bar' },
+	})
+
+	// a function to spy on that will play the role of set
+	const set = vi.fn()
+
+	// subscribe to the fields
+	cache.subscribe(
+		{
+			rootType: 'Query',
+			set,
+			selection,
+		},
+		{ value: 'bar' }
+	)
+
+	const insert = (id: string, name: string) =>
+		cache
+			.list('All_Users')
+			.when({ must: { filter: { name } } })
+			.prepend({
+				selection: {
+					fields: {
+						id: { visible: true, type: 'ID', keyRaw: 'id' },
+						firstName: { visible: true, type: 'String', keyRaw: 'firstName' },
+					},
+				},
+				data: {
+					id,
+					firstName: 'mary',
+				},
+			})
+
+	// a when condition that matches the resolved object filter applies
+	insert('3', 'bar')
+	expect(set).toHaveBeenCalledWith({
+		viewer: {
+			id: '1',
+			friends: [
+				{
+					firstName: 'mary',
+					id: '3',
+				},
+				{
+					firstName: 'jane',
+					id: '2',
+				},
+			],
+		},
+	})
+
+	// one that doesn't match is skipped
+	set.mockClear()
+	insert('4', 'not-bar')
+	expect(set).not.toHaveBeenCalled()
+})
+
 test('remove from list', () => {
 	// instantiate a cache
 	const cache = new Cache(config)
@@ -3341,7 +3470,10 @@ test('append when operation', () => {
 							list: 'All_Users',
 							when: {
 								must: {
-									value: 'not-foo',
+									value: {
+										kind: 'String',
+										value: 'not-foo',
+									},
 								},
 							},
 						},
@@ -3367,6 +3499,127 @@ test('append when operation', () => {
 
 	// make sure we just added to the list
 	expect([...cache.list('All_Users', '1')]).toHaveLength(0)
+})
+
+test('when operation with variable condition', () => {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	// create a list we will add to
+	cache.write({
+		selection: {
+			fields: {
+				viewer: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'viewer',
+					selection: {
+						fields: {
+							id: {
+								type: 'ID',
+								visible: true,
+								keyRaw: 'id',
+							},
+						},
+					},
+				},
+			},
+		},
+		data: {
+			viewer: {
+				id: '1',
+			},
+		},
+	})
+
+	// subscribe to the data to register the list
+	cache.subscribe(
+		{
+			rootType: 'User',
+			selection: {
+				fields: {
+					friends: {
+						type: 'User',
+						visible: true,
+						keyRaw: 'friends',
+						list: {
+							name: 'All_Users',
+							connection: false,
+							type: 'User',
+						},
+						filters: {
+							value: {
+								kind: 'String',
+								value: 'foo',
+							},
+						},
+						selection: {
+							fields: {
+								id: {
+									type: 'ID',
+									visible: true,
+									keyRaw: 'id',
+								},
+							},
+						},
+					},
+				},
+			},
+			parentID: cache._internal_unstable.id('User', '1')!,
+			set: vi.fn(),
+		},
+		{}
+	)
+
+	// the selection for a mutation whose when condition points to a variable
+	const mutationSelection: SubscriptionSelection = {
+		fields: {
+			newUser: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'newUser',
+				operations: [
+					{
+						action: 'insert',
+						list: 'All_Users',
+						when: {
+							must: {
+								value: {
+									kind: 'Variable',
+									value: 'target',
+								},
+							},
+						},
+					},
+				],
+				selection: {
+					fields: {
+						id: {
+							type: 'ID',
+							visible: true,
+							keyRaw: 'id',
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// a write whose variable doesn't match the list's filters gets skipped
+	cache.write({
+		selection: mutationSelection,
+		data: { newUser: { id: '3' } },
+		variables: { target: 'not-foo' },
+	})
+	expect([...cache.list('All_Users', '1')]).toHaveLength(0)
+
+	// one whose variable matches the filter applies
+	cache.write({
+		selection: mutationSelection,
+		data: { newUser: { id: '3' } },
+		variables: { target: 'foo' },
+	})
+	expect([...cache.list('All_Users', '1')]).toEqual(['User:3'])
 })
 
 test('prepend when operation', () => {
@@ -3460,7 +3713,10 @@ test('prepend when operation', () => {
 							position: 'first',
 							when: {
 								must: {
-									value: 'not-foo',
+									value: {
+										kind: 'String',
+										value: 'not-foo',
+									},
 								},
 							},
 						},

--- a/packages/houdini/src/runtime/cache/tests/refresh.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/refresh.test.ts
@@ -408,3 +408,58 @@ test('refresh on an unknown record is a no-op', () => {
 	// nothing to assert beyond it not throwing
 	cache.refresh('User:999')
 })
+
+test('refresh notifies a document exactly once even when subscribed to many fields', () => {
+	// regression for the O(n²) dedup: the handler must fire once regardless of how
+	// many fields of the record the document is subscribed to
+	const cache = new Cache(config)
+
+	const wideSelection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						id: { type: 'ID', visible: true, keyRaw: 'id' },
+						firstName: { type: 'String', visible: true, keyRaw: 'firstName' },
+						lastName: { type: 'String', visible: true, keyRaw: 'lastName' },
+						email: { type: 'String', visible: true, keyRaw: 'email' },
+					},
+				},
+			},
+		},
+	}
+
+	cache.write({
+		selection: wideSelection,
+		data: { viewer: { id: '1', firstName: 'bob', lastName: 'smith', email: 'b@b.com' } },
+	})
+
+	const onMessage = vi.fn()
+	cache.subscribe({ rootType: 'Query', selection: wideSelection, onMessage })
+
+	cache.refresh('User:1')
+
+	// subscribed to 4 fields on the record — must still only get one message
+	expect(onMessage).toHaveBeenCalledTimes(1)
+	expect(onMessage).toHaveBeenCalledWith({ kind: 'refetch' })
+})
+
+test('refresh after unsubscribe does not notify removed handler', () => {
+	const cache = new Cache(config)
+
+	cache.write({
+		selection: visibleSelection,
+		data: { viewer: { id: '1', firstName: 'bob' } },
+	})
+
+	const onMessage = vi.fn()
+	const spec = { rootType: 'Query', selection: visibleSelection, onMessage }
+	cache.subscribe(spec)
+	cache.unsubscribe(spec)
+
+	cache.refresh('User:1')
+	expect(onMessage).not.toHaveBeenCalled()
+})

--- a/packages/houdini/src/runtime/cache/tests/reset.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/reset.test.ts
@@ -135,6 +135,52 @@ test('make sure the cache lists were reset', () => {
 	expect(() => cache.list('All_Users')).toThrowError('Cannot find list with name')
 })
 
+test('cache.reset notifies documents holding records only behind masked boundaries', () => {
+	const cache = new Cache(config)
+
+	// viewer is visible but everything on the user is masked (simulates a fragment spread)
+	const maskedSelection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						id: {
+							type: 'ID',
+							keyRaw: 'id',
+						},
+						firstName: {
+							type: 'String',
+							keyRaw: 'firstName',
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cache.write({
+		selection: maskedSelection,
+		data: { viewer: { id: '1', firstName: 'bob' } },
+	})
+
+	const onMessage = vi.fn()
+	cache.subscribe({ rootType: 'Query', selection: maskedSelection, onMessage })
+
+	// a masked-field write must NOT notify the subscriber
+	cache.write({
+		selection: maskedSelection,
+		data: { viewer: { id: '1', firstName: 'alice' } },
+	})
+	expect(onMessage).not.toHaveBeenCalled()
+
+	// reset MUST notify the subscriber even though its fields are masked
+	cache.reset()
+	expect(onMessage).toHaveBeenCalledTimes(1)
+})
+
 test('make sure the cache subscribers were reset', () => {
 	const cache = new Cache(config)
 

--- a/packages/houdini/src/runtime/types.ts
+++ b/packages/houdini/src/runtime/types.ts
@@ -142,7 +142,15 @@ export type FetchContext = {
 	session: App.Session | null
 }
 
-type Filter = { [key: string]: string | boolean | number }
+export type FilterValue =
+	| string
+	| boolean
+	| number
+	| null
+	| readonly FilterValue[]
+	| { [key: string]: FilterValue }
+
+export type Filter = { [key: string]: FilterValue }
 
 export type ListWhen = {
 	must?: Filter
@@ -180,7 +188,12 @@ export type MutationOperation = {
 	}
 	position?: 'first' | 'last'
 	target?: 'all'
-	when?: ListWhen
+	// when conditions are encoded as filter nodes so that variable references
+	// can be resolved when the operation is applied
+	when?: {
+		must?: Record<string, ListFilter>
+		must_not?: Record<string, ListFilter>
+	}
 }
 
 export type GraphQLObject = { [key: string]: GraphQLValue }
@@ -208,6 +221,14 @@ export type LoadingSpec =
 	| { kind: 'continue'; list?: { depth: number; count: number } }
 	| { kind: 'value'; value?: any; list?: { depth: number; count: number } }
 
+export type ListFilter =
+	| {
+			kind: 'Boolean' | 'String' | 'Float' | 'Int' | 'Enum' | 'Variable'
+			value: string | number | boolean
+	  }
+	| { kind: 'Object'; value: Record<string, ListFilter> }
+	| { kind: 'List'; value: readonly ListFilter[] }
+
 export type SubscriptionSelection = Readonly<{
 	loadingTypes?: string[]
 	fragments?: Record<string, { arguments: ValueMap; loading?: boolean }>
@@ -230,13 +251,7 @@ export type SubscriptionSelection = Readonly<{
 			directives?: readonly { name: string; arguments: ValueMap }[]
 			updates?: readonly string[]
 			visible?: boolean
-			filters?: Record<
-				string,
-				{
-					kind: 'Boolean' | 'String' | 'Float' | 'Int' | 'Variable'
-					value: string | number | boolean
-				}
-			>
+			filters?: Record<string, ListFilter>
 			selection?: SubscriptionSelection
 			abstract?: boolean
 			// If set, this is an abstract type with at least one abstract field made non-nullable by


### PR DESCRIPTION
List filters and @when conditions were broken when arguments contained object values or variable references nested inside objects. The compiler was emitting these as raw GraphQL text (not valid JavaScript), and the runtime wasn't recursively resolving variable references nested inside object arguments.
