### PR TITLE
Fix cache link leak when refetching connections with CacheAndNetwork

### DIFF
--- a/.changeset/fix-refetch-cache-links-leak.md
+++ b/.changeset/fix-refetch-cache-links-leak.md
@@ -1,0 +1,5 @@
+---
+'houdini': patch
+---
+
+Fix cache link leak when refetching connections — embedded edge records now reuse their existing keys on write instead of generating new ones, and records that fall out of the list are cleaned up immediately.

--- a/e2e/kit/src/lib/utils/routes.ts
+++ b/e2e/kit/src/lib/utils/routes.ts
@@ -81,6 +81,8 @@ export const routes = {
 	Stores_Layouts: '/layouts',
 	Stores_Layouts_page2: '/layouts/page2',
 
+	Bug_RefetchCacheLinksLeak: '/bug/refetch-cache-links-leak',
+
 	Svelte5_Runes_Simple_SSR: '/svelte5-runes/simple-ssr',
 	Svelte5_Runes_Pagination: '/svelte5-runes/pagination',
 	Svelte5_Runes_Fragment: '/svelte5-runes/fragment',

--- a/e2e/kit/src/routes/bug/refetch-cache-links-leak/+page.svelte
+++ b/e2e/kit/src/routes/bug/refetch-cache-links-leak/+page.svelte
@@ -1,0 +1,79 @@
+<!--
+To reproduce:
+1. open this page
+2. wait for data to be loaded
+3. click "refresh links" on the right. notice how there's 8 "User:testing:2.friendsConnection.edges[x]" links
+4. click "refetch data" on the left.
+5. click "refresh links" on the right. notice how there's now 16 "User:testing:2.friendsConnection.edges[x]" links
+
+This only happens when the refetch query has to fetch new data from the network and write it to the cache.
+Using "NoCache" or "CacheOrNetwork" as policies avoid this behavior.
+Additionally, this only happens with connections. If we'd use the `friendsList` list instead, this behavior disappears.
+-->
+
+<script lang="ts">
+  import { cache, graphql } from '$houdini';
+  import { onMount } from 'svelte';
+
+  const store = graphql(`
+    query TestingOneUser($id: ID!) {
+      user(id: $id, snapshot: "testing") {
+        friendsConnection {
+          edges {
+            node {
+              id
+            }
+          }
+        }
+      }
+    }
+  `);
+
+  let links = $state<object>({});
+
+  onMount(() => {
+    store.fetch({
+      variables: { id: '2' },
+      policy: 'CacheAndNetwork'
+    });
+  });
+
+  const refetch = () => {
+    store.fetch({
+      variables: { id: '2' },
+      policy: 'CacheAndNetwork'
+    });
+  };
+
+  const refreshLinks = () => {
+    links = cache._internal_unstable._internal_unstable.storage.data[0].links;
+  };
+</script>
+
+<div class="cols">
+  <div class="col">
+    <button onclick={() => refetch()}>refetch data</button>
+
+    {#if $store.fetching}
+      <p>Loading...</p>
+    {:else}
+      <pre>{JSON.stringify($store.data, null, 2)}</pre>
+    {/if}
+  </div>
+  <div class="col">
+    <button onclick={() => refreshLinks()}>refresh links</button>
+    <p>Links: ({Object.keys(links).length})</p>
+    <pre>{JSON.stringify(links, null, 2)}</pre>
+  </div>
+</div>
+
+<style>
+  .cols {
+    display: flex;
+    gap: 1em;
+
+    .col {
+      flex: 1;
+    }
+  }
+</style>

--- a/e2e/kit/src/routes/bug/refetch-cache-links-leak/+page.svelte
+++ b/e2e/kit/src/routes/bug/refetch-cache-links-leak/+page.svelte
@@ -1,16 +1,3 @@
-<!--
-To reproduce:
-1. open this page
-2. wait for data to be loaded
-3. click "refresh links" on the right. notice how there's 8 "User:testing:2.friendsConnection.edges[x]" links
-4. click "refetch data" on the left.
-5. click "refresh links" on the right. notice how there's now 16 "User:testing:2.friendsConnection.edges[x]" links
-
-This only happens when the refetch query has to fetch new data from the network and write it to the cache.
-Using "NoCache" or "CacheOrNetwork" as policies avoid this behavior.
-Additionally, this only happens with connections. If we'd use the `friendsList` list instead, this behavior disappears.
--->
-
 <script lang="ts">
   import { cache, graphql } from '$houdini';
   import { onMount } from 'svelte';
@@ -29,51 +16,32 @@ Additionally, this only happens with connections. If we'd use the `friendsList` 
     }
   `);
 
-  let links = $state<object>({});
+  // Count only the embedded edge records so the test has a stable signal.
+  // Before the fix, refetching with CacheAndNetwork would double this count
+  // because each write generated new keys instead of reusing existing ones.
+  const edgeLinkCount = $derived(
+    $store.fetching
+      ? -1
+      : Object.keys(
+          cache._internal_unstable._internal_unstable.storage.data[0].links
+        ).filter((k) => k.includes('.friendsConnection.edges[')).length
+  );
 
   onMount(() => {
-    store.fetch({
-      variables: { id: '2' },
-      policy: 'CacheAndNetwork'
-    });
+    store.fetch({ variables: { id: '2' }, policy: 'CacheAndNetwork' });
   });
 
   const refetch = () => {
-    store.fetch({
-      variables: { id: '2' },
-      policy: 'CacheAndNetwork'
-    });
-  };
-
-  const refreshLinks = () => {
-    links = cache._internal_unstable._internal_unstable.storage.data[0].links;
+    store.fetch({ variables: { id: '2' }, policy: 'CacheAndNetwork' });
   };
 </script>
 
-<div class="cols">
-  <div class="col">
-    <button onclick={() => refetch()}>refetch data</button>
+<button id="refetch" onclick={() => refetch()}>refetch data</button>
 
-    {#if $store.fetching}
-      <p>Loading...</p>
-    {:else}
-      <pre>{JSON.stringify($store.data, null, 2)}</pre>
-    {/if}
-  </div>
-  <div class="col">
-    <button onclick={() => refreshLinks()}>refresh links</button>
-    <p>Links: ({Object.keys(links).length})</p>
-    <pre>{JSON.stringify(links, null, 2)}</pre>
-  </div>
-</div>
+{#if $store.fetching}
+  <p>Loading...</p>
+{:else}
+  <div id="result">{JSON.stringify($store.data)}</div>
+{/if}
 
-<style>
-  .cols {
-    display: flex;
-    gap: 1em;
-
-    .col {
-      flex: 1;
-    }
-  }
-</style>
+<div id="edge-link-count">{edgeLinkCount}</div>

--- a/e2e/kit/src/routes/bug/refetch-cache-links-leak/spec.ts
+++ b/e2e/kit/src/routes/bug/refetch-cache-links-leak/spec.ts
@@ -1,0 +1,19 @@
+import { routes } from '../../../lib/utils/routes.js'
+import { expect_1_gql, goto_expect_n_gql } from '../../../lib/utils/testsHelper.js'
+import { test, expect } from '@playwright/test'
+
+test.describe('bug/refetch-cache-links-leak', () => {
+	test('refetching a connection does not duplicate embedded cache links', async ({ page }) => {
+		await goto_expect_n_gql(page, routes.Bug_RefetchCacheLinksLeak, 1)
+
+		const countEl = page.locator('div[id="edge-link-count"]')
+
+		const initialCount = parseInt((await countEl.textContent()) ?? '0')
+		expect(initialCount).toBeGreaterThan(0)
+
+		await expect_1_gql(page, 'button[id="refetch"]')
+
+		const afterCount = parseInt((await countEl.textContent()) ?? '0')
+		expect(afterCount).toBe(initialCount)
+	})
+})

--- a/packages/houdini/src/runtime/cache/gc.ts
+++ b/packages/houdini/src/runtime/cache/gc.ts
@@ -18,6 +18,10 @@ export class GarbageCollector {
 		this.lifetimes.clear()
 	}
 
+	delete(id: string) {
+		this.lifetimes.delete(id)
+	}
+
 	resetLifetime(id: string, field: string) {
 		// if this is the first time we've seen the id
 		if (!this.lifetimes.get(id)) {

--- a/packages/houdini/src/runtime/cache/index.ts
+++ b/packages/houdini/src/runtime/cache/index.ts
@@ -737,6 +737,16 @@ class CacheInternal {
 				// build up the list of linked ids
 				let linkedIDs: NestedList = []
 
+				// if we are applying an append/prepend update the new entries get concatenated
+				// with the previous ones so they can't take over the previous embedded keys.
+				// a normal write replaces the field's links so embedded entries can reuse the
+				// key of the record they replace instead of generating a new one every write
+				const insertingUpdates = Boolean(
+					applyUpdates?.some(
+						(update) => update !== 'replace' && updates?.includes(update)
+					)
+				)
+
 				// it could be a list of lists, in order to recreate the list of lists we need
 				// we need to track two sets of IDs, the ids of the embedded records and
 				// then the full structure of embedded lists. we'll use the flat list to add
@@ -754,6 +764,10 @@ class CacheInternal {
 					fields: fieldSelection,
 					layer,
 					forceNotify,
+					previousIDs:
+						!insertingUpdates && Array.isArray(previousValue)
+							? (previousValue as NestedList)
+							: null,
 				})
 
 				// we have to do something different if we are writing to an optimistic layer or not
@@ -873,6 +887,20 @@ class CacheInternal {
 					}
 
 					this.subscriptions.remove(lostID, fieldSelection, specs, variables)
+
+					// embedded records can only be referenced by the field that wrote them
+					// so once they fall out of the list their data can be cleaned up. if
+					// we're writing to an optimistic layer the old values have to survive
+					// a potential rollback so we leave them for the garbage collector
+					if (
+						!layer.optimistic &&
+						typeof lostID === 'string' &&
+						lostID.startsWith(`${parent}.${key}[`)
+					) {
+						this.storage.removeEmbeddedRecord(lostID)
+						this.lifetimes.delete(lostID)
+						this.staleManager.deleteRecord(lostID)
+					}
 				}
 
 				// if there was a change in the list
@@ -1542,6 +1570,7 @@ class CacheInternal {
 		specs,
 		layer,
 		forceNotify,
+		previousIDs,
 	}: {
 		value: GraphQLValue[]
 		recordID: string
@@ -1554,6 +1583,7 @@ class CacheInternal {
 		fields: SubscriptionSelection
 		layer: Layer
 		forceNotify?: boolean
+		previousIDs?: NestedList | null
 	}): { nestedIDs: NestedList; newIDs: (string | null)[] } {
 		// build up the two lists
 		const nestedIDs: NestedList = []
@@ -1563,6 +1593,7 @@ class CacheInternal {
 			// if we found another list
 			if (Array.isArray(entry)) {
 				// compute the nested list of ids
+				const previousEntry = previousIDs?.[i]
 				const inner = this.extractNestedListIDs({
 					value: entry as GraphQLValue[],
 					abstract,
@@ -1575,6 +1606,7 @@ class CacheInternal {
 					specs,
 					layer,
 					forceNotify,
+					previousIDs: Array.isArray(previousEntry) ? previousEntry : null,
 				})
 
 				// add the list of new ids to our list
@@ -1594,8 +1626,14 @@ class CacheInternal {
 			// we know now that entry is an object
 			const entryObj = entry as GraphQLObject
 
-			// start off building up the embedded id
-			let linkedID = `${recordID}.${key}[${this.storage.nextRank}]`
+			// start off building up the embedded id. if the previous write left an
+			// embedded record at this position, take over its key so that rewriting
+			// a list doesn't leave orphaned records behind
+			const previousID = previousIDs?.[i]
+			let linkedID =
+				typeof previousID === 'string' && previousID.startsWith(`${recordID}.${key}[`)
+					? previousID
+					: `${recordID}.${key}[${this.storage.nextRank}]`
 			let innerType = linkedType
 
 			const typename = entryObj.__typename as string | undefined

--- a/packages/houdini/src/runtime/cache/staleManager.ts
+++ b/packages/houdini/src/runtime/cache/staleManager.ts
@@ -99,6 +99,11 @@ export class StaleManager {
 		}
 	}
 
+	// remove every entry associated with a record
+	deleteRecord(id: string) {
+		this.fieldsTime.delete(id)
+	}
+
 	// clean up the stale manager
 	delete(id: string, field: string) {
 		if (this.fieldsTime.has(id)) {

--- a/packages/houdini/src/runtime/cache/storage.ts
+++ b/packages/houdini/src/runtime/cache/storage.ts
@@ -58,6 +58,22 @@ export class InMemoryStorage {
 		return this.topLayer.deleteField(id, field)
 	}
 
+	// embedded records are only ever referenced by the field that wrote them so once
+	// that reference is gone the data can be physically removed. any embedded
+	// descendants are left for the garbage collector
+	removeEmbeddedRecord(id: string) {
+		for (const layer of this.data) {
+			// optimistic layers hold their own copy of the data and get rolled back
+			// or merged wholesale so we leave them alone
+			if (layer.optimistic) {
+				continue
+			}
+
+			delete layer.fields[id]
+			delete layer.links[id]
+		}
+	}
+
 	getLayer(id: number): Layer {
 		for (const layer of this.data) {
 			if (layer.id === id) {

--- a/packages/houdini/src/runtime/cache/tests/list.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/list.test.ts
@@ -6666,3 +6666,100 @@ test('@listID operation inserts into the correct list via opaque key', () => {
 
 	expect([...cache.list('All_Users', '1')]).toHaveLength(2)
 })
+test('writing the same data with connections should not cause additional links to be inserted', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			user: {
+				keyRaw: 'user(id: $id, snapshot: "testing")',
+				type: 'User',
+				visible: true,
+				selection: {
+					fields: {
+						id: {
+							keyRaw: 'id',
+							type: 'ID',
+							visible: true,
+						},
+						friendsConnection: {
+							keyRaw: 'friendsConnection',
+							type: 'UserConnection',
+							visible: true,
+							selection: {
+								fields: {
+									edges: {
+										keyRaw: 'edges',
+										type: 'UserEdge',
+										visible: true,
+										selection: {
+											fields: {
+												node: {
+													keyRaw: 'node',
+													nullable: true,
+													type: 'User',
+													visible: true,
+													selection: {
+														fields: {
+															id: {
+																keyRaw: 'id',
+																type: 'ID',
+																visible: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// start off associated with one object
+	cache.write({
+		selection,
+		data: {
+			user: {
+				friendsConnection: {
+					edges: [
+						{ node: { id: '1' } },
+						{ node: { id: '2' } },
+						{ node: { id: '3' } },
+						{ node: { id: '4' } },
+					],
+				},
+			},
+		},
+	})
+
+	const pre = Object.keys(cache._internal_unstable.storage.data[0].links).length
+
+	// We'll write the same selection again. This shouldn't affect the amount of links stored in the cache.
+	cache.write({
+		selection,
+		data: {
+			user: {
+				friendsConnection: {
+					edges: [
+						{ node: { id: '1' } },
+						{ node: { id: '2' } },
+						{ node: { id: '3' } },
+						{ node: { id: '4' } },
+					],
+				},
+			},
+		},
+	})
+
+	const post = Object.keys(cache._internal_unstable.storage.data[0].links).length
+
+	expect(post).toBe(pre)
+})
+

--- a/packages/houdini/src/runtime/cache/tests/list.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/list.test.ts
@@ -6763,3 +6763,95 @@ test('writing the same data with connections should not cause additional links t
 	expect(post).toBe(pre)
 })
 
+test('shrinking a connection cleans up the orphaned edge records', function () {
+	// instantiate a cache
+	const cache = new Cache(config)
+
+	const selection: SubscriptionSelection = {
+		fields: {
+			user: {
+				keyRaw: 'user(id: $id, snapshot: "testing")',
+				type: 'User',
+				visible: true,
+				selection: {
+					fields: {
+						id: {
+							keyRaw: 'id',
+							type: 'ID',
+							visible: true,
+						},
+						friendsConnection: {
+							keyRaw: 'friendsConnection',
+							type: 'UserConnection',
+							visible: true,
+							selection: {
+								fields: {
+									edges: {
+										keyRaw: 'edges',
+										type: 'UserEdge',
+										visible: true,
+										selection: {
+											fields: {
+												node: {
+													keyRaw: 'node',
+													nullable: true,
+													type: 'User',
+													visible: true,
+													selection: {
+														fields: {
+															id: {
+																keyRaw: 'id',
+																type: 'ID',
+																visible: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// start off with a connection holding 4 edges
+	cache.write({
+		selection,
+		data: {
+			user: {
+				friendsConnection: {
+					edges: [
+						{ node: { id: '1' } },
+						{ node: { id: '2' } },
+						{ node: { id: '3' } },
+						{ node: { id: '4' } },
+					],
+				},
+			},
+		},
+	})
+
+	const pre = Object.keys(cache._internal_unstable.storage.data[0].links).length
+
+	// write the same connection with only 2 edges. the records for the 2 lost
+	// edges should be cleaned up
+	cache.write({
+		selection,
+		data: {
+			user: {
+				friendsConnection: {
+					edges: [{ node: { id: '1' } }, { node: { id: '2' } }],
+				},
+			},
+		},
+	})
+
+	const post = Object.keys(cache._internal_unstable.storage.data[0].links).length
+
+	expect(post).toBe(pre - 2)
+})


### PR DESCRIPTION
Refetching a connection with `CacheAndNetwork` caused embedded edge records to accumulate in the cache on every fetch — each write generated a new key for each embedded record instead of reusing the existing one, so the old records were never cleaned up. 
  
The fix threads the previous list of embedded IDs into `extractNestedListIDs` so that a normal (non-appending) write reuses the key of the record it replaces. Records that fall out of the list are now explicitly removed from storage and the GC/stale tracking tables.