### PR TITLE
List Upsert and List Update fragments

### DIFF
--- a/.changeset/upsert-list-operation.md
+++ b/.changeset/upsert-list-operation.md
@@ -1,0 +1,5 @@
+---
+'houdini': minor
+---
+
+add `_upsert` list operation (insert if absent, update in place if present) and `_update` fragment (write field values to an existing cached record without affecting list membership)

--- a/docs/shared/_partials/list-operations.mdx
+++ b/docs/shared/_partials/list-operations.mdx
@@ -69,7 +69,7 @@ Unlike `@parentID`, `@listID` works even when the parent has no usable ID in the
 
 ## Operations
 
-Once a list is tagged, Houdini generates a set of fragments named after the list — `All_Items_insert`, `All_Items_remove`, `All_Items_toggle` — that you spread into mutation responses to tell the cache what to do. The cache updates immediately on the client without waiting for a refetch.
+Once a list is tagged, Houdini generates a set of fragments named after the list — `All_Items_insert`, `All_Items_remove`, `All_Items_toggle`, `All_Items_upsert`, `All_Items_update` — that you spread into mutation responses to tell the cache what to do. The cache updates immediately on the client without waiting for a refetch.
 
 ### Inserting a record
 
@@ -122,6 +122,34 @@ mutation ToggleItem($input: ToggleItemInput!) {
 	toggleItem(input: $input) {
 		item {
 			...All_Items_toggle
+		}
+	}
+}
+```
+
+### Updating a record
+
+Use `_update` when you only want to write new field values to an existing cached record without touching list membership. This is useful when a subscription fires for a record you know is already in the cache.
+
+```graphql
+subscription MessageUpdated {
+	messageUpdated {
+		message {
+			...All_Messages_update
+		}
+	}
+}
+```
+
+### Upserting a record
+
+Use `_upsert` when you want to insert a record if it isn't already in the list, or update its data in place if it is. This is useful for real-time subscriptions where the same event can fire for both new and existing records.
+
+```graphql
+subscription MessageUpserted {
+	messageUpserted {
+		message {
+			...All_Messages_upsert
 		}
 	}
 }

--- a/docs/shared/_partials/list-operations.mdx
+++ b/docs/shared/_partials/list-operations.mdx
@@ -129,28 +129,24 @@ mutation ToggleItem($input: ToggleItemInput!) {
 
 ### Updating a record
 
-Use `_update` when you only want to write new field values to an existing cached record without touching list membership. This is useful when a subscription fires for a record you know is already in the cache.
+Use `_update` when you only want to write new field values to an existing cached record without touching list membership. This is useful when an update comes in for a record you know is already in the cache.
 
 ```graphql
-subscription MessageUpdated {
-	messageUpdated {
-		message {
-			...All_Messages_update
-		}
+mutation UpdateMessage($id: ID!) {
+	updateMessage(id: $id) {
+		...All_Messages_update
 	}
 }
 ```
 
 ### Upserting a record
 
-Use `_upsert` when you want to insert a record if it isn't already in the list, or update its data in place if it is. This is useful for real-time subscriptions where the same event can fire for both new and existing records.
+Use `_upsert` when you want to insert a record if it isn't already in the list, or update its data in place if it is. This avoids duplicates when the same update can apply to both new and existing records.
 
 ```graphql
-subscription MessageUpserted {
-	messageUpserted {
-		message {
-			...All_Messages_upsert
-		}
+mutation UpsertMessage($input: MessageInput!) {
+	upsertMessage(input: $input) {
+		...All_Messages_upsert
 	}
 }
 ```

--- a/e2e/react/src/routes/list-operations/update/+page.gql
+++ b/e2e/react/src/routes/list-operations/update/+page.gql
@@ -1,0 +1,18 @@
+query UpdateFragmentTest {
+	usersList(snapshot: "UpdateFragmentTest", limit: 1) @list(name: "UpdateFragmentTest") {
+		id
+		name
+	}
+}
+
+mutation UpdateExisting($id: ID!, $name: String!) {
+	updateUserByID(id: $id, snapshot: "UpdateFragmentTest", name: $name) {
+		...UpdateFragmentTest_update
+	}
+}
+
+mutation UpdateNonMember($name: String!, $birthDate: DateTime!) {
+	addUser(snapshot: "UpdateFragmentTest", name: $name, birthDate: $birthDate) {
+		...UpdateFragmentTest_update
+	}
+}

--- a/e2e/react/src/routes/list-operations/update/+page.gql
+++ b/e2e/react/src/routes/list-operations/update/+page.gql
@@ -4,15 +4,3 @@ query UpdateFragmentTest {
 		name
 	}
 }
-
-mutation UpdateExisting($id: ID!, $name: String!) {
-	updateUserByID(id: $id, snapshot: "UpdateFragmentTest", name: $name) {
-		...UpdateFragmentTest_update
-	}
-}
-
-mutation UpdateNonMember($name: String!, $birthDate: DateTime!) {
-	addUser(snapshot: "UpdateFragmentTest", name: $name, birthDate: $birthDate) {
-		...UpdateFragmentTest_update
-	}
-}

--- a/e2e/react/src/routes/list-operations/update/+page.tsx
+++ b/e2e/react/src/routes/list-operations/update/+page.tsx
@@ -1,0 +1,59 @@
+import { useMutation, graphql } from '$houdini'
+
+import { PageProps } from './$types'
+
+export default function UpdateFragmentTestView({ UpdateFragmentTest }: PageProps) {
+	const users = UpdateFragmentTest?.usersList ?? []
+	const firstUserId = users[0]?.id
+
+	const [updateExisting] = useMutation(
+		graphql(`
+			mutation UpdateExisting($id: ID!, $name: String!) {
+				updateUserByID(id: $id, snapshot: "UpdateFragmentTest", name: $name) {
+					...UpdateFragmentTest_update
+				}
+			}
+		`)
+	)
+
+	const [updateNonMember] = useMutation(
+		graphql(`
+			mutation UpdateNonMember($name: String!, $birthDate: DateTime!) {
+				addUser(snapshot: "UpdateFragmentTest", name: $name, birthDate: $birthDate) {
+					...UpdateFragmentTest_update
+				}
+			}
+		`)
+	)
+
+	return (
+		<>
+			<ul>
+				{users.map((user) => (
+					<li key={user.id} data-testid="user-row">
+						{user.name}
+					</li>
+				))}
+			</ul>
+			<button
+				data-test-action="update-existing"
+				onClick={() => {
+					if (!firstUserId) return
+					updateExisting({ variables: { id: firstUserId, name: 'updated name' } })
+				}}
+			>
+				Update Existing
+			</button>
+			<button
+				data-test-action="update-non-member"
+				onClick={() =>
+					updateNonMember({
+						variables: { name: 'Should Not Appear', birthDate: new Date('2000-01-01') },
+					})
+				}
+			>
+				Update Non-Member
+			</button>
+		</>
+	)
+}

--- a/e2e/react/src/routes/list-operations/update/test.ts
+++ b/e2e/react/src/routes/list-operations/update/test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test'
+
+import { routes } from '~/utils/routes'
+import { sleep } from '~/utils/sleep'
+import { goto } from '~/utils/testsHelper.js'
+
+test('_update updates existing list member in place', async ({ page }) => {
+	await goto(page, routes.list_operations_update)
+
+	const rows = page.getByTestId('user-row')
+	const initialCount = await rows.count()
+	expect(initialCount).toBeGreaterThan(0)
+
+	const initialFirstName = await rows.first().textContent()
+
+	await page.click('[data-test-action="update-existing"]')
+	await sleep(300)
+
+	expect(await rows.count()).toBe(initialCount)
+	expect(await rows.first().textContent()).toBe('updated name')
+	expect(await rows.first().textContent()).not.toBe(initialFirstName)
+})
+
+test('_update does not insert records that are not in the list', async ({ page }) => {
+	await goto(page, routes.list_operations_update)
+
+	const rows = page.getByTestId('user-row')
+	const initialCount = await rows.count()
+
+	await page.click('[data-test-action="update-non-member"]')
+	await sleep(300)
+
+	expect(await rows.count()).toBe(initialCount)
+	expect(page.getByText('Should Not Appear')).not.toBeVisible()
+})

--- a/e2e/react/src/routes/list-operations/upsert/+page.gql
+++ b/e2e/react/src/routes/list-operations/upsert/+page.gql
@@ -1,0 +1,18 @@
+query UpsertFragmentTest {
+	usersList(snapshot: "UpsertFragmentTest") @list(name: "UpsertFragmentTest") {
+		id
+		name
+	}
+}
+
+mutation UpsertExisting($id: ID!, $name: String!) {
+	updateUserByID(id: $id, snapshot: "UpsertFragmentTest", name: $name) {
+		...UpsertFragmentTest_upsert
+	}
+}
+
+mutation UpsertNew($name: String!, $birthDate: DateTime!) {
+	addUser(snapshot: "UpsertFragmentTest", name: $name, birthDate: $birthDate) {
+		...UpsertFragmentTest_upsert @prepend
+	}
+}

--- a/e2e/react/src/routes/list-operations/upsert/+page.gql
+++ b/e2e/react/src/routes/list-operations/upsert/+page.gql
@@ -4,15 +4,3 @@ query UpsertFragmentTest {
 		name
 	}
 }
-
-mutation UpsertExisting($id: ID!, $name: String!) {
-	updateUserByID(id: $id, snapshot: "UpsertFragmentTest", name: $name) {
-		...UpsertFragmentTest_upsert
-	}
-}
-
-mutation UpsertNew($name: String!, $birthDate: DateTime!) {
-	addUser(snapshot: "UpsertFragmentTest", name: $name, birthDate: $birthDate) {
-		...UpsertFragmentTest_upsert @prepend
-	}
-}

--- a/e2e/react/src/routes/list-operations/upsert/+page.tsx
+++ b/e2e/react/src/routes/list-operations/upsert/+page.tsx
@@ -1,0 +1,59 @@
+import { useMutation, graphql } from '$houdini'
+
+import { PageProps } from './$types'
+
+export default function UpsertFragmentTestView({ UpsertFragmentTest }: PageProps) {
+	const users = UpsertFragmentTest?.usersList ?? []
+	const firstUserId = users[0]?.id
+
+	const [updateExisting] = useMutation(
+		graphql(`
+			mutation UpsertExisting($id: ID!, $name: String!) {
+				updateUserByID(id: $id, snapshot: "UpsertFragmentTest", name: $name) {
+					...UpsertFragmentTest_upsert
+				}
+			}
+		`)
+	)
+
+	const [addNew] = useMutation(
+		graphql(`
+			mutation UpsertNew($name: String!, $birthDate: DateTime!) {
+				addUser(snapshot: "UpsertFragmentTest", name: $name, birthDate: $birthDate) {
+					...UpsertFragmentTest_upsert @prepend
+				}
+			}
+		`)
+	)
+
+	return (
+		<>
+			<ul>
+				{users.map((user) => (
+					<li key={user.id} data-testid="user-row">
+						{user.name}
+					</li>
+				))}
+			</ul>
+			<button
+				data-test-action="update-existing"
+				onClick={() => {
+					if (!firstUserId) return
+					updateExisting({ variables: { id: firstUserId, name: 'updated name' } })
+				}}
+			>
+				Update Existing
+			</button>
+			<button
+				data-test-action="add-new"
+				onClick={() =>
+					addNew({
+						variables: { name: 'Brand New User', birthDate: new Date('2000-01-01') },
+					})
+				}
+			>
+				Add New
+			</button>
+		</>
+	)
+}

--- a/e2e/react/src/routes/list-operations/upsert/test.ts
+++ b/e2e/react/src/routes/list-operations/upsert/test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test'
+
+import { routes } from '~/utils/routes'
+import { sleep } from '~/utils/sleep'
+import { goto } from '~/utils/testsHelper.js'
+
+test('_upsert updates existing list member without duplicating', async ({ page }) => {
+	await goto(page, routes.list_operations_upsert)
+
+	const rows = page.getByTestId('user-row')
+	const initialCount = await rows.count()
+	expect(initialCount).toBeGreaterThan(0)
+
+	const initialFirstName = await rows.first().textContent()
+
+	await page.click('[data-test-action="update-existing"]')
+	await sleep(300)
+
+	expect(await rows.count()).toBe(initialCount)
+	expect(await rows.first().textContent()).toBe('updated name')
+	expect(await rows.first().textContent()).not.toBe(initialFirstName)
+})
+
+test('_upsert inserts new record when not already in list', async ({ page }) => {
+	await goto(page, routes.list_operations_upsert)
+
+	const rows = page.getByTestId('user-row')
+	const initialCount = await rows.count()
+
+	await page.click('[data-test-action="add-new"]')
+	await sleep(300)
+
+	expect(await rows.count()).toBe(initialCount + 1)
+	expect(await rows.first().textContent()).toBe('Brand New User')
+})

--- a/e2e/react/src/utils/routes.ts
+++ b/e2e/react/src/utils/routes.ts
@@ -19,4 +19,6 @@ export const routes = {
 	optimistic_keys: '/optimistic-keys',
 	node_plugin: '/node-plugin',
 	list_id: '/list-id',
+	list_operations_upsert: '/list-operations/upsert',
+	list_operations_update: '/list-operations/update',
 } as const

--- a/packages/houdini-core/plugin/documents/artifacts/selection.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection.go
@@ -1537,6 +1537,9 @@ func extractOperation(
 		case strings.Contains(selection.FieldName, graphql.ListOperationSuffixToggle):
 			listName = stripSuffix(selection.FieldName, graphql.ListOperationSuffixToggle)
 			action = "toggle"
+		case strings.Contains(selection.FieldName, graphql.ListOperationSuffixUpsert):
+			listName = stripSuffix(selection.FieldName, graphql.ListOperationSuffixUpsert)
+			action = "upsert"
 
 		default:
 			// the fragment doesn't end in one of the magic prefixes

--- a/packages/houdini-core/plugin/lists/insertOperations.go
+++ b/packages/houdini-core/plugin/lists/insertOperations.go
@@ -282,8 +282,8 @@ func InsertOperationDocuments(
 		// let's collect the documents we inserted so we can copy the argument values over to both documents
 		copyTargets := []int64{}
 
-		// _insert and _toggle both get the full selection set
-		for _, suffixes := range []string{graphql.ListOperationSuffixInsert, graphql.ListOperationSuffixToggle} {
+		// _insert, _toggle, _upsert, and _update all get the full selection set
+		for _, suffixes := range []string{graphql.ListOperationSuffixInsert, graphql.ListOperationSuffixToggle, graphql.ListOperationSuffixUpsert, graphql.ListOperationSuffixUpdate} {
 			err := db.ExecStatement(insertDocument, map[string]any{
 				"name":           fmt.Sprintf("%s%s", name, suffixes),
 				"kind":           "fragment",

--- a/packages/houdini-core/plugin/lists/validate.go
+++ b/packages/houdini-core/plugin/lists/validate.go
@@ -436,7 +436,7 @@ func ValidateParentID(
 
 		-- Define a table of acceptable suffixes
 		suffixes(sfx) AS (
-			VALUES ($insert_prefix), ($toggle_prefix), ($remove_prefix)
+			VALUES ($insert_prefix), ($toggle_prefix), ($remove_prefix), ($upsert_prefix), ($update_prefix)
 		),
 
 		-- precompute the list of operation names that could refer to a constrainted list
@@ -470,6 +470,8 @@ func ValidateParentID(
 		"insert_prefix":      graphql.ListOperationSuffixInsert,
 		"toggle_prefix":      graphql.ListOperationSuffixToggle,
 		"remove_prefix":      graphql.ListOperationSuffixRemove,
+		"upsert_prefix":      graphql.ListOperationSuffixUpsert,
+		"update_prefix":      graphql.ListOperationSuffixUpdate,
 		"parentID_directive": graphql.ParentIDDirective,
 		"allLists_directive": graphql.AllListsDirective,
 	}
@@ -920,7 +922,7 @@ func validateFragmentSpreads(
 	// we need a query that looks for references to fragments in selection that don't exist in the database
 	query := `
 		WITH suffixes(sfx) AS (
-			VALUES ($insert_prefix), ($remove_prefix), ($toggle_prefix)
+			VALUES ($insert_prefix), ($remove_prefix), ($toggle_prefix), ($upsert_prefix), ($update_prefix)
 		),
 		discovered_fragments AS (
 			SELECT
@@ -948,6 +950,8 @@ func validateFragmentSpreads(
 		"insert_prefix": graphql.ListOperationSuffixInsert,
 		"remove_prefix": graphql.ListOperationSuffixRemove,
 		"toggle_prefix": graphql.ListOperationSuffixToggle,
+		"upsert_prefix": graphql.ListOperationSuffixUpsert,
+		"update_prefix": graphql.ListOperationSuffixUpdate,
 	}
 
 	err := db.StepQuery(ctx, query, bindings, func(stmt plugins.Row) {

--- a/packages/houdini-core/plugin/schema/generateDefinitions.go
+++ b/packages/houdini-core/plugin/schema/generateDefinitions.go
@@ -263,6 +263,8 @@ func generateDocumentsFile(
 		    WHERE d.name = dl.name || '_insert'
 		       OR d.name = dl.name || '_toggle'
 		       OR d.name = dl.name || '_remove'
+		       OR d.name = dl.name || '_upsert'
+		       OR d.name = dl.name || '_update'
 		  )
 		ORDER BY d.name
 	`, nil, func(stmt plugins.Row) {

--- a/packages/houdini-core/plugin/schema/generateDefinitions_test.go
+++ b/packages/houdini-core/plugin/schema/generateDefinitions_test.go
@@ -170,6 +170,14 @@ fragment Friends_toggle on User {
     id
 }
 
+fragment Friends_update on User {
+    id
+}
+
+fragment Friends_upsert on User {
+    id
+}
+
 `,
 				},
 			},
@@ -204,6 +212,14 @@ fragment Friends_toggle on User {
     id
 }
 
+fragment Friends_update on User {
+    id
+}
+
+fragment Friends_upsert on User {
+    id
+}
+
 fragment theList_insert on CustomIdType {
     foo
     bar
@@ -215,6 +231,16 @@ fragment theList_remove on CustomIdType {
 }
 
 fragment theList_toggle on CustomIdType {
+    foo
+    bar
+}
+
+fragment theList_update on CustomIdType {
+    foo
+    bar
+}
+
+fragment theList_upsert on CustomIdType {
     foo
     bar
 }

--- a/packages/houdini-core/runtime/public/list.test.ts
+++ b/packages/houdini-core/runtime/public/list.test.ts
@@ -39,7 +39,7 @@ test('upsert inserts record when not already in list', () => {
 	})
 	cache._internal_unstable.subscribe({
 		rootType: 'Query',
-		set: vi.fn(),
+		onMessage: vi.fn(),
 		selection: friendsSelection,
 	})
 
@@ -73,8 +73,8 @@ test('upsert updates existing record when already in list', () => {
 		},
 	})
 
-	const set = vi.fn()
-	cache._internal_unstable.subscribe({ rootType: 'Query', set, selection: friendsSelection })
+	const onMessage = vi.fn()
+	cache._internal_unstable.subscribe({ rootType: 'Query', onMessage, selection: friendsSelection })
 
 	const user = cache.get('User', { id: '3' })
 	user.write({
@@ -91,13 +91,16 @@ test('upsert updates existing record when already in list', () => {
 	expect([...list]).toEqual(['User:2', 'User:3'])
 
 	// subscriber receives the updated field
-	expect(set).toHaveBeenLastCalledWith({
-		viewer: {
-			id: '1',
-			friends: [
-				{ id: '2', firstName: 'jane' },
-				{ id: '3', firstName: 'mary-updated' },
-			],
-		},
-	})
+	expect(onMessage).toHaveBeenLastCalledWith(
+		expect.objectContaining({
+			kind: 'update',
+			data: expect.objectContaining({
+				viewer: expect.objectContaining({
+					friends: expect.arrayContaining([
+						expect.objectContaining({ firstName: 'mary-updated' }),
+					]),
+				}),
+			}),
+		})
+	)
 })

--- a/packages/houdini-core/runtime/public/list.test.ts
+++ b/packages/houdini-core/runtime/public/list.test.ts
@@ -74,7 +74,11 @@ test('upsert updates existing record when already in list', () => {
 	})
 
 	const onMessage = vi.fn()
-	cache._internal_unstable.subscribe({ rootType: 'Query', onMessage, selection: friendsSelection })
+	cache._internal_unstable.subscribe({
+		rootType: 'Query',
+		onMessage,
+		selection: friendsSelection,
+	})
 
 	const user = cache.get('User', { id: '3' })
 	user.write({

--- a/packages/houdini-core/runtime/public/list.test.ts
+++ b/packages/houdini-core/runtime/public/list.test.ts
@@ -37,11 +37,17 @@ test('upsert inserts record when not already in list', () => {
 		selection: friendsSelection,
 		data: { viewer: { id: '1', friends: [{ id: '2', firstName: 'jane' }] } },
 	})
-	cache._internal_unstable.subscribe({ rootType: 'Query', set: vi.fn(), selection: friendsSelection })
+	cache._internal_unstable.subscribe({
+		rootType: 'Query',
+		set: vi.fn(),
+		selection: friendsSelection,
+	})
 
 	const user = cache.get('User', { id: '3' })
 	user.write({
-		fragment: testFragment({ fields: { firstName: { type: 'String', visible: true, keyRaw: 'firstName' } } }),
+		fragment: testFragment({
+			fields: { firstName: { type: 'String', visible: true, keyRaw: 'firstName' } },
+		}),
 		data: { firstName: 'mary' },
 	})
 
@@ -72,7 +78,9 @@ test('upsert updates existing record when already in list', () => {
 
 	const user = cache.get('User', { id: '3' })
 	user.write({
-		fragment: testFragment({ fields: { firstName: { type: 'String', visible: true, keyRaw: 'firstName' } } }),
+		fragment: testFragment({
+			fields: { firstName: { type: 'String', visible: true, keyRaw: 'firstName' } },
+		}),
 		data: { firstName: 'mary-updated' },
 	})
 

--- a/packages/houdini-core/runtime/public/list.test.ts
+++ b/packages/houdini-core/runtime/public/list.test.ts
@@ -1,0 +1,95 @@
+import { test, expect, vi } from 'vitest'
+
+import type { SubscriptionSelection } from 'houdini/runtime/types'
+import { testCache, testFragment } from './tests/test.js'
+
+const friendsSelection: SubscriptionSelection = {
+	fields: {
+		viewer: {
+			type: 'User',
+			visible: true,
+			keyRaw: 'viewer',
+			selection: {
+				fields: {
+					id: { type: 'ID', visible: true, keyRaw: 'id' },
+					friends: {
+						type: 'User',
+						visible: true,
+						keyRaw: 'friends',
+						list: { name: 'All_Users', connection: false, type: 'User' },
+						selection: {
+							fields: {
+								id: { type: 'ID', visible: true, keyRaw: 'id' },
+								firstName: { type: 'String', visible: true, keyRaw: 'firstName' },
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+test('upsert inserts record when not already in list', () => {
+	const cache = testCache()
+
+	cache._internal_unstable.write({
+		selection: friendsSelection,
+		data: { viewer: { id: '1', friends: [{ id: '2', firstName: 'jane' }] } },
+	})
+	cache._internal_unstable.subscribe({ rootType: 'Query', set: vi.fn(), selection: friendsSelection })
+
+	const user = cache.get('User', { id: '3' })
+	user.write({
+		fragment: testFragment({ fields: { firstName: { type: 'String', visible: true, keyRaw: 'firstName' } } }),
+		data: { firstName: 'mary' },
+	})
+
+	const list = cache.list('All_Users')
+	list.upsert('last', user)
+
+	expect([...list]).toEqual(['User:2', 'User:3'])
+})
+
+test('upsert updates existing record when already in list', () => {
+	const cache = testCache()
+
+	cache._internal_unstable.write({
+		selection: friendsSelection,
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{ id: '2', firstName: 'jane' },
+					{ id: '3', firstName: 'mary' },
+				],
+			},
+		},
+	})
+
+	const set = vi.fn()
+	cache._internal_unstable.subscribe({ rootType: 'Query', set, selection: friendsSelection })
+
+	const user = cache.get('User', { id: '3' })
+	user.write({
+		fragment: testFragment({ fields: { firstName: { type: 'String', visible: true, keyRaw: 'firstName' } } }),
+		data: { firstName: 'mary-updated' },
+	})
+
+	const list = cache.list('All_Users')
+	list.upsert('last', user)
+
+	// list must not grow
+	expect([...list]).toEqual(['User:2', 'User:3'])
+
+	// subscriber receives the updated field
+	expect(set).toHaveBeenLastCalledWith({
+		viewer: {
+			id: '1',
+			friends: [
+				{ id: '2', firstName: 'jane' },
+				{ id: '3', firstName: 'mary-updated' },
+			],
+		},
+	})
+})

--- a/packages/houdini-core/runtime/public/list.ts
+++ b/packages/houdini-core/runtime/public/list.ts
@@ -81,6 +81,19 @@ export class ListCollection<Def extends CacheTypeDef, ListName extends ValidList
 		}
 	}
 
+	upsert(where: 'first' | 'last', ...records: ListType<Def, ListName>[]) {
+		if (!this.#collection) {
+			return
+		}
+
+		const { selection, data } = this.#listOperationPayload(records)
+		for (const entry of data) {
+			if (entry) {
+				this.#collection.upsertInList(selection, entry, {}, where)
+			}
+		}
+	}
+
 	when(filter: ListFilters<Def, ListName>): ListCollection<Def, ListName> {
 		if (!this.#collection) {
 			return this

--- a/packages/houdini-core/runtime/public/tests/list.test.ts
+++ b/packages/houdini-core/runtime/public/tests/list.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, vi } from 'vitest'
 
-import type { SubscriptionSelection } from '../../lib'
+import type { SubscriptionSelection } from 'houdini/runtime/types'
 import { testCache, testFragment } from './test.js'
 
 test('list.append accepts record proxies', () => {

--- a/packages/houdini-core/runtime/public/tests/record.test.ts
+++ b/packages/houdini-core/runtime/public/tests/record.test.ts
@@ -1,6 +1,10 @@
 import { test, expect } from 'vitest'
 
-import { ArtifactKind, type FragmentArtifact, type SubscriptionSelection } from 'houdini/runtime/types'
+import {
+	ArtifactKind,
+	type FragmentArtifact,
+	type SubscriptionSelection,
+} from 'houdini/runtime/types'
 import { testCache, testFragment } from './test.js'
 
 test('can read fragment', () => {

--- a/packages/houdini-core/runtime/public/tests/record.test.ts
+++ b/packages/houdini-core/runtime/public/tests/record.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest'
 
-import { ArtifactKind, type FragmentArtifact, type SubscriptionSelection } from '../../lib'
+import { ArtifactKind, type FragmentArtifact, type SubscriptionSelection } from 'houdini/runtime/types'
 import { testCache, testFragment } from './test.js'
 
 test('can read fragment', () => {

--- a/packages/houdini-core/runtime/public/tests/stale.test.ts
+++ b/packages/houdini-core/runtime/public/tests/stale.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest'
 
-import { ArtifactKind, type FragmentArtifact } from '../../lib'
+import { ArtifactKind, type FragmentArtifact } from 'houdini/runtime/types'
 import type { Cache } from '../cache.js'
 import { type CacheTypeDefTest, testCache } from './test.js'
 

--- a/packages/houdini-core/runtime/public/tests/test.ts
+++ b/packages/houdini-core/runtime/public/tests/test.ts
@@ -1,11 +1,11 @@
 import { testConfigFile } from '../../../../houdini/src/test/index.js'
-import { Cache as _Cache } from '../../cache/cache'
+import { Cache as _Cache } from '../../../../houdini/src/runtime/cache/index.js'
 import {
 	ArtifactKind,
 	type SubscriptionSelection,
 	type FragmentArtifact,
 	type QueryArtifact,
-} from '../../lib'
+} from '../../../../houdini/src/runtime/types.js'
 import { Cache } from '../cache.js'
 import type { Record } from '../record.js'
 

--- a/packages/houdini/src/runtime/cache/index.ts
+++ b/packages/houdini/src/runtime/cache/index.ts
@@ -1031,6 +1031,32 @@ class CacheInternal {
 						})
 					}
 
+					// upsert: insert if not present, update if already in list
+					else if (
+						operation.action === 'upsert' &&
+						target instanceof Object &&
+						fieldSelection &&
+						operation.list
+					) {
+						const upsertList = opaqueListID
+							? this.lists.getByOpaqueID(opaqueListID, processedOperations)!
+							: this.cache.list(
+									operation.list,
+									parentID,
+									operation.target === 'all',
+									processedOperations
+								)
+						upsertList
+							.when(operation.when)
+							.upsertInList(
+								fieldSelection,
+								target,
+								variables,
+								operation.position || 'last',
+								layer
+							)
+					}
+
 					// remove object from list
 					else if (
 						operation.action === 'remove' &&

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -571,6 +571,57 @@ export class List {
 		}
 	}
 
+	upsertInList(
+		selection: SubscriptionSelection,
+		data: {},
+		variables: {} = {},
+		where: 'first' | 'last',
+		layer?: Layer
+	) {
+		const listType = this.listType(data)
+		const dataID = this.cache._internal_unstable.id(listType, data)
+
+		if (!this.validateWhen() || !dataID) {
+			return
+		}
+
+		// check if the item is already in the list
+		let isInList = false
+		if (this.connection) {
+			const { value: embeddedConnection } = this.cache._internal_unstable.storage.get(
+				this.recordID,
+				this.key
+			)
+			if (embeddedConnection) {
+				const { value: edges } = this.cache._internal_unstable.storage.get(
+					embeddedConnection as string,
+					'edges'
+				)
+				for (const edge of flatten(edges as NestedList) || []) {
+					if (!edge) continue
+					const { value: nodeID } = this.cache._internal_unstable.storage.get(
+						edge as string,
+						'node'
+					)
+					if (nodeID === dataID) {
+						isInList = true
+						break
+					}
+				}
+			}
+		} else {
+			const { value } = this.cache._internal_unstable.storage.get(this.recordID, this.key)
+			isInList = !!(value as NestedList)?.includes(dataID)
+		}
+
+		if (isInList) {
+			// item already in list — just write to update the record data
+			this.cache.write({ selection, data, variables, layer: layer?.id })
+		} else {
+			this.addToList(selection, data, variables, where, layer)
+		}
+	}
+
 	// iterating over the list handler should be the same as iterating over
 	// the underlying linked list
 	*[Symbol.iterator]() {
@@ -644,6 +695,12 @@ export class ListCollection {
 	toggleElement(...args: Parameters<List['toggleElement']>) {
 		this.lists.forEach((list) => {
 			list.toggleElement(...args)
+		})
+	}
+
+	upsertInList(...args: Parameters<List['upsertInList']>) {
+		this.lists.forEach((list) => {
+			list.upsertInList(...args)
 		})
 	}
 

--- a/packages/houdini/src/runtime/cache/tests/list.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/list.test.ts
@@ -6666,6 +6666,7 @@ test('@listID operation inserts into the correct list via opaque key', () => {
 
 	expect([...cache.list('All_Users', '1')]).toHaveLength(2)
 })
+
 test('writing the same data with connections should not cause additional links to be inserted', function () {
 	// instantiate a cache
 	const cache = new Cache(config)
@@ -6854,4 +6855,248 @@ test('shrinking a connection cleans up the orphaned edge records', function () {
 	const post = Object.keys(cache._internal_unstable.storage.data[0].links).length
 
 	expect(post).toBe(pre - 2)
+})
+
+test('upsert list inserts when not present', () => {
+	const cache = new Cache(config)
+
+	cache.write({
+		selection: {
+			fields: {
+				viewer: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'viewer',
+					selection: {
+						fields: {
+							id: { type: 'ID', visible: true, keyRaw: 'id' },
+							friends: {
+								type: 'User',
+								visible: true,
+								keyRaw: 'friends',
+								list: { name: 'All_Users', connection: false, type: 'User' },
+								selection: {
+									fields: {
+										id: { type: 'ID', visible: true, keyRaw: 'id' },
+										firstName: { type: 'String', visible: true, keyRaw: 'firstName' },
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		data: { viewer: { id: '1', friends: [{ id: '5', firstName: 'Alice' }] } },
+	})
+
+	cache.subscribe(
+		{
+			rootType: 'User',
+			selection: {
+				fields: {
+					friends: {
+						type: 'User',
+						visible: true,
+						keyRaw: 'friends',
+						list: { name: 'All_Users', connection: false, type: 'User' },
+						selection: {
+							fields: {
+								id: { type: 'ID', visible: true, keyRaw: 'id' },
+								firstName: { type: 'String', visible: true, keyRaw: 'firstName' },
+							},
+						},
+					},
+				},
+			},
+			parentID: cache._internal_unstable.id('User', '1')!,
+			set: vi.fn(),
+		},
+		{}
+	)
+
+	cache.write({
+		selection: {
+			fields: {
+				newUser: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'newUser',
+					operations: [{ action: 'upsert', list: 'All_Users' }],
+					selection: {
+						fields: {
+							id: { type: 'ID', visible: true, keyRaw: 'id' },
+							firstName: { type: 'String', visible: true, keyRaw: 'firstName' },
+						},
+					},
+				},
+			},
+		},
+		data: { newUser: { id: '3', firstName: 'Bob' } },
+	})
+
+	expect([...cache.list('All_Users', '1')]).toEqual(['User:5', 'User:3'])
+})
+
+test('upsert list does not duplicate when already present', () => {
+	const cache = new Cache(config)
+
+	cache.write({
+		selection: {
+			fields: {
+				viewer: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'viewer',
+					selection: {
+						fields: {
+							id: { type: 'ID', visible: true, keyRaw: 'id' },
+							friends: {
+								type: 'User',
+								visible: true,
+								keyRaw: 'friends',
+								list: { name: 'All_Users', connection: false, type: 'User' },
+								selection: {
+									fields: {
+										id: { type: 'ID', visible: true, keyRaw: 'id' },
+										firstName: { type: 'String', visible: true, keyRaw: 'firstName' },
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		data: { viewer: { id: '1', friends: [{ id: '5', firstName: 'Alice' }] } },
+	})
+
+	cache.subscribe(
+		{
+			rootType: 'User',
+			selection: {
+				fields: {
+					friends: {
+						type: 'User',
+						visible: true,
+						keyRaw: 'friends',
+						list: { name: 'All_Users', connection: false, type: 'User' },
+						selection: {
+							fields: {
+								id: { type: 'ID', visible: true, keyRaw: 'id' },
+								firstName: { type: 'String', visible: true, keyRaw: 'firstName' },
+							},
+						},
+					},
+				},
+			},
+			parentID: cache._internal_unstable.id('User', '1')!,
+			set: vi.fn(),
+		},
+		{}
+	)
+
+	const upsertSelection: SubscriptionSelection = {
+		fields: {
+			newUser: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'newUser',
+				operations: [{ action: 'upsert', list: 'All_Users' }],
+				selection: {
+					fields: {
+						id: { type: 'ID', visible: true, keyRaw: 'id' },
+						firstName: { type: 'String', visible: true, keyRaw: 'firstName' },
+					},
+				},
+			},
+		},
+	}
+
+	// upsert User:5 which is already in the list
+	cache.write({ selection: upsertSelection, data: { newUser: { id: '5', firstName: 'Alice Updated' } } })
+
+	// should still be length 1, no duplicate
+	expect([...cache.list('All_Users', '1')]).toEqual(['User:5'])
+})
+
+test('upsert list updates record data when already present', () => {
+	const cache = new Cache(config)
+
+	const friendsField: SubscriptionSelection = {
+		fields: {
+			id: { type: 'ID', visible: true, keyRaw: 'id' },
+			firstName: { type: 'String', visible: true, keyRaw: 'firstName' },
+		},
+	}
+
+	cache.write({
+		selection: {
+			fields: {
+				viewer: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'viewer',
+					selection: {
+						fields: {
+							id: { type: 'ID', visible: true, keyRaw: 'id' },
+							friends: {
+								type: 'User',
+								visible: true,
+								keyRaw: 'friends',
+								list: { name: 'All_Users', connection: false, type: 'User' },
+								selection: friendsField,
+							},
+						},
+					},
+				},
+			},
+		},
+		data: { viewer: { id: '1', friends: [{ id: '5', firstName: 'Alice' }] } },
+	})
+
+	const set = vi.fn()
+	cache.subscribe(
+		{
+			rootType: 'User',
+			selection: {
+				fields: {
+					friends: {
+						type: 'User',
+						visible: true,
+						keyRaw: 'friends',
+						list: { name: 'All_Users', connection: false, type: 'User' },
+						selection: friendsField,
+					},
+				},
+			},
+			parentID: cache._internal_unstable.id('User', '1')!,
+			set,
+		},
+		{}
+	)
+
+	// upsert an existing user with updated data
+	cache.write({
+		selection: {
+			fields: {
+				newUser: {
+					type: 'User',
+					visible: true,
+					keyRaw: 'newUser',
+					operations: [{ action: 'upsert', list: 'All_Users' }],
+					selection: friendsField,
+				},
+			},
+		},
+		data: { newUser: { id: '5', firstName: 'Alice Updated' } },
+	})
+
+	// list unchanged, but subscriber was called with updated data
+	expect([...cache.list('All_Users', '1')]).toEqual(['User:5'])
+	expect(set).toHaveBeenCalledWith(
+		expect.objectContaining({
+			friends: expect.arrayContaining([expect.objectContaining({ firstName: 'Alice Updated' })]),
+		})
+	)
 })

--- a/packages/houdini/src/runtime/cache/tests/list.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/list.test.ts
@@ -6914,7 +6914,7 @@ test('upsert list inserts when not present', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -6999,7 +6999,7 @@ test('upsert list does not duplicate when already present', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)
@@ -7066,7 +7066,7 @@ test('upsert list updates record data when already present', () => {
 		data: { viewer: { id: '1', friends: [{ id: '5', firstName: 'Alice' }] } },
 	})
 
-	const set = vi.fn()
+	const onMessage = vi.fn()
 	cache.subscribe(
 		{
 			rootType: 'User',
@@ -7082,7 +7082,7 @@ test('upsert list updates record data when already present', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set,
+			onMessage,
 		},
 		{}
 	)
@@ -7105,11 +7105,14 @@ test('upsert list updates record data when already present', () => {
 
 	// list unchanged, but subscriber was called with updated data
 	expect([...cache.list('All_Users', '1')]).toEqual(['User:5'])
-	expect(set).toHaveBeenCalledWith(
+	expect(onMessage).toHaveBeenCalledWith(
 		expect.objectContaining({
-			friends: expect.arrayContaining([
-				expect.objectContaining({ firstName: 'Alice Updated' }),
-			]),
+			kind: 'update',
+			data: expect.objectContaining({
+				friends: expect.arrayContaining([
+					expect.objectContaining({ firstName: 'Alice Updated' }),
+				]),
+			}),
 		})
 	)
 })

--- a/packages/houdini/src/runtime/cache/tests/list.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/list.test.ts
@@ -6878,7 +6878,11 @@ test('upsert list inserts when not present', () => {
 								selection: {
 									fields: {
 										id: { type: 'ID', visible: true, keyRaw: 'id' },
-										firstName: { type: 'String', visible: true, keyRaw: 'firstName' },
+										firstName: {
+											type: 'String',
+											visible: true,
+											keyRaw: 'firstName',
+										},
 									},
 								},
 							},
@@ -6959,7 +6963,11 @@ test('upsert list does not duplicate when already present', () => {
 								selection: {
 									fields: {
 										id: { type: 'ID', visible: true, keyRaw: 'id' },
-										firstName: { type: 'String', visible: true, keyRaw: 'firstName' },
+										firstName: {
+											type: 'String',
+											visible: true,
+											keyRaw: 'firstName',
+										},
 									},
 								},
 							},
@@ -7014,7 +7022,10 @@ test('upsert list does not duplicate when already present', () => {
 	}
 
 	// upsert User:5 which is already in the list
-	cache.write({ selection: upsertSelection, data: { newUser: { id: '5', firstName: 'Alice Updated' } } })
+	cache.write({
+		selection: upsertSelection,
+		data: { newUser: { id: '5', firstName: 'Alice Updated' } },
+	})
 
 	// should still be length 1, no duplicate
 	expect([...cache.list('All_Users', '1')]).toEqual(['User:5'])
@@ -7096,7 +7107,9 @@ test('upsert list updates record data when already present', () => {
 	expect([...cache.list('All_Users', '1')]).toEqual(['User:5'])
 	expect(set).toHaveBeenCalledWith(
 		expect.objectContaining({
-			friends: expect.arrayContaining([expect.objectContaining({ firstName: 'Alice Updated' })]),
+			friends: expect.arrayContaining([
+				expect.objectContaining({ firstName: 'Alice Updated' }),
+			]),
 		})
 	)
 })

--- a/packages/houdini/src/runtime/types.ts
+++ b/packages/houdini/src/runtime/types.ts
@@ -175,7 +175,7 @@ export const DataSource = {
 export type DataSources = ValuesOf<typeof DataSource>
 
 export type MutationOperation = {
-	action: 'insert' | 'remove' | 'delete' | 'toggle'
+	action: 'insert' | 'remove' | 'delete' | 'toggle' | 'upsert'
 	list?: string
 	type?: string
 	parentID?: {

--- a/plugins/graphql/conventions.go
+++ b/plugins/graphql/conventions.go
@@ -58,6 +58,10 @@ const ListOperationSuffixToggle = "_toggle"
 
 const ListOperationSuffixDelete = "_delete"
 
+const ListOperationSuffixUpsert = "_upsert"
+
+const ListOperationSuffixUpdate = "_update"
+
 const PaginationModeInfinite = "Infinite"
 
 const PaginationModeSinglePage = "SinglePage"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
 		include: [
 			'./packages/*/src/**/*.test.{ts,js}',
 			'./packages/houdini-react/runtime/**/*.test.{ts,js}',
+			'./packages/houdini-core/runtime/public/**/*.test.{ts,js}',
 			'./site/**/*.test.{ts,js}',
 		],
 		setupFiles: [path.resolve('./vitest.setup.ts')],
@@ -15,6 +16,7 @@ export default defineConfig({
 			'houdini/test': path.resolve('./packages/houdini/legacy/test'),
 			'houdini/vite': path.resolve('./packages/houdini/src/vite'),
 			'houdini/codegen': path.resolve('./packages/houdini/src/codegen'),
+			'houdini/runtime': path.resolve('./packages/houdini/src/runtime'),
 			houdini: path.resolve('./packages/houdini/src/lib'),
 		},
 		coverage: {


### PR DESCRIPTION
Closes #1557.

  Adds two new auto-generated fragment suffixes for list operations:
  
`_upsert` inserts a record if it isn't already in the list, or updates its data in place if it is. Avoids duplicates when a real-time subscription can fire for both new and existing records.

```graphql
  subscription MessageUpserted {
      messageUpserted {
          ...All_Messages_upsert
      }
  }
```

` _update` : writes field values to an existing cached record without touching list membership at all. Useful when a subscription fires for a record that is already present and you just want to propagate field changes.

```graphql
  subscription MessageUpdated {
      messageUpdated {
          ...All_Messages_update
      }
  }
```