### PR TITLE
Extensible Errors

### DIFF
--- a/.changeset/error-extensions.md
+++ b/.changeset/error-extensions.md
@@ -1,6 +1,7 @@
 ---
 'houdini': patch
 'houdini-react': patch
+'houdini-svelte': patch
 ---
 
 GraphQL errors now expose `locations`, `path`, and `extensions` per the spec; augment `App.GraphQLErrorExtensions` to type your server's extensions.

--- a/.changeset/error-extensions.md
+++ b/.changeset/error-extensions.md
@@ -1,0 +1,6 @@
+---
+'houdini': patch
+'houdini-react': patch
+---
+
+GraphQL errors now expose `locations`, `path`, and `extensions` per the spec; augment `App.GraphQLErrorExtensions` to type your server's extensions.

--- a/docs/shared/_partials/error-handling.mdx
+++ b/docs/shared/_partials/error-handling.mdx
@@ -22,3 +22,18 @@ export default new HoudiniClient({
 ```
 
 Note that mutations always throw on error regardless of the `throwOnError` configuration. The thrown value is a `RuntimeGraphQLError` with a `.raw` field containing the full error payload from the server.
+
+## Typing Error Extensions
+
+The GraphQL spec allows servers to include an `extensions` field on errors with arbitrary data (error codes, stack traces, etc.). Houdini passes these through at runtime, and you can type them by augmenting `App.GraphQLErrorExtensions` in your app's type declarations:
+
+```typescript title="src/app.d.ts"
+declare namespace App {
+    interface GraphQLErrorExtensions {
+        code: string
+        timestamp: string
+    }
+}
+```
+
+Once declared, `errors[n].extensions` will be typed as `App.GraphQLErrorExtensions` everywhere Houdini exposes errors — query results, mutation responses, subscriptions, and the `throwOnError` callback.

--- a/docs/svelte/05-guides/02-error-handling.mdx
+++ b/docs/svelte/05-guides/02-error-handling.mdx
@@ -3,12 +3,13 @@ title: "Error Handling"
 description: "Handle GraphQL and network errors."
 ---
 
-There are 2 ways you can handle errors in GraphQL: you can either have documents throw an exception if an
-`error` key is located in the payload (and is a list with at least one member) or they can fail silently
-and rely on application level code to function.
+import ErrorHandling from '@shared/_partials/error-handling.mdx'
 
-By default, Houdini will behave "silently" and not throw any exceptions if an error is the query response is
-seen. If you want to turn on exceptions, you can specify the details in the `throwOnError` field:
+<ErrorHandling />
+
+## SvelteKit Integration
+
+In SvelteKit, use the `error` helper from `@sveltejs/kit` inside `throwOnError` to produce proper HTTP error responses:
 
 ```typescript title="src/client.ts&typescriptToggle=true"
 import { error } from '@sveltejs/kit'
@@ -16,10 +17,7 @@ import { error } from '@sveltejs/kit'
 export default new HoudiniClient({
     url: '...',
     throwOnError: {
-        // can be any combination of
-        // query, mutation, subscription, and all
         operations: ['all'],
-        // the function to call
         error: (errors, ctx) => error(500,
             `(${ctx.artifact.name}): ` +
             errors.map((err) => err.message).join('. ') + '.'

--- a/packages/houdini-core/runtime/plugins/subscription.ts
+++ b/packages/houdini-core/runtime/plugins/subscription.ts
@@ -1,6 +1,7 @@
 import { deepEquals } from 'houdini/runtime'
 import type { ClientPluginContext } from 'houdini/runtime/documentStore'
 import { ArtifactKind, DataSource } from 'houdini/runtime/types'
+import type { GraphQLError } from 'houdini/runtime/types'
 
 import { documentPlugin } from './utils/index.js'
 
@@ -110,7 +111,7 @@ export type SubscriptionClient = {
 			extensions?: Record<'persistedQuery', string> | Record<string, unknown>
 		},
 		handlers: {
-			next: (payload: { data?: {} | null; errors?: readonly { message: string }[] }) => void
+			next: (payload: { data?: {} | null; errors?: readonly GraphQLError[] }) => void
 			error: (data: {}) => void
 			complete: () => void
 		}

--- a/packages/houdini-react/runtime/hooks/useDocumentHandle.ts
+++ b/packages/houdini-react/runtime/hooks/useDocumentHandle.ts
@@ -4,6 +4,7 @@ import { ArtifactKind } from 'houdini/runtime'
 import type {
 	GraphQLObject,
 	GraphQLVariables,
+	GraphQLError,
 	CursorHandlers,
 	OffsetHandlers,
 	PageInfo,
@@ -205,7 +206,7 @@ export type DocumentHandle<
 	data: _Data
 	partial: boolean
 	fetching: boolean
-	errors: { message: string }[] | null
+	errors: GraphQLError[] | null
 	fetch: FetchFn<_Data, Partial<_Input>>
 	variables: _Input
 } & RefetchHandlers<_Artifact, _Data, _Input>

--- a/packages/houdini-react/runtime/hooks/useSubscriptionHandle.ts
+++ b/packages/houdini-react/runtime/hooks/useSubscriptionHandle.ts
@@ -1,10 +1,10 @@
-import type { SubscriptionArtifact, GraphQLObject, GraphQLVariables } from 'houdini/runtime'
+import type { SubscriptionArtifact, GraphQLObject, GraphQLVariables, GraphQLError } from 'houdini/runtime'
 
 import { useDocumentSubscription } from './useDocumentSubscription.js'
 
 export type SubscriptionHandle<_Result extends GraphQLObject, _Input extends GraphQLVariables> = {
 	data: _Result | null
-	errors: { message: string }[] | null
+	errors: GraphQLError[] | null
 	variables: _Input
 	listen: (args: { variables?: _Input }) => void
 	unlisten: () => void

--- a/packages/houdini-react/runtime/hooks/useSubscriptionHandle.ts
+++ b/packages/houdini-react/runtime/hooks/useSubscriptionHandle.ts
@@ -1,4 +1,9 @@
-import type { SubscriptionArtifact, GraphQLObject, GraphQLVariables, GraphQLError } from 'houdini/runtime'
+import type {
+	SubscriptionArtifact,
+	GraphQLObject,
+	GraphQLVariables,
+	GraphQLError,
+} from 'houdini/runtime'
 
 import { useDocumentSubscription } from './useDocumentSubscription.js'
 

--- a/packages/houdini-svelte/runtime/stores/pagination/fragment.ts
+++ b/packages/houdini-svelte/runtime/stores/pagination/fragment.ts
@@ -8,6 +8,7 @@ import type {
 	CachePolicies,
 	FragmentArtifact,
 	GraphQLObject,
+	GraphQLError,
 	HoudiniFetchContext,
 	QueryArtifact,
 	PageInfo,
@@ -270,7 +271,7 @@ export class FragmentStoreOffset<
 export type FragmentStorePaginated<_Data extends GraphQLObject, _Input> = Readable<{
 	data: _Data
 	fetching: boolean
-	errors: { message: string }[] | null
+	errors: GraphQLError[] | null
 	pageInfo: PageInfo
 }> & {
 	fetch(params?: { policy?: CachePolicies }): Promise<void>
@@ -289,5 +290,5 @@ export type FragmentStorePaginated<_Data extends GraphQLObject, _Input> = Readab
 export type FragmentPaginatedResult<_Data, _ExtraFields = {}> = {
 	data: _Data | null
 	fetching: boolean
-	errors: { message: string }[] | null
+	errors: GraphQLError[] | null
 } & _ExtraFields

--- a/packages/houdini/src/runtime/types.ts
+++ b/packages/houdini/src/runtime/types.ts
@@ -18,6 +18,7 @@ declare global {
 	namespace App {
 		interface Session {}
 		interface Metadata {}
+		interface GraphQLErrorExtensions {}
 		interface Stuff {
 			inputs: {
 				init: boolean
@@ -275,9 +276,16 @@ export type FetchQueryResult<_Data> = {
 	source: DataSources | null
 }
 
+export type GraphQLError = {
+	message: string
+	locations?: { line: number; column: number }[]
+	path?: (string | number)[]
+	extensions?: App.GraphQLErrorExtensions
+}
+
 export type QueryResult<_Data = GraphQLObject, _Input = GraphQLVariables | undefined> = {
 	data: _Data | null
-	errors: { message: string }[] | null
+	errors: GraphQLError[] | null
 	fetching: boolean
 	partial: boolean
 	stale: boolean
@@ -287,11 +295,7 @@ export type QueryResult<_Data = GraphQLObject, _Input = GraphQLVariables | undef
 
 export type RequestPayload<GraphQLObject = any> = {
 	data: GraphQLObject | null
-	errors:
-		| {
-				message: string
-		  }[]
-		| null
+	errors: GraphQLError[] | null
 }
 
 export type NestedList<_Result = string> = (_Result | null | NestedList<_Result>)[]

--- a/packages/houdini/src/runtime/types.ts
+++ b/packages/houdini/src/runtime/types.ts
@@ -279,7 +279,7 @@ export type FetchQueryResult<_Data> = {
 export type GraphQLError = {
 	message: string
 	locations?: readonly { line: number; column: number }[]
-	path?: (string | number)[]
+	path?: readonly (string | number)[]
 	extensions?: App.GraphQLErrorExtensions
 }
 

--- a/packages/houdini/src/runtime/types.ts
+++ b/packages/houdini/src/runtime/types.ts
@@ -278,7 +278,7 @@ export type FetchQueryResult<_Data> = {
 
 export type GraphQLError = {
 	message: string
-	locations?: { line: number; column: number }[]
+	locations?: readonly { line: number; column: number }[]
 	path?: (string | number)[]
 	extensions?: App.GraphQLErrorExtensions
 }


### PR DESCRIPTION
This PR adds a GraphQLError type that matches the spec and wires it through QueryResult, RequestPayload, and all the framework-specific handle/store types. The extensions field is typed via a new App.GraphQLErrorExtensions interface that users can augment to match their server's error shape.

Fixes https://github.com/HoudiniGraphql/houdini/issues/1520