### PR TITLE
Expose full GraphQL error shape with typed extensions

### DIFF
--- a/.changeset/lemon-files-follow.md
+++ b/.changeset/lemon-files-follow.md
@@ -1,0 +1,5 @@
+---
+"houdini-core": patch
+---
+
+Add support for @includeListID directive

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -242,6 +242,9 @@ jobs:
         runs-on: ubuntu-latest
         needs: [format]
         if: always()
+        strategy:
+            matrix:
+                framework: [e2e-kit, e2e-react]
         steps:
             - uses: actions/checkout@v3
               with:
@@ -265,7 +268,6 @@ jobs:
             - run: pnpm install --frozen-lockfile --prefer-offline
             - run: pnpm run build
             - run: find ./packages -path "*/bin/houdini-*" -type f | xargs chmod +x 2>/dev/null || true
-            - run: pnpm --filter e2e-kit run build
-            - run: pnpm --filter e2e-kit run lint
-            - run: pnpm --filter e2e-kit run check
-            - run: pnpm --filter e2e-react run lint
+            - run: pnpm --filter ${{ matrix.framework }} run build
+            - run: pnpm --filter ${{ matrix.framework }} run lint
+            - run: pnpm --filter ${{ matrix.framework }} run check

--- a/docs/shared/_partials/list-operations.mdx
+++ b/docs/shared/_partials/list-operations.mdx
@@ -36,7 +36,7 @@ The `value` argument must be the ID of the parent record that owns the list. Wit
 
 `@parentID` requires knowing the parent record's ID at mutation time, but that isn't always possible — the parent type may not expose an ID field, or the ID may not appear anywhere in the query document. `@includeListID` and `@listID` solve this by letting the cache identify the list for you.
 
-Add `@includeListID` to the list field alongside `@list` or `@paginate`. The cache will stamp an opaque `__listID` value directly onto the returned list, and the generated TypeScript type will include `__listID: string` so you can read it without any casting:
+Add `@includeListID` to the list field alongside `@list` or `@paginate`. The cache will stamp an opaque `__id` value directly onto the returned list, and the generated TypeScript type will include `__id: string` so you can read it without any casting:
 
 ```graphql
 query AllItems {
@@ -50,7 +50,7 @@ query AllItems {
 
 ```tsx
 const items = data?.userNodes.items
-const listId = items?.__listID  // string | undefined — typed by codegen
+const listId = items?.__id  // string | undefined — typed by codegen
 ```
 
 Then pass that value to `@listID` on the mutation fragment spread instead of `@parentID`:

--- a/docs/shared/_partials/list-operations.mdx
+++ b/docs/shared/_partials/list-operations.mdx
@@ -32,6 +32,41 @@ mutation AddFriend($friendID: ID!, $userID: ID!) {
 
 The `value` argument must be the ID of the parent record that owns the list. Without it, Houdini will update every instance of that list in the cache.
 
+## `@listID` and `@includeListID`
+
+`@parentID` requires knowing the parent record's ID at mutation time, but that isn't always possible — the parent type may not expose an ID field, or the ID may not appear anywhere in the query document. `@includeListID` and `@listID` solve this by letting the cache identify the list for you.
+
+Add `@includeListID` to the list field alongside `@list` or `@paginate`. The cache will stamp an opaque `__listID` value directly onto the returned list, and the generated TypeScript type will include `__listID: string` so you can read it without any casting:
+
+```graphql
+query AllItems {
+    userNodes {
+        items @list(name: "All_Items") @includeListID {
+            id
+        }
+    }
+}
+```
+
+```tsx
+const items = data?.userNodes.items
+const listId = items?.__listID  // string | undefined — typed by codegen
+```
+
+Then pass that value to `@listID` on the mutation fragment spread instead of `@parentID`:
+
+```graphql
+mutation NewItem($input: AddItemInput!, $listId: ID!) {
+    addItem(input: $input) {
+        item {
+            ...All_Items_insert @listID(value: $listId)
+        }
+    }
+}
+```
+
+Unlike `@parentID`, `@listID` works even when the parent has no usable ID in the document — the opaque key encodes everything the cache needs to find the right list instance.
+
 ## Operations
 
 Once a list is tagged, Houdini generates a set of fragments named after the list — `All_Items_insert`, `All_Items_remove`, `All_Items_toggle` — that you spread into mutation responses to tell the cache what to do. The cache updates immediately on the client without waiting for a refetch.

--- a/e2e/react/eslint.config.js
+++ b/e2e/react/eslint.config.js
@@ -3,6 +3,9 @@ import tsParser from '@typescript-eslint/parser'
 
 export default [
 	{
+		ignores: ['.houdini/**', 'build/**', 'node_modules/**'],
+	},
+	{
 		files: ['src/**/*.{ts,tsx}'],
 		plugins: { '@typescript-eslint': tsPlugin },
 		languageOptions: {

--- a/e2e/react/package.json
+++ b/e2e/react/package.json
@@ -29,7 +29,8 @@
 		"tw": "npx tailwindcss -i ./src/styles.css -o ./public/assets/output.css --watch",
 		"preview": "vite dev",
 		"preinstall": "node preInstall.js",
-		"lint": "eslint ."
+		"lint": "eslint .",
+		"check": "tsc --noEmit"
 	},
 	"dependencies": {
 		"@cloudflare/workers-types": "^4.20260605.1",

--- a/e2e/react/src/routes/list-id/+page.gql
+++ b/e2e/react/src/routes/list-id/+page.gql
@@ -1,0 +1,8 @@
+query ListIDTest {
+	userNodes(snapshot: "ListIDTest") {
+		nodes @list(name: "ListID_Users") @includeListID {
+			id
+			name
+		}
+	}
+}

--- a/e2e/react/src/routes/list-id/+page.tsx
+++ b/e2e/react/src/routes/list-id/+page.tsx
@@ -3,7 +3,7 @@ import { PageProps } from './$types'
 
 export default function ListIDTestView({ ListIDTest }: PageProps) {
 	const nodes = ListIDTest?.userNodes.nodes
-	const listId = nodes?.__listID
+	const listId = nodes?.__id
 
 	const [, addUser] = useMutation(
 		graphql(`

--- a/e2e/react/src/routes/list-id/+page.tsx
+++ b/e2e/react/src/routes/list-id/+page.tsx
@@ -1,11 +1,9 @@
 import { useMutation, graphql } from '$houdini'
-import React from 'react'
-
 import { PageProps } from './$types'
 
 export default function ListIDTestView({ ListIDTest }: PageProps) {
 	const nodes = ListIDTest?.userNodes.nodes
-	const listId = (nodes as any)?.__listID as string | undefined
+	const listId = nodes?.__listID
 
 	const [, addUser] = useMutation(
 		graphql(`

--- a/e2e/react/src/routes/list-id/+page.tsx
+++ b/e2e/react/src/routes/list-id/+page.tsx
@@ -5,7 +5,7 @@ export default function ListIDTestView({ ListIDTest }: PageProps) {
 	const nodes = ListIDTest?.userNodes.nodes
 	const listId = nodes?.__id
 
-	const [, addUser] = useMutation(
+	const [addUser] = useMutation(
 		graphql(`
 			mutation ListIDAddUser($name: String!, $birthDate: DateTime!, $listId: ID!) {
 				addUser(snapshot: "ListIDTest", name: $name, birthDate: $birthDate) {

--- a/e2e/react/src/routes/list-id/+page.tsx
+++ b/e2e/react/src/routes/list-id/+page.tsx
@@ -1,0 +1,46 @@
+import { useMutation, graphql } from '$houdini'
+import React from 'react'
+
+import { PageProps } from './$types'
+
+export default function ListIDTestView({ ListIDTest }: PageProps) {
+	const nodes = ListIDTest?.userNodes.nodes
+	const listId = (nodes as any)?.__listID as string | undefined
+
+	const [, addUser] = useMutation(
+		graphql(`
+			mutation ListIDAddUser($name: String!, $birthDate: DateTime!, $listId: ID!) {
+				addUser(snapshot: "ListIDTest", name: $name, birthDate: $birthDate) {
+					...ListID_Users_insert @listID(value: $listId)
+				}
+			}
+		`)
+	)
+
+	return (
+		<>
+			<ul>
+				{nodes?.map((user) => (
+					<li key={user.id} data-testid="user-row">
+						{user.name}
+					</li>
+				))}
+			</ul>
+			<button
+				data-test-action="add"
+				onClick={() => {
+					if (!listId) return
+					addUser({
+						variables: {
+							name: 'New User',
+							birthDate: new Date('2000-01-01'),
+							listId,
+						},
+					})
+				}}
+			>
+				Add User
+			</button>
+		</>
+	)
+}

--- a/e2e/react/src/routes/list-id/test.ts
+++ b/e2e/react/src/routes/list-id/test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test'
+import { routes } from '~/utils/routes'
+import { sleep } from '~/utils/sleep'
+import { goto } from '~/utils/testsHelper.js'
+
+test('@listID inserts into an embedded list with no natural parent ID', async ({ page }) => {
+	await goto(page, routes.list_id)
+
+	const rows = page.getByTestId('user-row')
+	const initialCount = await rows.count()
+	expect(initialCount).toBeGreaterThan(0)
+
+	await page.click('[data-test-action="add"]')
+	await sleep(300)
+
+	expect(await rows.count()).toBe(initialCount + 1)
+
+	// the new user should appear in the list
+	const lastRow = rows.last()
+	expect(await lastRow.textContent()).toContain('New User')
+})

--- a/e2e/react/src/routes/list-id/test.ts
+++ b/e2e/react/src/routes/list-id/test.ts
@@ -14,8 +14,12 @@ test('@listID inserts into an embedded list with no natural parent ID', async ({
 	await sleep(300)
 
 	expect(await rows.count()).toBe(initialCount + 1)
+	expect(await rows.last().textContent()).toContain('New User')
 
-	// the new user should appear in the list
-	const lastRow = rows.last()
-	expect(await lastRow.textContent()).toContain('New User')
+	// second insert: __id must survive the re-render caused by the first insert
+	await page.click('[data-test-action="add"]')
+	await sleep(300)
+
+	expect(await rows.count()).toBe(initialCount + 2)
+	expect(await rows.last().textContent()).toContain('New User')
 })

--- a/e2e/react/src/utils/routes.ts
+++ b/e2e/react/src/utils/routes.ts
@@ -18,4 +18,5 @@ export const routes = {
 	pagination_query_offset_variable: '/pagination/query/offset-variable/2',
 	optimistic_keys: '/optimistic-keys',
 	node_plugin: '/node-plugin',
+	list_id: '/list-id',
 } as const

--- a/e2e/react/tsconfig.json
+++ b/e2e/react/tsconfig.json
@@ -1,3 +1,6 @@
 {
-	"extends": "./.houdini/tsconfig.json"
+    "extends": "./.houdini/tsconfig.json",
+    "compilerOptions": {
+        "ignoreDeprecations": "6.0"
+    }
 }

--- a/packages/houdini-core/plugin/documents/artifacts/print.go
+++ b/packages/houdini-core/plugin/documents/artifacts/print.go
@@ -289,6 +289,11 @@ func printSelection(
 	var resultBuilder strings.Builder
 
 	for _, selection := range selections {
+		// __listID is a synthetic field resolved by the cache; never send it to the server
+		if selection.Kind == "field" && selection.FieldName == "__listID" {
+			continue
+		}
+
 		// before we print children and directives we need
 		// to handle the specific selection type
 		switch selection.Kind {

--- a/packages/houdini-core/plugin/documents/artifacts/print.go
+++ b/packages/houdini-core/plugin/documents/artifacts/print.go
@@ -289,8 +289,8 @@ func printSelection(
 	var resultBuilder strings.Builder
 
 	for _, selection := range selections {
-		// __listID is a synthetic field resolved by the cache; never send it to the server
-		if selection.Kind == "field" && selection.FieldName == "__listID" {
+		// __id is a synthetic field resolved by the cache; never send it to the server
+		if selection.Kind == "field" && selection.FieldName == "__id" {
 			continue
 		}
 

--- a/packages/houdini-core/plugin/documents/artifacts/selection.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection.go
@@ -1004,9 +1004,13 @@ func stringifyFieldSelection(
 	hasRequiredDirective := false
 	hasLoading := forceLoading
 	loadingCount := 3
+	includeListID := false
 
 	for _, directive := range selection.Directives {
 		switch directive.Name {
+		case graphql.IncludeListIDDirective:
+			includeListID = true
+			continue
 		case graphql.OptimisticKeyDirective:
 			optimisticKey = fmt.Sprintf(`
 %s"optimisticKey": true,`, indent4)
@@ -1208,12 +1212,17 @@ func stringifyFieldSelection(
 	list := ""
 	filters := ""
 	if selection.List != nil && selection.List.Name != "" {
+		includeListIDStr := ""
+		if includeListID {
+			includeListIDStr = fmt.Sprintf(`,
+%s"includeListID": true`, indent5)
+		}
 		// we need to record the list specification
 		list = fmt.Sprintf(`
 %s"list": {
 %s"name": "%s",
 %s"connection": %v,
-%s"type": "%s"
+%s"type": "%s"%s
 %s},`,
 			indent4,
 			indent5,
@@ -1222,6 +1231,7 @@ func stringifyFieldSelection(
 			selection.List.Connection,
 			indent5,
 			selection.List.Type,
+			includeListIDStr,
 			indent4,
 		)
 
@@ -1407,11 +1417,17 @@ func stringifyOperations(
 
 %s"parentID": %s`, indent5, operation.ParentID)
 		}
+		listID := ""
+		if operation.ListID != "" {
+			listID = fmt.Sprintf(`,
+
+%s"listID": %s`, indent5, operation.ListID)
+		}
 
 		fmt.Fprintf(&operationStringBuilder, `{
-%s"action": "%s"%s%s%s%s%s%s
+%s"action": "%s"%s%s%s%s%s%s%s
 %s},
-`, indent5, operation.Action, list, typ, position, target, when, parentID, indent4)
+`, indent5, operation.Action, list, typ, position, target, when, parentID, listID, indent4)
 
 	}
 	if operationStringBuilder.Len() > 0 {
@@ -1436,6 +1452,8 @@ func extractOperation(
 	when := ""
 	// along with a parentID specification
 	parentID := ""
+	// along with a listID specification (raw cache key, bypasses id(type,value) lookup)
+	listID := ""
 	for _, directive := range selection.Directives {
 		switch directive.Name {
 		// if we encounter a when directive
@@ -1475,6 +1493,9 @@ func extractOperation(
 			// parentID directive
 		case graphql.ParentIDDirective:
 			parentID = serializeFragmentArgument(directive.Arguments[0].Value, level-1)
+		// listID directive — raw cache key, bypasses the id(type, value) lookup
+		case graphql.ListIDDirective:
+			listID = serializeFragmentArgument(directive.Arguments[0].Value, level-1)
 		}
 	}
 
@@ -1492,6 +1513,7 @@ func extractOperation(
 					Action:   "delete",
 					When:     when,
 					ParentID: parentID,
+					ListID:   listID,
 				}
 			}
 		}
@@ -1552,6 +1574,7 @@ func extractOperation(
 			Target:   target,
 			When:     when,
 			ParentID: parentID,
+			ListID:   listID,
 		}
 	}
 
@@ -1566,6 +1589,7 @@ type CollectedOperation struct {
 	Type     string
 	When     string
 	ParentID string
+	ListID   string
 }
 
 func stripSuffix(s string, suffix string) string {

--- a/packages/houdini-core/plugin/documents/artifacts/selection_lists_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_lists_test.go
@@ -2015,7 +2015,7 @@ func TestIncludeListID(t *testing.T) {
 }
 
 // TestListIDMutation verifies that @listID on a fragment spread is serialized into the mutation
-// artifact's operations so the runtime can resolve the list via the opaque key from __listID.
+// artifact's operations so the runtime can resolve the list via the opaque key from __id.
 func TestListIDMutation(t *testing.T) {
 	tests.RunTable(t, tests.Table[config.PluginConfig, *plugin.HoudiniCore]{
 		Schema: `

--- a/packages/houdini-core/plugin/documents/artifacts/selection_lists_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_lists_test.go
@@ -1917,6 +1917,101 @@ export type TestQuery$artifact = typeof artifact
 	})
 }
 
+func TestIncludeListID(t *testing.T) {
+	tests.RunTable(t, tests.Table[config.PluginConfig, *plugin.HoudiniCore]{
+		Schema: `
+      type Query {
+        users: [User!]!
+        usersByCursor(first: Int, last: Int, after: String, before: String): UserConnection!
+      }
+
+      type User implements Node {
+        id: ID!
+        name: String!
+      }
+
+      type UserConnection {
+        edges: [UserEdge!]!
+        pageInfo: PageInfo!
+      }
+
+      type UserEdge {
+        node: User
+        cursor: String!
+      }
+
+      type PageInfo {
+        hasNextPage: Boolean!
+        hasPreviousPage: Boolean!
+        startCursor: String
+        endCursor: String
+      }
+
+      interface Node {
+        id: ID!
+      }
+    `,
+		PerformTest: func(t *testing.T, p *plugin.HoudiniCore, test tests.Test[config.PluginConfig]) {
+			performArtifactTest(t, p, test)
+
+			if !test.Pass {
+				return
+			}
+
+			projectConfig, err := p.DB.ProjectConfig(t.Context())
+			require.NoError(t, err)
+
+			artifactPath := projectConfig.ArtifactPath("TestQuery")
+			file, err := p.Fs.Open(artifactPath)
+			require.NoError(t, err)
+			content, err := afero.ReadAll(file)
+			require.NoError(t, err)
+
+			artifact := string(content)
+			require.True(t, strings.Contains(artifact, `"includeListID": true`),
+				"artifact should contain includeListID: true, got:\n%s", artifact)
+			require.False(t, strings.Contains(artifact, `includeListID`+"`"+` in raw query`),
+				"__listID should not appear in the raw query string")
+		},
+		Tests: []tests.Test[config.PluginConfig]{
+			{
+				Name: "non-connection list with @includeListID emits includeListID in artifact",
+				Pass: true,
+				Input: []string{`query TestQuery {
+  users @list(name: "All_Users") @includeListID {
+    id
+    name
+  }
+}`},
+			},
+			{
+				Name: "connection list with @paginate and @includeListID emits includeListID in artifact",
+				Pass: true,
+				Input: []string{`query TestQuery {
+  usersByCursor(first: 10) @paginate(name: "All_Users") @includeListID {
+    edges {
+      node {
+        id
+        name
+      }
+    }
+  }
+}`},
+			},
+			{
+				Name: "@includeListID without @list or @paginate fails validation",
+				Pass: false,
+				Input: []string{`query TestQuery {
+  users @includeListID {
+    id
+    name
+  }
+}`},
+			},
+		},
+	})
+}
+
 // TestPaginatePathWinsOverListPath verifies that when a document contains both a @paginate
 // field and a @list field, the refetch path points to the @paginate field.
 func TestPaginatePathWinsOverListPath(t *testing.T) {

--- a/packages/houdini-core/plugin/documents/artifacts/selection_lists_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_lists_test.go
@@ -1970,8 +1970,10 @@ func TestIncludeListID(t *testing.T) {
 			artifact := string(content)
 			require.True(t, strings.Contains(artifact, `"includeListID": true`),
 				"artifact should contain includeListID: true, got:\n%s", artifact)
-			require.False(t, strings.Contains(artifact, `includeListID`+"`"+` in raw query`),
-				"__listID should not appear in the raw query string")
+			// @includeListID is an internal directive; it must be stripped from the raw query
+			// sent to the server — only the selection metadata should carry it
+			require.NotContains(t, artifact, "@includeListID",
+				"@includeListID should be stripped from the raw query, got:\n%s", artifact)
 		},
 		Tests: []tests.Test[config.PluginConfig]{
 			{
@@ -2007,6 +2009,72 @@ func TestIncludeListID(t *testing.T) {
     name
   }
 }`},
+			},
+		},
+	})
+}
+
+// TestListIDMutation verifies that @listID on a fragment spread is serialized into the mutation
+// artifact's operations so the runtime can resolve the list via the opaque key from __listID.
+func TestListIDMutation(t *testing.T) {
+	tests.RunTable(t, tests.Table[config.PluginConfig, *plugin.HoudiniCore]{
+		Schema: `
+      type Mutation {
+          addUser(name: String!): User
+      }
+
+      type Query {
+          users: [User!]!
+      }
+
+      type User implements Node {
+          id: ID!
+          name: String!
+      }
+
+      interface Node {
+          id: ID!
+      }
+    `,
+		PerformTest: func(t *testing.T, p *plugin.HoudiniCore, test tests.Test[config.PluginConfig]) {
+			performArtifactTest(t, p, test)
+			if !test.Pass {
+				return
+			}
+
+			projectConfig, err := p.DB.ProjectConfig(t.Context())
+			require.NoError(t, err)
+
+			artifactPath := projectConfig.ArtifactPath("TestMutation")
+			file, err := p.Fs.Open(artifactPath)
+			require.NoError(t, err)
+			content, err := afero.ReadAll(file)
+			require.NoError(t, err)
+
+			artifact := string(content)
+			require.Contains(t, artifact, `"listID"`,
+				"mutation artifact should contain listID in operations, got:\n%s", artifact)
+			// @listID is internal; it should not appear in the raw mutation sent to the server
+			require.NotContains(t, artifact, "@listID",
+				"@listID should be stripped from the raw query, got:\n%s", artifact)
+		},
+		Tests: []tests.Test[config.PluginConfig]{
+			{
+				Name: "@listID on fragment spread produces listID field in mutation artifact operations",
+				Pass: true,
+				Input: []string{
+					`query TestQuery {
+  users @list(name: "All_Users") @includeListID {
+    id
+    name
+  }
+}`,
+					`mutation TestMutation($listId: ID!) {
+  addUser(name: "Test") {
+    ...All_Users_insert @listID(value: $listId)
+  }
+}`,
+				},
 			},
 		},
 	})

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
@@ -588,10 +588,10 @@ func generateSelectionType(
 			fieldType = convertLeafType(ctx, selection.FieldType, selection.TypeModifiers, collectedDocs)
 		}
 
-		// @includeListID attaches an opaque __listID to the runtime value; reflect that in the type
+		// @includeListID attaches an opaque __id to the runtime value; reflect that in the type
 		for _, directive := range selection.Directives {
 			if directive.Name == graphql.IncludeListIDDirective {
-				fieldType = fieldType + " & { __listID: string }"
+				fieldType = fieldType + " & { __id: string }"
 				break
 			}
 		}

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
@@ -588,6 +588,14 @@ func generateSelectionType(
 			fieldType = convertLeafType(ctx, selection.FieldType, selection.TypeModifiers, collectedDocs)
 		}
 
+		// @includeListID attaches an opaque __listID to the runtime value; reflect that in the type
+		for _, directive := range selection.Directives {
+			if directive.Name == graphql.IncludeListIDDirective {
+				fieldType = fieldType + " & { __listID: string }"
+				break
+			}
+		}
+
 		// Add readonly modifier if needed
 		readonlyPrefix := ""
 		if readonly {

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
@@ -1003,7 +1003,20 @@ func generateOptimisticType(
 
 		visibleSelections = append(visibleSelections, sel)
 		if sel.FieldName != "__typename" {
-			explicitFieldCount++
+			// @optimisticKey fields are server-generated; the caller can never provide them,
+			// so they don't count as "explicit" — without this, a selection like
+			// { id @optimisticKey ...Frag } would suppress fragment expansion and produce
+			// a broken `Frag?: null` optimistic type instead of inlining the fragment fields.
+			isOptimisticKey := false
+			for _, d := range sel.Directives {
+				if d.Name == graphql.OptimisticKeyDirective {
+					isOptimisticKey = true
+					break
+				}
+			}
+			if !isOptimisticKey {
+				explicitFieldCount++
+			}
 		}
 	}
 

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/masking_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/masking_test.go
@@ -285,3 +285,56 @@ func TestTypescriptFragmentMasking(t *testing.T) {
 		},
 	})
 }
+
+// @includeListID stamps an opaque __id onto the list value so the client can
+// pass it back via @listID; the generated type must reflect that intersection
+func TestTypescriptIncludeListID(t *testing.T) {
+	tests.RunTable(t, tests.Table[config.PluginConfig, *plugin.HoudiniCore]{
+		Schema: `
+			type Query {
+				users: [User!]!
+			}
+
+			type User implements Node {
+				id: ID!
+				name: String!
+			}
+
+			interface Node {
+				id: ID!
+			}
+		`,
+		VerifyTest: func(t *testing.T, plugin *plugin.HoudiniCore, test tests.Test[config.PluginConfig]) {
+			config, err := plugin.DB.ProjectConfig(context.Background())
+			require.NoError(t, err)
+
+			for docName, expected := range test.Extra {
+				typeDefs, err := afero.ReadFile(plugin.Fs, config.ArtifactTypePath(docName))
+				require.NoError(t, err)
+				require.Contains(t, string(typeDefs), expected)
+			}
+		},
+		Tests: []tests.Test[config.PluginConfig]{
+			{
+				Name: "@includeListID intersects __id onto the list type",
+				Pass: true,
+				Input: []string{`query TestQuery {
+					users @list(name: "All_Users") @includeListID {
+						id
+						name
+					}
+				}`},
+				Extra: map[string]any{
+					"TestQuery": tests.Dedent(`
+						export type TestQuery$result = {
+							readonly users: ({
+								readonly id: string;
+								readonly name: string;
+							})[] & { __id: string };
+						};
+					`),
+				},
+			},
+		},
+	})
+}

--- a/packages/houdini-core/plugin/lists/validate.go
+++ b/packages/houdini-core/plugin/lists/validate.go
@@ -63,6 +63,58 @@ func ValidateConflictingPrependAppend(
 	}
 }
 
+func ValidateIncludeListID(
+	ctx context.Context,
+	db plugins.DatabasePool[config.PluginConfig],
+	errs *plugins.ErrorList,
+) {
+	// @includeListID is only valid on fields that also carry @list or @paginate
+	query := `
+	SELECT
+	  raw_documents.filepath,
+	  raw_documents.offset_line,
+	  raw_documents.offset_column,
+	  sd.row AS line,
+	  sd.column,
+	  documents.name AS documentName
+	FROM selection_directives sd
+	  JOIN selection_refs ON selection_refs.child_id = sd.selection_id
+	  JOIN documents ON documents.id = selection_refs.document
+	  JOIN raw_documents ON raw_documents.id = documents.raw_document
+	WHERE sd.directive = $includeListID
+	  AND (raw_documents.current_task = $task_id OR $task_id IS NULL)
+	  AND NOT EXISTS (
+	    SELECT 1 FROM selection_directives sd2
+	    WHERE sd2.selection_id = sd.selection_id
+	      AND sd2.directive IN ($list, $paginate)
+	  )
+	`
+	bindings := map[string]any{
+		"includeListID": graphql.IncludeListIDDirective,
+		"list":          graphql.ListDirective,
+		"paginate":      graphql.PaginationDirective,
+	}
+	err := db.StepQuery(ctx, query, bindings, func(stmt plugins.Row) {
+		filepath := stmt.ColumnText(0)
+		line := int(stmt.ColumnInt(1)) + int(stmt.ColumnInt(3))
+		column := int(stmt.ColumnInt(2)) + int(stmt.ColumnInt(4))
+		documentName := stmt.ColumnText(5)
+		errs.Append(&plugins.Error{
+			Message: fmt.Sprintf(
+				"@includeListID can only be used on fields that also have @list or @paginate in document %q",
+				documentName,
+			),
+			Kind: plugins.ErrorKindValidation,
+			Locations: []*plugins.ErrorLocation{
+				{Filepath: filepath, Line: line, Column: column},
+			},
+		})
+	})
+	if err != nil {
+		errs.Append(plugins.WrapError(err))
+	}
+}
+
 func ValidateConflictingParentIDAllLists(
 	ctx context.Context,
 	db plugins.DatabasePool[config.PluginConfig],

--- a/packages/houdini-core/plugin/lists/validate.go
+++ b/packages/houdini-core/plugin/lists/validate.go
@@ -81,13 +81,12 @@ func ValidateIncludeListID(
 	  JOIN selection_refs ON selection_refs.child_id = sd.selection_id
 	  JOIN documents ON documents.id = selection_refs.document
 	  JOIN raw_documents ON raw_documents.id = documents.raw_document
+	  LEFT JOIN selection_directives sd2
+	    ON sd2.selection_id = sd.selection_id
+	    AND sd2.directive IN ($list, $paginate)
 	WHERE sd.directive = $includeListID
 	  AND (raw_documents.current_task = $task_id OR $task_id IS NULL)
-	  AND NOT EXISTS (
-	    SELECT 1 FROM selection_directives sd2
-	    WHERE sd2.selection_id = sd.selection_id
-	      AND sd2.directive IN ($list, $paginate)
-	  )
+	  AND sd2.selection_id IS NULL
 	`
 	bindings := map[string]any{
 		"includeListID": graphql.IncludeListIDDirective,

--- a/packages/houdini-core/plugin/runtime/runtimeIndex.go
+++ b/packages/houdini-core/plugin/runtime/runtimeIndex.go
@@ -42,11 +42,11 @@ func GenerateRuntimeIndexFile(
 	defer db.Put(conn)
 
 	documentSearch, err := conn.Prepare(`
-		SELECT 
-			name 
-		FROM documents 
+		SELECT
+			name
+		FROM documents
 		JOIN raw_documents ON documents.raw_document = raw_documents.id
-		WHERE printed IS NOT NULL and internal = 0 
+		WHERE internal = 0
 		ORDER BY name ASC
 	`)
 	if err != nil {

--- a/packages/houdini-core/plugin/schema/generateDefinitions_test.go
+++ b/packages/houdini-core/plugin/schema/generateDefinitions_test.go
@@ -87,6 +87,12 @@ directive @allLists on FRAGMENT_SPREAD
 """@parentID is used to provide a parentID without specifying position or in situations where it doesn't make sense (eg when deleting a node.)"""
 directive @parentID(value: ID!) on FRAGMENT_SPREAD
 
+"""@includeListID exposes an opaque __listID value on the list that can be passed to @listID on a mutation to target a specific list instance."""
+directive @includeListID on FIELD
+
+"""@listID is used to identify a list by the opaque key obtained from __listID (via @includeListID)."""
+directive @listID(value: ID!) on FRAGMENT_SPREAD
+
 """@when is used to provide a conditional or in situations where it doesn't make sense (eg when removing or deleting a node.)"""
 directive @when on FRAGMENT_SPREAD
 
@@ -224,7 +230,7 @@ fragment theList_toggle on CustomIdType {
 				},
 				Extra: map[string]any{
 					"runGenerationTwice": true,
-					"directiveCount":     1,
+					"directiveCount":     2, // @list and @listID both match "directive @list"
 				},
 			},
 		},

--- a/packages/houdini-core/plugin/schema/generateDefinitions_test.go
+++ b/packages/houdini-core/plugin/schema/generateDefinitions_test.go
@@ -87,10 +87,10 @@ directive @allLists on FRAGMENT_SPREAD
 """@parentID is used to provide a parentID without specifying position or in situations where it doesn't make sense (eg when deleting a node.)"""
 directive @parentID(value: ID!) on FRAGMENT_SPREAD
 
-"""@includeListID exposes an opaque __listID value on the list that can be passed to @listID on a mutation to target a specific list instance."""
+"""@includeListID exposes an opaque __id value on the list that can be passed to @listID on a mutation to target a specific list instance."""
 directive @includeListID on FIELD
 
-"""@listID is used to identify a list by the opaque key obtained from __listID (via @includeListID)."""
+"""@listID is used to identify a list by the opaque key obtained from __id (via @includeListID)."""
 directive @listID(value: ID!) on FRAGMENT_SPREAD
 
 """@when is used to provide a conditional or in situations where it doesn't make sense (eg when removing or deleting a node.)"""

--- a/packages/houdini-core/plugin/schema/write.go
+++ b/packages/houdini-core/plugin/schema/write.go
@@ -753,6 +753,49 @@ then the request will never be deduplicated.`,
 		return err
 	}
 
+	// @includeListID on FIELD_DEFINITION — exposes __listID on the list for use with @listID
+	err = db.ExecStatement(statements.InsertInternalDirective, map[string]any{
+		"name":        graphql.IncludeListIDDirective,
+		"description": "@includeListID exposes an opaque __listID value on the list that can be passed to @listID on a mutation to target a specific list instance.",
+		"visible":     true,
+	})
+	if err != nil {
+		return err
+	}
+	err = db.ExecStatement(statements.InsertDirectiveLocation, map[string]any{
+		"directive": graphql.IncludeListIDDirective,
+		"location":  "FIELD",
+	})
+	if err != nil {
+		return err
+	}
+
+	// @listID(value: ID!) on FRAGMENT_SPREAD
+	err = db.ExecStatement(statements.InsertInternalDirective, map[string]any{
+		"name":        graphql.ListIDDirective,
+		"description": "@listID is used to identify a list by the opaque key obtained from __listID (via @includeListID).",
+		"visible":     true,
+	})
+	if err != nil {
+		return err
+	}
+	err = db.ExecStatement(statements.InsertDirectiveLocation, map[string]any{
+		"directive": graphql.ListIDDirective,
+		"location":  "FRAGMENT_SPREAD",
+	})
+	if err != nil {
+		return err
+	}
+	err = db.ExecStatement(statements.InsertDirectiveArgument, map[string]any{
+		"directive":      graphql.ListIDDirective,
+		"name":           "value",
+		"type":           "ID",
+		"type_modifiers": "!",
+	})
+	if err != nil {
+		return err
+	}
+
 	// @when on FRAGMENT_SPREAD
 	err = db.ExecStatement(statements.InsertInternalDirective, map[string]any{
 		"name":        graphql.WhenDirective,

--- a/packages/houdini-core/plugin/schema/write.go
+++ b/packages/houdini-core/plugin/schema/write.go
@@ -753,10 +753,10 @@ then the request will never be deduplicated.`,
 		return err
 	}
 
-	// @includeListID on FIELD_DEFINITION — exposes __listID on the list for use with @listID
+	// @includeListID on FIELD_DEFINITION — exposes __id on the list for use with @listID
 	err = db.ExecStatement(statements.InsertInternalDirective, map[string]any{
 		"name":        graphql.IncludeListIDDirective,
-		"description": "@includeListID exposes an opaque __listID value on the list that can be passed to @listID on a mutation to target a specific list instance.",
+		"description": "@includeListID exposes an opaque __id value on the list that can be passed to @listID on a mutation to target a specific list instance.",
 		"visible":     true,
 	})
 	if err != nil {
@@ -773,7 +773,7 @@ then the request will never be deduplicated.`,
 	// @listID(value: ID!) on FRAGMENT_SPREAD
 	err = db.ExecStatement(statements.InsertInternalDirective, map[string]any{
 		"name":        graphql.ListIDDirective,
-		"description": "@listID is used to identify a list by the opaque key obtained from __listID (via @includeListID).",
+		"description": "@listID is used to identify a list by the opaque key obtained from __id (via @includeListID).",
 		"visible":     true,
 	})
 	if err != nil {

--- a/packages/houdini-core/plugin/validate.go
+++ b/packages/houdini-core/plugin/validate.go
@@ -49,6 +49,7 @@ func (p *HoudiniCore) Validate(ctx context.Context) error {
 		lists.DiscoverListsThenValidate,
 		lists.ValidateConflictingParentIDAllLists,
 		lists.ValidateConflictingPrependAppend,
+		lists.ValidateIncludeListID,
 		lists.ValidatePaginateTypeCondition,
 		lists.ValidateSinglePaginateDirective,
 		lists.ValidateParentID,

--- a/packages/houdini-react/plugin/runtime.go
+++ b/packages/houdini-react/plugin/runtime.go
@@ -327,11 +327,11 @@ var hookSpecs = []hookSpec{
 		},
 		overloads: func(name string) string {
 			return fmt.Sprintf(
-				"export function useMutation(document: { artifact: %s$artifact }): [boolean, MutationHandler<%s$result, %s$input, %s$optimistic>]\n",
+				"export function useMutation(document: { artifact: %s$artifact }): [MutationHandler<%s$result, %s$input, %s$optimistic>, boolean]\n",
 				name, name, name, name,
 			)
 		},
-		passthrough: "export function useMutation<_Result extends GraphQLObject, _Input extends GraphQLVariables, _Optimistic extends GraphQLObject>(document: { artifact: MutationArtifact }): [boolean, MutationHandler<_Result, _Input, _Optimistic>]",
+		passthrough: "export function useMutation<_Result extends GraphQLObject, _Input extends GraphQLVariables, _Optimistic extends GraphQLObject>(document: { artifact: MutationArtifact }): [MutationHandler<_Result, _Input, _Optimistic>, boolean]",
 	},
 	{
 		file:   "useSubscription.ts",

--- a/packages/houdini-react/plugin/runtime.go
+++ b/packages/houdini-react/plugin/runtime.go
@@ -404,7 +404,7 @@ func (p *HoudiniReact) AddGraphQLType(ctx context.Context) ([]string, error) {
 	var typeChain strings.Builder
 
 	for _, cf := range cfs {
-		preamble.WriteString(fmt.Sprintf("import type { %s } from '$houdini'\n", cf.fragment))
+		preamble.WriteString(fmt.Sprintf("import type { %s } from '../artifacts/%s'\n", cf.fragment, cf.fragment))
 		typeChain.WriteString(fmt.Sprintf("_Document extends `%s` ? Required<%s>['shape'] : ", cf.content, cf.fragment))
 	}
 

--- a/packages/houdini-react/plugin/runtime_test.go
+++ b/packages/houdini-react/plugin/runtime_test.go
@@ -237,8 +237,8 @@ func TestUpdateHookFiles(t *testing.T) {
 						"useMutation.ts": "import type { MyMutation$result, MyMutation$artifact, MyMutation$input, MyMutation$optimistic } from '$houdini/artifacts/MyMutation'\n" +
 							"\n" +
 							"import type { MutationArtifact } from 'houdini/runtime'\n\n" +
-							"export function useMutation(document: { artifact: MyMutation$artifact }): [boolean, MutationHandler<MyMutation$result, MyMutation$input, MyMutation$optimistic>]\n" +
-							"export function useMutation<_Result extends GraphQLObject, _Input extends GraphQLVariables, _Optimistic extends GraphQLObject>(document: { artifact: MutationArtifact }): [boolean, MutationHandler<_Result, _Input, _Optimistic>]\n" +
+							"export function useMutation(document: { artifact: MyMutation$artifact }): [MutationHandler<MyMutation$result, MyMutation$input, MyMutation$optimistic>, boolean]\n" +
+							"export function useMutation<_Result extends GraphQLObject, _Input extends GraphQLVariables, _Optimistic extends GraphQLObject>(document: { artifact: MutationArtifact }): [MutationHandler<_Result, _Input, _Optimistic>, boolean]\n" +
 							"export function useMutation<_A>(doc: any): any {}\n",
 					},
 				},

--- a/packages/houdini-react/plugin/runtime_test.go
+++ b/packages/houdini-react/plugin/runtime_test.go
@@ -352,7 +352,7 @@ func TestAddGraphQLType(t *testing.T) {
 						},
 					},
 					// preamble (fragment imports) go BEFORE existing content, type appended at end
-					"expected": "import type { UserAvatar } from '$houdini'\n" +
+					"expected": "import type { UserAvatar } from '../artifacts/UserAvatar'\n" +
 						indexStub +
 						"\nexport type GraphQL<_Document extends string> = " +
 						"_Document extends `fragment UserAvatar on User { avatar }` ? Required<UserAvatar>['shape'] : " +
@@ -374,7 +374,7 @@ func TestAddGraphQLType(t *testing.T) {
 						{"filepath": "src/components/Avatar.tsx", "type": "User", "field": "Avatar", "prop": "user", "fragment": "UserAvatar", "content": "fragment UserAvatar on User { avatar }"},
 					},
 					"call_twice": true,
-					"expected": "import type { UserAvatar } from '$houdini'\n" +
+					"expected": "import type { UserAvatar } from '../artifacts/UserAvatar'\n" +
 						indexStub +
 						"\nexport type GraphQL<_Document extends string> = " +
 						"_Document extends `fragment UserAvatar on User { avatar }` ? Required<UserAvatar>['shape'] : " +

--- a/packages/houdini-react/runtime/hooks/recycleNodesInto.test.ts
+++ b/packages/houdini-react/runtime/hooks/recycleNodesInto.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect } from 'vitest'
+import { recycleNodesInto } from './recycleNodesInto.js'
+
+describe('recycleNodesInto', () => {
+	test('preserves object identity for unchanged subtrees', () => {
+		const a = { id: '1', name: 'Alice' }
+		const prev = [a]
+		const next = [{ id: '1', name: 'Alice' }]
+		const result = recycleNodesInto(prev, next)
+		expect(result).toBe(prev)
+		expect((result as any[])[0]).toBe(a)
+	})
+
+	test('returns new array when element changes', () => {
+		const prev = [{ id: '1', name: 'Alice' }]
+		const next = [{ id: '1', name: 'Bob' }]
+		const result = recycleNodesInto(prev, next)
+		expect(result).not.toBe(prev)
+	})
+
+	test('copies non-index properties from next when array length changes', () => {
+		const prev = [{ id: '1' }] as any[]
+		;(prev as any).__id = 'root::MyList'
+		const next = [{ id: '1' }, { id: '2' }] as any[]
+		;(next as any).__id = 'root::MyList'
+
+		const result = recycleNodesInto(prev, next) as any[]
+		expect(result.length).toBe(2)
+		expect((result as any).__id).toBe('root::MyList')
+	})
+
+	test('copies non-index properties from next when element changes', () => {
+		const prev = [{ id: '1', name: 'Alice' }] as any[]
+		;(prev as any).__id = 'root::MyList'
+		const next = [{ id: '1', name: 'Bob' }] as any[]
+		;(next as any).__id = 'root::MyList'
+
+		const result = recycleNodesInto(prev, next) as any[]
+		expect((result as any).__id).toBe('root::MyList')
+	})
+
+	test('returns prev (with its own properties) when array is unchanged', () => {
+		const prev = [{ id: '1' }] as any[]
+		;(prev as any).__id = 'root::MyList'
+		const next = [{ id: '1' }] as any[]
+		;(next as any).__id = 'root::MyList'
+
+		const result = recycleNodesInto(prev, next) as any[]
+		expect(result).toBe(prev)
+		expect((result as any).__id).toBe('root::MyList')
+	})
+
+	test('first render (prev null) returns next with its properties', () => {
+		const next = [{ id: '1' }] as any[]
+		;(next as any).__id = 'root::MyList'
+
+		const result = recycleNodesInto(null, next) as any[]
+		expect(result).toBe(next)
+		expect((result as any).__id).toBe('root::MyList')
+	})
+})

--- a/packages/houdini-react/runtime/hooks/recycleNodesInto.ts
+++ b/packages/houdini-react/runtime/hooks/recycleNodesInto.ts
@@ -33,6 +33,13 @@ export function recycleNodesInto<T>(prev: T | null | undefined, next: T): T {
 		}
 
 		if (!changed && prevLen === nextLen) return prev as T
+
+		// Copy non-index own properties from next (e.g. __id from @includeListID)
+		for (const key of Object.keys(next as any)) {
+			if (isNaN(Number(key))) {
+				;(result as any)[key] = (next as any)[key]
+			}
+		}
 		return result as unknown as T
 	}
 

--- a/packages/houdini-react/runtime/hooks/useQuery.ts
+++ b/packages/houdini-react/runtime/hooks/useQuery.ts
@@ -1,4 +1,4 @@
-import type { GraphQLObject, QueryArtifact } from 'houdini/runtime'
+import type { GraphQLObject, GraphQLVariables, QueryArtifact } from 'houdini/runtime'
 
 import type { UseQueryConfig } from './useQueryHandle.js'
 import { useQueryHandle } from './useQueryHandle.js'

--- a/packages/houdini/src/runtime/cache/index.ts
+++ b/packages/houdini/src/runtime/cache/index.ts
@@ -137,10 +137,9 @@ export class Cache {
 		name: string,
 		parentID?: string,
 		allLists?: boolean,
-		skipMatches?: Set<string>,
-		rawParentID?: string
+		skipMatches?: Set<string>
 	): ListCollection {
-		const handler = this._internal_unstable.lists.get(name, parentID, allLists, skipMatches, rawParentID)
+		const handler = this._internal_unstable.lists.get(name, parentID, allLists, skipMatches)
 		if (!handler) {
 			throw new Error(
 				`Cannot find list with name: ${name}${
@@ -877,26 +876,26 @@ class CacheInternal {
 					}
 				}
 
-				// listID is an opaque cache key from __listID/@includeListID — use directly
-				let rawParentID: string | undefined
+				// resolve the opaque list ID from @listID (the value of __listID set by @includeListID)
+				let opaqueListID: string | undefined
 				if (operation.listID) {
 					if (operation.listID.kind !== 'Variable') {
-						rawParentID = operation.listID.value
+						opaqueListID = operation.listID.value
 					} else {
 						const id = variables[operation.listID.value]
 						if (typeof id !== 'string') {
 							throw new Error('listID value must be a string')
 						}
-						rawParentID = id
+						opaqueListID = id
 					}
 				}
 
 				// if the necessary list doesn't exist, don't do anything
-				if (
-					operation.list &&
-					!this.lists.get(operation.list, parentID, operation.target === 'all', undefined, rawParentID)
-				) {
-					continue
+				if (operation.list) {
+					const exists = opaqueListID
+						? this.lists.getByOpaqueID(opaqueListID)
+						: this.lists.get(operation.list, parentID, operation.target === 'all')
+					if (!exists) continue
 				}
 
 				// there could be a list of elements to perform the operation on
@@ -909,14 +908,10 @@ class CacheInternal {
 						fieldSelection &&
 						operation.list
 					) {
-						this.cache
-							.list(
-								operation.list,
-								parentID,
-								operation.target === 'all',
-								processedOperations,
-								rawParentID
-							)
+						const insertList = opaqueListID
+							? this.lists.getByOpaqueID(opaqueListID, processedOperations)!
+							: this.cache.list(operation.list, parentID, operation.target === 'all', processedOperations)
+						insertList
 							.when(operation.when)
 							.addToList(
 								fieldSelection,
@@ -934,14 +929,10 @@ class CacheInternal {
 						fieldSelection &&
 						operation.list
 					) {
-						this.cache
-							.list(
-								operation.list,
-								parentID,
-								operation.target === 'all',
-								processedOperations,
-								rawParentID
-							)
+						const toggleList = opaqueListID
+							? this.lists.getByOpaqueID(opaqueListID, processedOperations)!
+							: this.cache.list(operation.list, parentID, operation.target === 'all', processedOperations)
+						toggleList
 							.when(operation.when)
 							.toggleElement({
 								selection: fieldSelection,
@@ -959,14 +950,10 @@ class CacheInternal {
 						fieldSelection &&
 						operation.list
 					) {
-						this.cache
-							.list(
-								operation.list,
-								parentID,
-								operation.target === 'all',
-								processedOperations,
-								rawParentID
-							)
+						const removeList = opaqueListID
+							? this.lists.getByOpaqueID(opaqueListID, processedOperations)!
+							: this.cache.list(operation.list, parentID, operation.target === 'all', processedOperations)
+						removeList
 							.when(operation.when)
 							.remove(target, variables, layer)
 					}
@@ -990,13 +977,9 @@ class CacheInternal {
 
 				if (operation.list) {
 					// figure out the field referenced by the list
-					const matchingLists = this.cache.list(
-						operation.list,
-						parentID,
-						operation.target === 'all',
-						undefined,
-						rawParentID
-					)
+					const matchingLists = opaqueListID
+						? this.lists.getByOpaqueID(opaqueListID)!
+						: this.cache.list(operation.list, parentID, operation.target === 'all')
 					for (const list of matchingLists.lists) {
 						processedOperations.add(list.fieldRef)
 					}
@@ -1294,9 +1277,10 @@ class CacheInternal {
 			}
 
 			// if the list requested an opaque key, attach it to the hydrated value so the
-			// user can pass it to @listID on a mutation to target this specific list instance
+			// user can pass it to @listID on a mutation to target this specific list instance.
+			// the format matches what ListManager.listsByOpaqueID uses as its key.
 			if (list?.includeListID && fieldTarget[attributeName] != null) {
-				;(fieldTarget[attributeName] as any).__listID = parent
+				;(fieldTarget[attributeName] as any).__listID = `${list.name}::${parent}`
 			}
 
 			// if we are generating a loading value then we might need to wrap up the result

--- a/packages/houdini/src/runtime/cache/index.ts
+++ b/packages/houdini/src/runtime/cache/index.ts
@@ -910,7 +910,12 @@ class CacheInternal {
 					) {
 						const insertList = opaqueListID
 							? this.lists.getByOpaqueID(opaqueListID, processedOperations)!
-							: this.cache.list(operation.list, parentID, operation.target === 'all', processedOperations)
+							: this.cache.list(
+									operation.list,
+									parentID,
+									operation.target === 'all',
+									processedOperations
+								)
 						insertList
 							.when(operation.when)
 							.addToList(
@@ -931,16 +936,19 @@ class CacheInternal {
 					) {
 						const toggleList = opaqueListID
 							? this.lists.getByOpaqueID(opaqueListID, processedOperations)!
-							: this.cache.list(operation.list, parentID, operation.target === 'all', processedOperations)
-						toggleList
-							.when(operation.when)
-							.toggleElement({
-								selection: fieldSelection,
-								data: target,
-								variables,
-								where: operation.position || 'last',
-								layer,
-							})
+							: this.cache.list(
+									operation.list,
+									parentID,
+									operation.target === 'all',
+									processedOperations
+								)
+						toggleList.when(operation.when).toggleElement({
+							selection: fieldSelection,
+							data: target,
+							variables,
+							where: operation.position || 'last',
+							layer,
+						})
 					}
 
 					// remove object from list
@@ -952,10 +960,13 @@ class CacheInternal {
 					) {
 						const removeList = opaqueListID
 							? this.lists.getByOpaqueID(opaqueListID, processedOperations)!
-							: this.cache.list(operation.list, parentID, operation.target === 'all', processedOperations)
-						removeList
-							.when(operation.when)
-							.remove(target, variables, layer)
+							: this.cache.list(
+									operation.list,
+									parentID,
+									operation.target === 'all',
+									processedOperations
+								)
+						removeList.when(operation.when).remove(target, variables, layer)
 					}
 
 					// delete the target

--- a/packages/houdini/src/runtime/cache/index.ts
+++ b/packages/houdini/src/runtime/cache/index.ts
@@ -18,7 +18,7 @@ import type {
 import { fragmentKey } from '../types.js'
 import { GarbageCollector } from './gc.js'
 import type { ListCollection } from './lists.js'
-import { ListManager } from './lists.js'
+import { ListManager, opaqueListID } from './lists.js'
 import { StaleManager } from './staleManager.js'
 import type { Layer, LayerID } from './storage.js'
 import { InMemoryStorage } from './storage.js'
@@ -1280,7 +1280,7 @@ class CacheInternal {
 			// user can pass it to @listID on a mutation to target this specific list instance.
 			// the format matches what ListManager.listsByOpaqueID uses as its key.
 			if (list?.includeListID && fieldTarget[attributeName] != null) {
-				;(fieldTarget[attributeName] as any).__listID = `${list.name}::${parent}`
+				;(fieldTarget[attributeName] as any).__listID = opaqueListID(parent, list.name)
 			}
 
 			// if we are generating a loading value then we might need to wrap up the result

--- a/packages/houdini/src/runtime/cache/index.ts
+++ b/packages/houdini/src/runtime/cache/index.ts
@@ -137,9 +137,10 @@ export class Cache {
 		name: string,
 		parentID?: string,
 		allLists?: boolean,
-		skipMatches?: Set<string>
+		skipMatches?: Set<string>,
+		rawParentID?: string
 	): ListCollection {
-		const handler = this._internal_unstable.lists.get(name, parentID, allLists, skipMatches)
+		const handler = this._internal_unstable.lists.get(name, parentID, allLists, skipMatches, rawParentID)
 		if (!handler) {
 			throw new Error(
 				`Cannot find list with name: ${name}${
@@ -876,10 +877,24 @@ class CacheInternal {
 					}
 				}
 
+				// listID is an opaque cache key from __listID/@includeListID — use directly
+				let rawParentID: string | undefined
+				if (operation.listID) {
+					if (operation.listID.kind !== 'Variable') {
+						rawParentID = operation.listID.value
+					} else {
+						const id = variables[operation.listID.value]
+						if (typeof id !== 'string') {
+							throw new Error('listID value must be a string')
+						}
+						rawParentID = id
+					}
+				}
+
 				// if the necessary list doesn't exist, don't do anything
 				if (
 					operation.list &&
-					!this.lists.get(operation.list, parentID, operation.target === 'all')
+					!this.lists.get(operation.list, parentID, operation.target === 'all', undefined, rawParentID)
 				) {
 					continue
 				}
@@ -899,7 +914,8 @@ class CacheInternal {
 								operation.list,
 								parentID,
 								operation.target === 'all',
-								processedOperations
+								processedOperations,
+								rawParentID
 							)
 							.when(operation.when)
 							.addToList(
@@ -923,7 +939,8 @@ class CacheInternal {
 								operation.list,
 								parentID,
 								operation.target === 'all',
-								processedOperations
+								processedOperations,
+								rawParentID
 							)
 							.when(operation.when)
 							.toggleElement({
@@ -947,7 +964,8 @@ class CacheInternal {
 								operation.list,
 								parentID,
 								operation.target === 'all',
-								processedOperations
+								processedOperations,
+								rawParentID
 							)
 							.when(operation.when)
 							.remove(target, variables, layer)
@@ -975,7 +993,9 @@ class CacheInternal {
 					const matchingLists = this.cache.list(
 						operation.list,
 						parentID,
-						operation.target === 'all'
+						operation.target === 'all',
+						undefined,
+						rawParentID
 					)
 					for (const list of matchingLists.lists) {
 						processedOperations.add(list.fieldRef)
@@ -1271,6 +1291,12 @@ class CacheInternal {
 				if (objectFields.hasData) {
 					hasData = true
 				}
+			}
+
+			// if the list requested an opaque key, attach it to the hydrated value so the
+			// user can pass it to @listID on a mutation to target this specific list instance
+			if (list?.includeListID && fieldTarget[attributeName] != null) {
+				;(fieldTarget[attributeName] as any).__listID = parent
 			}
 
 			// if we are generating a loading value then we might need to wrap up the result

--- a/packages/houdini/src/runtime/cache/index.ts
+++ b/packages/houdini/src/runtime/cache/index.ts
@@ -876,7 +876,7 @@ class CacheInternal {
 					}
 				}
 
-				// resolve the opaque list ID from @listID (the value of __listID set by @includeListID)
+				// resolve the opaque list ID from @listID (the value of __id set by @includeListID)
 				let opaqueListID: string | undefined
 				if (operation.listID) {
 					if (operation.listID.kind !== 'Variable') {
@@ -1291,7 +1291,7 @@ class CacheInternal {
 			// user can pass it to @listID on a mutation to target this specific list instance.
 			// the format matches what ListManager.listsByOpaqueID uses as its key.
 			if (list?.includeListID && fieldTarget[attributeName] != null) {
-				;(fieldTarget[attributeName] as any).__listID = opaqueListID(parent, list.name)
+				;(fieldTarget[attributeName] as any).__id = opaqueListID(parent, list.name)
 			}
 
 			// if we are generating a loading value then we might need to wrap up the result

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -18,9 +18,9 @@ export class ListManager {
 
 	private listsByField: Map<string, Map<string, List[]>> = new Map()
 
-	get(listName: string, id?: string, allLists?: boolean, skipMatches?: Set<string>) {
+	get(listName: string, id?: string, allLists?: boolean, skipMatches?: Set<string>, rawParentID?: string) {
 		// get the list collection
-		const lists = this.getLists(listName, id, allLists)
+		const lists = this.getLists(listName, id, allLists, rawParentID)
 		if (!lists) {
 			return null
 		}
@@ -33,7 +33,7 @@ export class ListManager {
 		}
 	}
 
-	getLists(listName: string, id?: string, allLists?: boolean) {
+	getLists(listName: string, id?: string, allLists?: boolean, rawParentID?: string) {
 		const matches = this.lists.get(listName)
 
 		// if we don't have a list by that name, we're done
@@ -50,15 +50,19 @@ export class ListManager {
 
 		const head = [...matches.values()][0]
 
-		// the provided id won't match the cache's ID so we have to compute the internal ID, using
-		// one of the matches to figure out the type of the list element
+		// rawParentID is already the full cache key (from __id field), use it directly.
+		// Otherwise compute the internal ID from the record type and provided id.
 		const { recordType } = head.lists[0]
-		const parentID = id ? this.cache._internal_unstable.id(recordType || '', id)! : this.rootID
+		const parentID = rawParentID
+			? rawParentID
+			: id
+				? this.cache._internal_unstable.id(recordType || '', id)!
+				: this.rootID
 
 		// if there is only one list with that name, return it
 		if (matches?.size === 1) {
 			// if there is no provided id, just use the first one
-			if (!id) {
+			if (!id && !rawParentID) {
 				return head
 			}
 
@@ -70,9 +74,9 @@ export class ListManager {
 		// have provided an id. If they meant to refer to the root object
 		// it would have been caught in the size === 1 check above since
 		// root's ID is fixed
-		if (!id) {
+		if (!id && !rawParentID) {
 			console.error(
-				`Found multiple instances of "${listName}". Please provide one of @parentID or @allLists directives to ` +
+				`Found multiple instances of "${listName}". Please provide one of @parentID, @listID, or @allLists directives to ` +
 					`help identify which list you want modify. For more information, visit this guide: https://www.houdinigraphql.com/api/graphql#parentidvalue-string `
 			)
 			return null

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -22,7 +22,7 @@ export class ListManager {
 
 	private listsByField: Map<string, Map<string, List[]>> = new Map()
 
-	// indexed by the opaque list ID exposed as __listID
+	// indexed by the opaque list ID exposed as __id
 	private listsByOpaqueID: Map<string, ListCollection> = new Map()
 
 	get(listName: string, id?: string, allLists?: boolean, skipMatches?: Set<string>) {
@@ -40,7 +40,7 @@ export class ListManager {
 		}
 	}
 
-	// look up a list by the opaque ID that was attached as __listID
+	// look up a list by the opaque ID that was attached as __id
 	getByOpaqueID(opaqueID: string, skipMatches?: Set<string>): ListCollection | null {
 		const collection = this.listsByOpaqueID.get(opaqueID)
 		if (!collection) return null
@@ -153,7 +153,7 @@ export class ListManager {
 		this.lists.get(list.name)!.get(parentID)!.lists.push(handler)
 		this.listsByField.get(parentID)!.get(list.key)!.push(handler)
 
-		// register the opaque ID lookup (format matches what getSelection injects as __listID)
+		// register the opaque ID lookup (format matches what getSelection injects as __id)
 		this.listsByOpaqueID.set(opaqueListID(parentID, name), this.lists.get(name)!.get(parentID)!)
 	}
 

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -18,9 +18,12 @@ export class ListManager {
 
 	private listsByField: Map<string, Map<string, List[]>> = new Map()
 
-	get(listName: string, id?: string, allLists?: boolean, skipMatches?: Set<string>, rawParentID?: string) {
+	// indexed by the opaque list ID exposed as __listID (format: "listName::parentCacheKey")
+	private listsByOpaqueID: Map<string, ListCollection> = new Map()
+
+	get(listName: string, id?: string, allLists?: boolean, skipMatches?: Set<string>) {
 		// get the list collection
-		const lists = this.getLists(listName, id, allLists, rawParentID)
+		const lists = this.getLists(listName, id, allLists)
 		if (!lists) {
 			return null
 		}
@@ -33,7 +36,17 @@ export class ListManager {
 		}
 	}
 
-	getLists(listName: string, id?: string, allLists?: boolean, rawParentID?: string) {
+	// look up a list by the opaque ID that was attached as __listID
+	getByOpaqueID(opaqueID: string, skipMatches?: Set<string>): ListCollection | null {
+		const collection = this.listsByOpaqueID.get(opaqueID)
+		if (!collection) return null
+		if (skipMatches) {
+			return new ListCollection(collection.lists.filter((list) => !skipMatches.has(list.fieldRef)))
+		}
+		return collection
+	}
+
+	getLists(listName: string, id?: string, allLists?: boolean) {
 		const matches = this.lists.get(listName)
 
 		// if we don't have a list by that name, we're done
@@ -50,19 +63,16 @@ export class ListManager {
 
 		const head = [...matches.values()][0]
 
-		// rawParentID is already the full cache key (from __id field), use it directly.
-		// Otherwise compute the internal ID from the record type and provided id.
+		// compute the internal ID from the record type and provided id
 		const { recordType } = head.lists[0]
-		const parentID = rawParentID
-			? rawParentID
-			: id
-				? this.cache._internal_unstable.id(recordType || '', id)!
-				: this.rootID
+		const parentID = id
+			? this.cache._internal_unstable.id(recordType || '', id)!
+			: this.rootID
 
 		// if there is only one list with that name, return it
 		if (matches?.size === 1) {
 			// if there is no provided id, just use the first one
-			if (!id && !rawParentID) {
+			if (!id) {
 				return head
 			}
 
@@ -74,7 +84,7 @@ export class ListManager {
 		// have provided an id. If they meant to refer to the root object
 		// it would have been caught in the size === 1 check above since
 		// root's ID is fixed
-		if (!id && !rawParentID) {
+		if (!id) {
 			console.error(
 				`Found multiple instances of "${listName}". Please provide one of @parentID, @listID, or @allLists directives to ` +
 					`help identify which list you want modify. For more information, visit this guide: https://www.houdinigraphql.com/api/graphql#parentidvalue-string `
@@ -87,7 +97,9 @@ export class ListManager {
 	}
 
 	remove(listName: string, id: string) {
-		this.lists.get(listName)?.delete(id || this.rootID)
+		const parentID = id || this.rootID
+		this.lists.get(listName)?.delete(parentID)
+		this.listsByOpaqueID.delete(`${listName}::${parentID}`)
 	}
 
 	add(list: {
@@ -136,6 +148,9 @@ export class ListManager {
 		// add the list to the collection
 		this.lists.get(list.name)!.get(parentID)!.lists.push(handler)
 		this.listsByField.get(parentID)!.get(list.key)!.push(handler)
+
+		// register the opaque ID lookup (format matches what getSelection injects as __listID)
+		this.listsByOpaqueID.set(`${name}::${parentID}`, this.lists.get(name)!.get(parentID)!)
 	}
 
 	removeIDFromAllLists(id: string, layer?: Layer) {
@@ -162,6 +177,7 @@ export class ListManager {
 			this.lists.get(list.name)?.get(list.recordID)?.deleteListWithKey(field)
 			if (this.lists.get(list.name)?.get(list.recordID)?.lists.length === 0) {
 				this.lists.get(list.name)?.delete(list.recordID)
+				this.listsByOpaqueID.delete(`${list.name}::${list.recordID}`)
 			}
 		}
 
@@ -172,6 +188,7 @@ export class ListManager {
 	reset() {
 		this.lists.clear()
 		this.listsByField.clear()
+		this.listsByOpaqueID.clear()
 	}
 }
 

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -4,6 +4,10 @@ import type { Cache } from './index.js'
 import type { Layer } from './storage.js'
 import { rootID } from './stuff.js'
 
+export function opaqueListID(parentID: string, listName: string): string {
+	return `${parentID}::${listName}`
+}
+
 export class ListManager {
 	rootID: string
 	cache: Cache
@@ -18,7 +22,7 @@ export class ListManager {
 
 	private listsByField: Map<string, Map<string, List[]>> = new Map()
 
-	// indexed by the opaque list ID exposed as __listID (format: "listName::parentCacheKey")
+	// indexed by the opaque list ID exposed as __listID
 	private listsByOpaqueID: Map<string, ListCollection> = new Map()
 
 	get(listName: string, id?: string, allLists?: boolean, skipMatches?: Set<string>) {
@@ -99,7 +103,7 @@ export class ListManager {
 	remove(listName: string, id: string) {
 		const parentID = id || this.rootID
 		this.lists.get(listName)?.delete(parentID)
-		this.listsByOpaqueID.delete(`${listName}::${parentID}`)
+		this.listsByOpaqueID.delete(opaqueListID(parentID, listName))
 	}
 
 	add(list: {
@@ -150,7 +154,7 @@ export class ListManager {
 		this.listsByField.get(parentID)!.get(list.key)!.push(handler)
 
 		// register the opaque ID lookup (format matches what getSelection injects as __listID)
-		this.listsByOpaqueID.set(`${name}::${parentID}`, this.lists.get(name)!.get(parentID)!)
+		this.listsByOpaqueID.set(opaqueListID(parentID, name), this.lists.get(name)!.get(parentID)!)
 	}
 
 	removeIDFromAllLists(id: string, layer?: Layer) {
@@ -177,7 +181,7 @@ export class ListManager {
 			this.lists.get(list.name)?.get(list.recordID)?.deleteListWithKey(field)
 			if (this.lists.get(list.name)?.get(list.recordID)?.lists.length === 0) {
 				this.lists.get(list.name)?.delete(list.recordID)
-				this.listsByOpaqueID.delete(`${list.name}::${list.recordID}`)
+				this.listsByOpaqueID.delete(opaqueListID(list.recordID, list.name))
 			}
 		}
 

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -45,7 +45,9 @@ export class ListManager {
 		const collection = this.listsByOpaqueID.get(opaqueID)
 		if (!collection) return null
 		if (skipMatches) {
-			return new ListCollection(collection.lists.filter((list) => !skipMatches.has(list.fieldRef)))
+			return new ListCollection(
+				collection.lists.filter((list) => !skipMatches.has(list.fieldRef))
+			)
 		}
 		return collection
 	}
@@ -69,9 +71,7 @@ export class ListManager {
 
 		// compute the internal ID from the record type and provided id
 		const { recordType } = head.lists[0]
-		const parentID = id
-			? this.cache._internal_unstable.id(recordType || '', id)!
-			: this.rootID
+		const parentID = id ? this.cache._internal_unstable.id(recordType || '', id)! : this.rootID
 
 		// if there is only one list with that name, return it
 		if (matches?.size === 1) {

--- a/packages/houdini/src/runtime/cache/tests/gc.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/gc.test.ts
@@ -440,5 +440,7 @@ test('ticks of gc clean up listsByOpaqueID', () => {
 		cache._internal_unstable.collectGarbage()
 	}
 
-	expect(cache._internal_unstable.lists.getByOpaqueID(opaqueListID('User:1', 'All_Users'))).toBeNull()
+	expect(
+		cache._internal_unstable.lists.getByOpaqueID(opaqueListID('User:1', 'All_Users'))
+	).toBeNull()
 })

--- a/packages/houdini/src/runtime/cache/tests/gc.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/gc.test.ts
@@ -3,6 +3,7 @@ import { test, vi, expect } from 'vitest'
 import { testConfigFile } from '../../../test/index.js'
 import type { SubscriptionSelection } from '../../types.js'
 import { Cache } from '../index.js'
+import { opaqueListID } from '../lists.js'
 
 const config = testConfigFile()
 config.cacheBufferSize! = 10
@@ -376,4 +377,68 @@ test('ticks of gc delete list handlers', () => {
 
 	// make sure we dont have a handler for the list
 	expect(cache._internal_unstable.lists.get('All_Users')).toBeNull()
+})
+
+test('ticks of gc clean up listsByOpaqueID', () => {
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						id: {
+							type: 'ID',
+							visible: true,
+							keyRaw: 'id',
+						},
+						friends: {
+							type: 'User',
+							visible: true,
+							keyRaw: 'friends',
+							list: {
+								name: 'All_Users',
+								connection: false,
+								type: 'User',
+								includeListID: true,
+							},
+							selection: {
+								fields: {
+									id: {
+										type: 'ID',
+										visible: true,
+										keyRaw: 'id',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cache.write({
+		selection,
+		data: {
+			viewer: {
+				id: '1',
+				friends: [{ id: '2' }],
+			},
+		},
+	})
+
+	const set = vi.fn()
+
+	cache.subscribe({ rootType: 'Query', set, selection }, {})
+	cache.unsubscribe({ rootType: 'Query', set, selection }, {})
+
+	for (const _ of Array.from({ length: config.cacheBufferSize! + 1 })) {
+		cache._internal_unstable.collectGarbage()
+	}
+
+	expect(cache._internal_unstable.lists.getByOpaqueID(opaqueListID('User:1', 'All_Users'))).toBeNull()
 })

--- a/packages/houdini/src/runtime/cache/tests/list.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/list.test.ts
@@ -6092,7 +6092,7 @@ test('@includeListID attaches opaque key to plain list array', () => {
 	})
 
 	const parentKey = cache._internal_unstable.id('User', '1')
-	expect((result.data?.friends as any).__listID).toBe(opaqueListID(parentKey!, 'All_Users'))
+	expect((result.data?.friends as any).__id).toBe(opaqueListID(parentKey!, 'All_Users'))
 })
 
 test('@includeListID attaches opaque key to connection object', () => {
@@ -6193,8 +6193,8 @@ test('@includeListID attaches opaque key to connection object', () => {
 	})
 
 	const parentKey = cache._internal_unstable.id('User', '1')
-	// the connection object (not an array) gets __listID
-	expect((result.data?.friendsConnection as any)?.__listID).toBe(
+	// the connection object (not an array) gets __id
+	expect((result.data?.friendsConnection as any)?.__id).toBe(
 		opaqueListID(parentKey!, 'Friends_Conn')
 	)
 })
@@ -6269,8 +6269,8 @@ test('@includeListID generates distinct keys for two lists on the same parent', 
 	})
 
 	const parentKey = cache._internal_unstable.id('User', '1')
-	const friendsListID = (result.data?.friends as any).__listID
-	const followersListID = (result.data?.followers as any).__listID
+	const friendsListID = (result.data?.friends as any).__id
+	const followersListID = (result.data?.followers as any).__id
 
 	// same parent, but different list names → different opaque IDs
 	expect(friendsListID).toBe(opaqueListID(parentKey!, 'My_Friends'))
@@ -6328,13 +6328,13 @@ test('@listID operation inserts into the correct list via opaque key', () => {
 		{}
 	)
 
-	// read to obtain the __listID value
+	// read to obtain the __id value
 	const readResult = cache.read({
 		selection: friendsSelection,
 		parent: cache._internal_unstable.id('User', '1')!,
 	})
 
-	const opaqueID = (readResult.data?.friends as any).__listID as string
+	const opaqueID = (readResult.data?.friends as any).__id as string
 	expect(opaqueID).toBe(opaqueListID(cache._internal_unstable.id('User', '1')!, 'All_Users'))
 
 	// use the opaque key in a mutation operation

--- a/packages/houdini/src/runtime/cache/tests/list.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/list.test.ts
@@ -4,6 +4,7 @@ import { testConfigFile } from '../../../test/index.js'
 import type { SubscriptionSelection } from '../../types.js'
 import { RefetchUpdateMode } from '../../types.js'
 import { Cache } from '../index.js'
+import { opaqueListID } from '../lists.js'
 
 const config = testConfigFile()
 
@@ -6033,4 +6034,303 @@ test("two operations referencing the same list don't commit twice", () => {
 			},
 		],
 	})
+})
+
+test('@includeListID attaches opaque key to plain list array', () => {
+	const cache = new Cache(config)
+
+	cache.write({
+		selection: {
+			fields: {
+				viewer: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'viewer',
+					selection: {
+						fields: {
+							id: { type: 'ID', visible: true, keyRaw: 'id' },
+							friends: {
+								type: 'User',
+								visible: true,
+								keyRaw: 'friends',
+								selection: {
+									fields: {
+										id: { type: 'ID', visible: true, keyRaw: 'id' },
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		data: { viewer: { id: '1', friends: [{ id: '2' }] } },
+	})
+
+	const result = cache.read({
+		selection: {
+			fields: {
+				friends: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'friends',
+					list: { name: 'All_Users', connection: false, type: 'User', includeListID: true },
+					selection: {
+						fields: {
+							id: { type: 'ID', visible: true, keyRaw: 'id' },
+						},
+					},
+				},
+			},
+		},
+		parent: cache._internal_unstable.id('User', '1')!,
+	})
+
+	const parentKey = cache._internal_unstable.id('User', '1')
+	expect((result.data?.friends as any).__listID).toBe(opaqueListID(parentKey!, 'All_Users'))
+})
+
+test('@includeListID attaches opaque key to connection object', () => {
+	const cache = new Cache(config)
+
+	cache.write({
+		selection: {
+			fields: {
+				viewer: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'viewer',
+					selection: {
+						fields: {
+							id: { type: 'ID', visible: true, keyRaw: 'id' },
+							friendsConnection: {
+								type: 'UserConnection',
+								visible: true,
+								keyRaw: 'friendsConnection',
+								selection: {
+									fields: {
+										edges: {
+											type: 'UserEdge',
+											visible: true,
+											keyRaw: 'edges',
+											selection: {
+												fields: {
+													node: {
+														type: 'User',
+														visible: true,
+														keyRaw: 'node',
+														nullable: true,
+														selection: {
+															fields: {
+																id: { type: 'ID', visible: true, keyRaw: 'id' },
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		data: { viewer: { id: '1', friendsConnection: { edges: [{ node: { id: '2' } }] } } },
+	})
+
+	const result = cache.read({
+		selection: {
+			fields: {
+				friendsConnection: {
+					type: 'UserConnection',
+					visible: true,
+					keyRaw: 'friendsConnection',
+					list: { name: 'Friends_Conn', connection: true, type: 'User', includeListID: true },
+					selection: {
+						fields: {
+							edges: {
+								type: 'UserEdge',
+								visible: true,
+								keyRaw: 'edges',
+								selection: {
+									fields: {
+										node: {
+											type: 'User',
+											visible: true,
+											keyRaw: 'node',
+											nullable: true,
+											selection: {
+												fields: { id: { type: 'ID', visible: true, keyRaw: 'id' } },
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		parent: cache._internal_unstable.id('User', '1')!,
+	})
+
+	const parentKey = cache._internal_unstable.id('User', '1')
+	// the connection object (not an array) gets __listID
+	expect((result.data?.friendsConnection as any)?.__listID).toBe(opaqueListID(parentKey!, 'Friends_Conn'))
+})
+
+test('@includeListID generates distinct keys for two lists on the same parent', () => {
+	const cache = new Cache(config)
+
+	cache.write({
+		selection: {
+			fields: {
+				viewer: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'viewer',
+					selection: {
+						fields: {
+							id: { type: 'ID', visible: true, keyRaw: 'id' },
+							friends: {
+								type: 'User',
+								visible: true,
+								keyRaw: 'friends',
+								selection: { fields: { id: { type: 'ID', visible: true, keyRaw: 'id' } } },
+							},
+							followers: {
+								type: 'User',
+								visible: true,
+								keyRaw: 'followers',
+								selection: { fields: { id: { type: 'ID', visible: true, keyRaw: 'id' } } },
+							},
+						},
+					},
+				},
+			},
+		},
+		data: { viewer: { id: '1', friends: [{ id: '2' }], followers: [{ id: '3' }] } },
+	})
+
+	const result = cache.read({
+		selection: {
+			fields: {
+				friends: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'friends',
+					list: { name: 'My_Friends', connection: false, type: 'User', includeListID: true },
+					selection: { fields: { id: { type: 'ID', visible: true, keyRaw: 'id' } } },
+				},
+				followers: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'followers',
+					list: { name: 'My_Followers', connection: false, type: 'User', includeListID: true },
+					selection: { fields: { id: { type: 'ID', visible: true, keyRaw: 'id' } } },
+				},
+			},
+		},
+		parent: cache._internal_unstable.id('User', '1')!,
+	})
+
+	const parentKey = cache._internal_unstable.id('User', '1')
+	const friendsListID = (result.data?.friends as any).__listID
+	const followersListID = (result.data?.followers as any).__listID
+
+	// same parent, but different list names → different opaque IDs
+	expect(friendsListID).toBe(opaqueListID(parentKey!, 'My_Friends'))
+	expect(followersListID).toBe(opaqueListID(parentKey!, 'My_Followers'))
+	expect(friendsListID).not.toBe(followersListID)
+})
+
+test('@listID operation inserts into the correct list via opaque key', () => {
+	const cache = new Cache(config)
+
+	const friendsSelection: SubscriptionSelection = {
+		fields: {
+			friends: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'friends',
+				list: { name: 'All_Users', connection: false, type: 'User', includeListID: true },
+				selection: {
+					fields: {
+						id: { type: 'ID', visible: true, keyRaw: 'id' },
+						firstName: { type: 'String', visible: true, keyRaw: 'firstName' },
+					},
+				},
+			},
+		},
+	}
+
+	cache.write({
+		selection: {
+			fields: {
+				viewer: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'viewer',
+					selection: {
+						fields: {
+							id: { type: 'ID', visible: true, keyRaw: 'id' },
+							...friendsSelection.fields,
+						},
+					},
+				},
+			},
+		},
+		data: { viewer: { id: '1', friends: [{ id: '2', firstName: 'Jean' }] } },
+	})
+
+	// subscribing registers the list in listsByOpaqueID
+	cache.subscribe(
+		{
+			rootType: 'User',
+			selection: friendsSelection,
+			parentID: cache._internal_unstable.id('User', '1')!,
+			set: vi.fn(),
+		},
+		{}
+	)
+
+	// read to obtain the __listID value
+	const readResult = cache.read({
+		selection: friendsSelection,
+		parent: cache._internal_unstable.id('User', '1')!,
+	})
+
+	const opaqueID = (readResult.data?.friends as any).__listID as string
+	expect(opaqueID).toBe(opaqueListID(cache._internal_unstable.id('User', '1')!, 'All_Users'))
+
+	// use the opaque key in a mutation operation
+	cache.write({
+		selection: {
+			fields: {
+				newUser: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'newUser',
+					operations: [
+						{
+							action: 'insert',
+							list: 'All_Users',
+							listID: { kind: 'String', value: opaqueID },
+						},
+					],
+					selection: {
+						fields: {
+							id: { type: 'ID', visible: true, keyRaw: 'id' },
+							firstName: { type: 'String', visible: true, keyRaw: 'firstName' },
+						},
+					},
+				},
+			},
+		},
+		data: { newUser: { id: '3', firstName: 'New User' } },
+	})
+
+	expect([...cache.list('All_Users', '1')]).toHaveLength(2)
 })

--- a/packages/houdini/src/runtime/cache/tests/list.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/list.test.ts
@@ -6074,7 +6074,12 @@ test('@includeListID attaches opaque key to plain list array', () => {
 					type: 'User',
 					visible: true,
 					keyRaw: 'friends',
-					list: { name: 'All_Users', connection: false, type: 'User', includeListID: true },
+					list: {
+						name: 'All_Users',
+						connection: false,
+						type: 'User',
+						includeListID: true,
+					},
 					selection: {
 						fields: {
 							id: { type: 'ID', visible: true, keyRaw: 'id' },
@@ -6122,7 +6127,11 @@ test('@includeListID attaches opaque key to connection object', () => {
 														nullable: true,
 														selection: {
 															fields: {
-																id: { type: 'ID', visible: true, keyRaw: 'id' },
+																id: {
+																	type: 'ID',
+																	visible: true,
+																	keyRaw: 'id',
+																},
 															},
 														},
 													},
@@ -6147,7 +6156,12 @@ test('@includeListID attaches opaque key to connection object', () => {
 					type: 'UserConnection',
 					visible: true,
 					keyRaw: 'friendsConnection',
-					list: { name: 'Friends_Conn', connection: true, type: 'User', includeListID: true },
+					list: {
+						name: 'Friends_Conn',
+						connection: true,
+						type: 'User',
+						includeListID: true,
+					},
 					selection: {
 						fields: {
 							edges: {
@@ -6162,7 +6176,9 @@ test('@includeListID attaches opaque key to connection object', () => {
 											keyRaw: 'node',
 											nullable: true,
 											selection: {
-												fields: { id: { type: 'ID', visible: true, keyRaw: 'id' } },
+												fields: {
+													id: { type: 'ID', visible: true, keyRaw: 'id' },
+												},
 											},
 										},
 									},
@@ -6178,7 +6194,9 @@ test('@includeListID attaches opaque key to connection object', () => {
 
 	const parentKey = cache._internal_unstable.id('User', '1')
 	// the connection object (not an array) gets __listID
-	expect((result.data?.friendsConnection as any)?.__listID).toBe(opaqueListID(parentKey!, 'Friends_Conn'))
+	expect((result.data?.friendsConnection as any)?.__listID).toBe(
+		opaqueListID(parentKey!, 'Friends_Conn')
+	)
 })
 
 test('@includeListID generates distinct keys for two lists on the same parent', () => {
@@ -6198,13 +6216,17 @@ test('@includeListID generates distinct keys for two lists on the same parent', 
 								type: 'User',
 								visible: true,
 								keyRaw: 'friends',
-								selection: { fields: { id: { type: 'ID', visible: true, keyRaw: 'id' } } },
+								selection: {
+									fields: { id: { type: 'ID', visible: true, keyRaw: 'id' } },
+								},
 							},
 							followers: {
 								type: 'User',
 								visible: true,
 								keyRaw: 'followers',
-								selection: { fields: { id: { type: 'ID', visible: true, keyRaw: 'id' } } },
+								selection: {
+									fields: { id: { type: 'ID', visible: true, keyRaw: 'id' } },
+								},
 							},
 						},
 					},
@@ -6221,14 +6243,24 @@ test('@includeListID generates distinct keys for two lists on the same parent', 
 					type: 'User',
 					visible: true,
 					keyRaw: 'friends',
-					list: { name: 'My_Friends', connection: false, type: 'User', includeListID: true },
+					list: {
+						name: 'My_Friends',
+						connection: false,
+						type: 'User',
+						includeListID: true,
+					},
 					selection: { fields: { id: { type: 'ID', visible: true, keyRaw: 'id' } } },
 				},
 				followers: {
 					type: 'User',
 					visible: true,
 					keyRaw: 'followers',
-					list: { name: 'My_Followers', connection: false, type: 'User', includeListID: true },
+					list: {
+						name: 'My_Followers',
+						connection: false,
+						type: 'User',
+						includeListID: true,
+					},
 					selection: { fields: { id: { type: 'ID', visible: true, keyRaw: 'id' } } },
 				},
 			},

--- a/packages/houdini/src/runtime/types.ts
+++ b/packages/houdini/src/runtime/types.ts
@@ -174,6 +174,10 @@ export type MutationOperation = {
 		kind: string
 		value: string
 	}
+	listID?: {
+		kind: string
+		value: string
+	}
 	position?: 'first' | 'last'
 	target?: 'all'
 	when?: ListWhen
@@ -220,6 +224,7 @@ export type SubscriptionSelection = Readonly<{
 				name: string
 				connection: boolean
 				type: string
+				includeListID?: boolean
 			}
 			loading?: LoadingSpec
 			directives?: readonly { name: string; arguments: ValueMap }[]

--- a/plugins/graphql/conventions.go
+++ b/plugins/graphql/conventions.go
@@ -20,6 +20,10 @@ const AllListsDirective = "allLists"
 
 const ParentIDDirective = "parentID"
 
+const IncludeListIDDirective = "includeListID"
+
+const ListIDDirective = "listID"
+
 const WhenDirective = "when"
 
 const WhenNotDirective = "when_not"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,11 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
 	test: {
-		include: ['./packages/*/src/**/*.test.{ts,js}', './site/**/*.test.{ts,js}'],
+		include: [
+			'./packages/*/src/**/*.test.{ts,js}',
+			'./packages/houdini-react/runtime/**/*.test.{ts,js}',
+			'./site/**/*.test.{ts,js}',
+		],
 		setupFiles: [path.resolve('./vitest.setup.ts')],
 		alias: {
 			$houdini: path.resolve('./packages/houdini/src'),


### PR DESCRIPTION
This PR adds a `GraphQLError` type that matches the spec and wires it through `QueryResult`, `RequestPayload`, and all the framework-specific handle/store types. The `extensions` field is typed via a new `App.GraphQLErrorExtensions` interface that users can augment to match their server's error shape.

Fixes #1520