### PR TITLE
cache.reset() and record.refresh() correctness and performance

### DIFF
--- a/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
@@ -520,7 +520,6 @@ mutation B {
                                     "firstName": {
                                         "type": "String",
                                         "keyRaw": "firstName",
-                                        "visible": true,
                                     },
 
                                     "id": {

--- a/packages/houdini-core/runtime/plugins/query.test.ts
+++ b/packages/houdini-core/runtime/plugins/query.test.ts
@@ -1,4 +1,5 @@
 import { Cache } from 'houdini/runtime/cache'
+import { CachePolicy } from 'houdini/runtime/types'
 import { beforeEach, expect, test, vi } from 'vitest'
 
 import { testConfigFile } from '../../test'
@@ -9,6 +10,69 @@ import { createStore, fakeFetch } from './test.js'
 const config = testConfigFile()
 beforeEach(async () => {
 	setMockConfig(config)
+})
+
+test('refetch triggered by cache.refresh uses the most recent session, not the subscription-time session', async () => {
+	const cache = new Cache()
+
+	// write a record so the subscription has something to attach to
+	const selection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						id: { type: 'ID', visible: true, keyRaw: 'id' },
+						firstName: { type: 'String', visible: true, keyRaw: 'firstName' },
+					},
+				},
+			},
+		},
+	}
+
+	cache._internal_unstable.write({
+		selection,
+		data: { viewer: { id: '1', firstName: 'bob' } },
+	})
+
+	// spy to capture every network request and the session it carries
+	const fetchSpy = vi.fn()
+
+	const store = createStore({
+		artifact: {
+			kind: 'HoudiniQuery',
+			hash: '7777',
+			raw: 'RAW_TEXT',
+			name: 'TestArtifact',
+			rootType: 'Query',
+			pluginData: {},
+			stripVariables: [],
+			selection,
+		},
+		pipeline: [query(cache), fakeFetch({ spy: fetchSpy })],
+	})
+
+	// first send — establishes the cache subscription with session 'old'
+	await store.send({ session: { token: 'old' }, variables: {} })
+
+	// second send with the same variables but a new session — no new subscription is created
+	// but lastSession in the closure must be updated to 'new'
+	await store.send({ session: { token: 'new' }, variables: {} })
+
+	// reset the spy so we only see the refetch request
+	fetchSpy.mockClear()
+
+	// trigger a refetch via the cache
+	cache._internal_unstable.refresh('User:1')
+
+	// give the async send a tick to run
+	await new Promise((r) => setTimeout(r, 0))
+
+	// the refetch must carry the new session, not the stale one from subscription time
+	expect(fetchSpy).toHaveBeenCalledOnce()
+	expect(fetchSpy.mock.calls[0][0].session).toEqual({ token: 'new' })
 })
 
 test('query plugin evaluates runtime scalars', async () => {

--- a/packages/houdini-core/runtime/plugins/query.ts
+++ b/packages/houdini-core/runtime/plugins/query.ts
@@ -12,6 +12,11 @@ export const query = (cache: Cache) =>
 		// remember the last variables we were called with
 		let lastVariables: Record<string, any> | null = null
 
+		// track the most recent session so that refetch requests triggered by
+		// record.refresh() use the current auth token, not the one from when the
+		// subscription was first created
+		let lastSession: App.Session | null | undefined = null
+
 		// the function to call when a query is sent
 		return {
 			start(ctx, { next }) {
@@ -46,6 +51,10 @@ export const query = (cache: Cache) =>
 			// patch subscriptions on the way out so that we don't get a cache update
 			// before the promise resolves
 			end(ctx, { resolve, marshalVariables, variablesChanged }) {
+				// always keep the session current so that a later record.refresh() call
+				// uses the auth token from the most recent send(), not from subscription time
+				lastSession = ctx.session
+
 				// if the variables have changed we need to setup a new subscription with the cache
 				if (variablesChanged(ctx) && !ctx.cacheParams?.disableSubscriptions) {
 					// if the variables changed we need to unsubscribe from the old fields and
@@ -69,7 +78,7 @@ export const query = (cache: Cache) =>
 							if (message.kind === 'refetch') {
 								ctx.documentStore.send({
 									policy: CachePolicy.NetworkOnly,
-									session: ctx.session,
+									session: lastSession,
 									metadata: ctx.metadata,
 								})
 								return

--- a/packages/houdini/src/runtime/cache/index.ts
+++ b/packages/houdini/src/runtime/cache/index.ts
@@ -1018,7 +1018,9 @@ class CacheInternal {
 									operation.target === 'all',
 									processedOperations
 								)
-						removeList.when(resolveWhen(operation.when, variables)).remove(target, variables, layer)
+						removeList
+							.when(resolveWhen(operation.when, variables))
+							.remove(target, variables, layer)
 					}
 
 					// delete the target

--- a/packages/houdini/src/runtime/cache/index.ts
+++ b/packages/houdini/src/runtime/cache/index.ts
@@ -210,13 +210,13 @@ export class Cache {
 
 		// a document can be subscribed to multiple fields of the record so make
 		// sure we only send the message once per set
-		const notified: SubscriptionSpec['onMessage'][] = []
+		const notified = new Set<SubscriptionSpec['onMessage']>()
 		for (const recordID of recordIDs) {
 			for (const [spec] of this._internal_unstable.subscriptions.getAll(recordID, {
 				includeMaskedParents: true,
 			})) {
-				if (!notified.includes(spec.onMessage)) {
-					notified.push(spec.onMessage)
+				if (!notified.has(spec.onMessage)) {
+					notified.add(spec.onMessage)
 					spec.onMessage({ kind: 'refetch' })
 				}
 			}
@@ -377,11 +377,11 @@ export class Cache {
 		this._internal_unstable.epoch++
 		// the same spec will likely need to be updated multiple times, create the unique list by using the set
 		// function's identity
-		const notified: SubscriptionSpec['onMessage'][] = []
+		const notified = new Set<SubscriptionSpec['onMessage']>()
 		for (const spec of subs) {
 			// if we haven't added the set yet
-			if (!notified.includes(spec.onMessage)) {
-				notified.push(spec.onMessage)
+			if (!notified.has(spec.onMessage)) {
+				notified.add(spec.onMessage)
 				// trigger the update
 				spec.onMessage({
 					kind: 'update',

--- a/packages/houdini/src/runtime/cache/lists.ts
+++ b/packages/houdini/src/runtime/cache/lists.ts
@@ -1,6 +1,12 @@
 import { deepEquals } from '../deepEquals.js'
 import { flatten } from '../flatten.js'
-import type { Filter, SubscriptionSelection, ListWhen, SubscriptionSpec, NestedList } from '../types.js'
+import type {
+	Filter,
+	SubscriptionSelection,
+	ListWhen,
+	SubscriptionSpec,
+	NestedList,
+} from '../types.js'
 import type { Cache } from './index.js'
 import type { Layer } from './storage.js'
 import { rootID } from './stuff.js'

--- a/packages/houdini/src/runtime/cache/subscription.ts
+++ b/packages/houdini/src/runtime/cache/subscription.ts
@@ -607,10 +607,7 @@ export function filterValue(filter: ListFilter, variables: Record<string, any>):
 	}
 	if (filter.kind === 'Object') {
 		return Object.fromEntries(
-			Object.entries(filter.value).map(([key, value]) => [
-				key,
-				filterValue(value, variables),
-			])
+			Object.entries(filter.value).map(([key, value]) => [key, filterValue(value, variables)])
 		)
 	}
 	if (filter.kind === 'List') {

--- a/packages/houdini/src/runtime/cache/subscription.ts
+++ b/packages/houdini/src/runtime/cache/subscription.ts
@@ -198,7 +198,7 @@ export class InMemorySubscriptions {
 		// add this version of the key if we need to
 		this.keyVersions[key].add(key)
 
-		if (!selections.some(([{ onMessage }]) => onMessage === spec.onMessage)) {
+		if (!referenceCounts.has(spec.onMessage)) {
 			selections.push([spec, selection[1]])
 		}
 
@@ -418,9 +418,12 @@ export class InMemorySubscriptions {
 			this.subscribers.delete(id)
 		}
 
-		// Get list of all SubscriptionSpecs of subscribers
+		// Get list of all SubscriptionSpecs of subscribers (including masked parents so
+		// that documents holding records only behind fragment boundaries are also notified)
 		const subscriptionSpecs = subscribers.flatMap(([_id, fields]) =>
-			[...fields.values()].flatMap((field) => field.selections.map(([spec]) => spec))
+			[...fields.values()].flatMap((field) =>
+				field.selections.concat(field.maskedParentSelections).map(([spec]) => spec)
+			)
 		)
 
 		return subscriptionSpecs

--- a/packages/houdini/src/runtime/cache/tests/list.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/list.test.ts
@@ -2579,7 +2579,9 @@ test('list filter - object value with nested variable', () => {
 	cache.subscribe(
 		{
 			rootType: 'Query',
-			set,
+			onMessage: (msg) => {
+				if (msg.kind === 'update') set(msg.data)
+			},
 			selection,
 		},
 		{ value: 'bar' }
@@ -3566,7 +3568,7 @@ test('when operation with variable condition', () => {
 				},
 			},
 			parentID: cache._internal_unstable.id('User', '1')!,
-			set: vi.fn(),
+			onMessage: vi.fn(),
 		},
 		{}
 	)

--- a/packages/houdini/src/runtime/cache/tests/refresh.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/refresh.test.ts
@@ -408,3 +408,58 @@ test('refresh on an unknown record is a no-op', () => {
 	// nothing to assert beyond it not throwing
 	cache.refresh('User:999')
 })
+
+test('refresh notifies a document exactly once even when subscribed to many fields', () => {
+	// regression for the O(n²) dedup: the handler must fire once regardless of how
+	// many fields of the record the document is subscribed to
+	const cache = new Cache(config)
+
+	const wideSelection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						id: { type: 'ID', visible: true, keyRaw: 'id' },
+						firstName: { type: 'String', visible: true, keyRaw: 'firstName' },
+						lastName: { type: 'String', visible: true, keyRaw: 'lastName' },
+						email: { type: 'String', visible: true, keyRaw: 'email' },
+					},
+				},
+			},
+		},
+	}
+
+	cache.write({
+		selection: wideSelection,
+		data: { viewer: { id: '1', firstName: 'bob', lastName: 'smith', email: 'b@b.com' } },
+	})
+
+	const onMessage = vi.fn()
+	cache.subscribe({ rootType: 'Query', selection: wideSelection, onMessage })
+
+	cache.refresh('User:1')
+
+	// subscribed to 4 fields on the record — must still only get one message
+	expect(onMessage).toHaveBeenCalledTimes(1)
+	expect(onMessage).toHaveBeenCalledWith({ kind: 'refetch' })
+})
+
+test('refresh after unsubscribe does not notify removed handler', () => {
+	const cache = new Cache(config)
+
+	cache.write({
+		selection: visibleSelection,
+		data: { viewer: { id: '1', firstName: 'bob' } },
+	})
+
+	const onMessage = vi.fn()
+	const spec = { rootType: 'Query', selection: visibleSelection, onMessage }
+	cache.subscribe(spec)
+	cache.unsubscribe(spec)
+
+	cache.refresh('User:1')
+	expect(onMessage).not.toHaveBeenCalled()
+})

--- a/packages/houdini/src/runtime/cache/tests/reset.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/reset.test.ts
@@ -135,6 +135,52 @@ test('make sure the cache lists were reset', () => {
 	expect(() => cache.list('All_Users')).toThrowError('Cannot find list with name')
 })
 
+test('cache.reset notifies documents holding records only behind masked boundaries', () => {
+	const cache = new Cache(config)
+
+	// viewer is visible but everything on the user is masked (simulates a fragment spread)
+	const maskedSelection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						id: {
+							type: 'ID',
+							keyRaw: 'id',
+						},
+						firstName: {
+							type: 'String',
+							keyRaw: 'firstName',
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cache.write({
+		selection: maskedSelection,
+		data: { viewer: { id: '1', firstName: 'bob' } },
+	})
+
+	const onMessage = vi.fn()
+	cache.subscribe({ rootType: 'Query', selection: maskedSelection, onMessage })
+
+	// a masked-field write must NOT notify the subscriber
+	cache.write({
+		selection: maskedSelection,
+		data: { viewer: { id: '1', firstName: 'alice' } },
+	})
+	expect(onMessage).not.toHaveBeenCalled()
+
+	// reset MUST notify the subscriber even though its fields are masked
+	cache.reset()
+	expect(onMessage).toHaveBeenCalledTimes(1)
+})
+
 test('make sure the cache subscribers were reset', () => {
 	const cache = new Cache(config)
 


### PR DESCRIPTION
Four issues found during review of #1646, fixed here before merging the remaining PRs in the stack.

**Correctness**

`cache.reset()` only iterated `field.selections` when collecting specs to notify, skipping specs stored in `maskedParentSelections`. Documents that hold a record only behind a masked boundary (fragment spread) were silently not notified on reset.

The `onMessage` refetch handler in `query.ts` closed over `ctx.session` from subscription time. If the session changed (JWT refresh, re-login) without a variables change, subsequent `record.refresh()` calls triggered network requests with the stale auth token. Fixed with a `lastSession` ref that is updated on every `end()` call.

**Performance**

The dedup guards in `refresh()` and `#notifySubscribers()` used `Array.includes()` inside a loop — O(n²) for records with many subscribers. Replaced with `Set`.

`addFieldSubscription` used `selections.some()` to check whether a spec was already registered. The `referenceCounts` map already tracks this in O(1); `.has()` replaces the linear scan.