### PR TITLE
Support proper reverse pages with SinglePage pagination

### DIFF
--- a/.changeset/singlepage-cursor-stack.md
+++ b/.changeset/singlepage-cursor-stack.md
@@ -1,0 +1,6 @@
+---
+'houdini': minor
+'houdini-react': minor
+---
+
+Fix SinglePage cursor pagination to use replace semantics instead of accumulating edges, and add cursor-stack support so forward-only APIs can navigate backward and backward-only APIs can navigate forward after they've seen the previous page.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,6 @@ name: Release
 on:
     push:
         branches:
-            - houdini-2.0
-            - go
             - main
 
 env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,6 @@ on:
     push:
         branches:
             - 'main'
-            - 'houdini-2.0'
 
 env:
     PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/ms-playwright

--- a/.github/workflows/trigger-docs-rebuild.yml
+++ b/.github/workflows/trigger-docs-rebuild.yml
@@ -2,7 +2,7 @@ name: Trigger docs rebuild
 
 on:
   push:
-    branches: [houdini-2.0]
+    branches: [main]
     tags:
       - 'svelte-v*'
       - 'react-v*'

--- a/e2e/_api/graphql.mjs
+++ b/e2e/_api/graphql.mjs
@@ -127,6 +127,16 @@ export const typeDefs = /* GraphQL */ `
 			delay: Int
 			snapshot: String!
 		): UserConnection!
+		usersConnectionForwardOnly(
+			after: String
+			first: Int
+			snapshot: String!
+		): UserConnection!
+		usersConnectionBackwardOnly(
+			before: String
+			last: Int
+			snapshot: String!
+		): UserConnection!
 		usersList(limit: Int = 4, offset: Int, snapshot: String!): [User!]!
 		userNodes(limit: Int = 4, offset: Int, snapshot: String!): UserNodes!
 		userSearch(filter: UserNameFilter!, snapshot: String!): [User!]!
@@ -466,6 +476,12 @@ export const resolvers = {
 				await sleep(args.delay)
 			}
 
+			return connectionFromArray(getUserSnapshot(args.snapshot), args)
+		},
+		usersConnectionForwardOnly: (_, args) => {
+			return connectionFromArray(getUserSnapshot(args.snapshot), args)
+		},
+		usersConnectionBackwardOnly: (_, args) => {
 			return connectionFromArray(getUserSnapshot(args.snapshot), args)
 		},
 		user: async (_, args) => {

--- a/e2e/_api/schema.graphql
+++ b/e2e/_api/schema.graphql
@@ -114,6 +114,16 @@ type Query {
 		delay: Int
 		snapshot: String!
 	): UserConnection!
+	usersConnectionForwardOnly(
+		after: String
+		first: Int
+		snapshot: String!
+	): UserConnection!
+	usersConnectionBackwardOnly(
+		before: String
+		last: Int
+		snapshot: String!
+	): UserConnection!
 	usersList(limit: Int = 4, offset: Int, snapshot: String!): [User!]!
 	userNodes(limit: Int = 4, offset: Int, snapshot: String!): UserNodes!
 	userSearch(filter: UserNameFilter!, snapshot: String!): [User!]!

--- a/e2e/react/src/api/+schema.js
+++ b/e2e/react/src/api/+schema.js
@@ -119,6 +119,16 @@ export const typeDefs = /* GraphQL */ `
 			delay: Int
 			snapshot: String!
 		): UserConnection!
+		usersConnectionForwardOnly(
+			after: String
+			first: Int
+			snapshot: String!
+		): UserConnection!
+		usersConnectionBackwardOnly(
+			before: String
+			last: Int
+			snapshot: String!
+		): UserConnection!
 		usersList(limit: Int = 4, offset: Int, snapshot: String!): [User!]!
 		userNodes(limit: Int = 4, offset: Int, snapshot: String!): UserNodes!
 		userSearch(filter: UserNameFilter!, snapshot: String!): [User!]!

--- a/e2e/react/src/routes/pagination/query/connection-backwards-singlepage/+page.gql
+++ b/e2e/react/src/routes/pagination/query/connection-backwards-singlepage/+page.gql
@@ -1,0 +1,9 @@
+query BackwardsCursorSinglePagePaginationQuery {
+	usersConnectionBackwardOnly(last: 2, snapshot: "pagination-query-backwards-cursor-singlepage") @paginate(mode: SinglePage) {
+		edges {
+			node {
+				name
+			}
+		}
+	}
+}

--- a/e2e/react/src/routes/pagination/query/connection-backwards-singlepage/+page.tsx
+++ b/e2e/react/src/routes/pagination/query/connection-backwards-singlepage/+page.tsx
@@ -1,0 +1,28 @@
+import type { PageProps } from './$types'
+
+export default function ({
+	BackwardsCursorSinglePagePaginationQuery,
+	BackwardsCursorSinglePagePaginationQuery$handle,
+}: PageProps) {
+	const handle = BackwardsCursorSinglePagePaginationQuery$handle
+
+	return (
+		<>
+			<div id="result">
+				{BackwardsCursorSinglePagePaginationQuery.usersConnectionBackwardOnly.edges
+					.map(({ node }) => node?.name)
+					.join(', ')}
+			</div>
+
+			<div id="pageInfo">{JSON.stringify(handle.pageInfo)}</div>
+
+			<button id="previous" onClick={() => handle.loadPrevious()}>
+				previous
+			</button>
+
+			<button id="next" onClick={() => handle.loadNext()}>
+				next
+			</button>
+		</>
+	)
+}

--- a/e2e/react/src/routes/pagination/query/connection-backwards-singlepage/test.ts
+++ b/e2e/react/src/routes/pagination/query/connection-backwards-singlepage/test.ts
@@ -1,0 +1,34 @@
+import { test } from '@playwright/test'
+import { routes } from '~/utils/routes.js'
+import { expect_to_be, expectToContain, expect_1_gql, locator_click, goto } from '~/utils/testsHelper.js'
+
+test.describe('backwards-only cursor single page paginated query', () => {
+	test('loadNextPage via cursor stack (no forwards API support)', async ({ page }) => {
+		await goto(page, routes.pagination_query_backwards_cursor_singlepage)
+
+		await expect_to_be(page, 'Eddie Murphy, Clint Eastwood')
+		await expectToContain(page, `"hasNextPage":false`)
+		await expectToContain(page, `"hasPreviousPage":true`)
+
+		await expect_1_gql(page, 'button[id=previous]')
+		await expect_to_be(page, 'Will Smith, Harrison Ford')
+		await expectToContain(page, `"hasNextPage":true`)
+		await expectToContain(page, `"hasPreviousPage":true`)
+
+		await expect_1_gql(page, 'button[id=previous]')
+		await expect_to_be(page, 'Morgan Freeman, Tom Hanks')
+		await expectToContain(page, `"hasNextPage":true`)
+		await expectToContain(page, `"hasPreviousPage":true`)
+
+		// Cursor stack re-issues a backward query with the prior cursor
+		await locator_click(page, 'button[id=next]')
+		await expect_to_be(page, 'Will Smith, Harrison Ford')
+		await expectToContain(page, `"hasNextPage":true`)
+		await expectToContain(page, `"hasPreviousPage":true`)
+
+		await locator_click(page, 'button[id=next]')
+		await expect_to_be(page, 'Eddie Murphy, Clint Eastwood')
+		await expectToContain(page, `"hasNextPage":false`)
+		await expectToContain(page, `"hasPreviousPage":true`)
+	})
+})

--- a/e2e/react/src/routes/pagination/query/connection-forwards-singlepage/+page.gql
+++ b/e2e/react/src/routes/pagination/query/connection-forwards-singlepage/+page.gql
@@ -1,0 +1,9 @@
+query ForwardsCursorSinglePagePaginationQuery {
+	usersConnectionForwardOnly(first: 2, snapshot: "pagination-query-forwards-cursor-singlepage") @paginate(mode: SinglePage) {
+		edges {
+			node {
+				name
+			}
+		}
+	}
+}

--- a/e2e/react/src/routes/pagination/query/connection-forwards-singlepage/+page.tsx
+++ b/e2e/react/src/routes/pagination/query/connection-forwards-singlepage/+page.tsx
@@ -1,0 +1,28 @@
+import type { PageProps } from './$types'
+
+export default function ({
+	ForwardsCursorSinglePagePaginationQuery,
+	ForwardsCursorSinglePagePaginationQuery$handle,
+}: PageProps) {
+	const handle = ForwardsCursorSinglePagePaginationQuery$handle
+
+	return (
+		<>
+			<div id="result">
+				{ForwardsCursorSinglePagePaginationQuery.usersConnectionForwardOnly.edges
+					.map(({ node }) => node?.name)
+					.join(', ')}
+			</div>
+
+			<div id="pageInfo">{JSON.stringify(handle.pageInfo)}</div>
+
+			<button id="previous" onClick={() => handle.loadPrevious()}>
+				previous
+			</button>
+
+			<button id="next" onClick={() => handle.loadNext()}>
+				next
+			</button>
+		</>
+	)
+}

--- a/e2e/react/src/routes/pagination/query/connection-forwards-singlepage/test.ts
+++ b/e2e/react/src/routes/pagination/query/connection-forwards-singlepage/test.ts
@@ -1,0 +1,34 @@
+import { test } from '@playwright/test'
+import { routes } from '~/utils/routes.js'
+import { expect_to_be, expectToContain, expect_1_gql, locator_click, goto } from '~/utils/testsHelper.js'
+
+test.describe('forwards-only cursor single page paginated query', () => {
+	test('loadPreviousPage via cursor stack (no backwards API support)', async ({ page }) => {
+		await goto(page, routes.pagination_query_forwards_cursor_singlepage)
+
+		await expect_to_be(page, 'Bruce Willis, Samuel Jackson')
+		await expectToContain(page, `"hasPreviousPage":false`)
+		await expectToContain(page, `"hasNextPage":true`)
+
+		await expect_1_gql(page, 'button[id=next]')
+		await expect_to_be(page, 'Morgan Freeman, Tom Hanks')
+		await expectToContain(page, `"hasPreviousPage":true`)
+		await expectToContain(page, `"hasNextPage":true`)
+
+		await expect_1_gql(page, 'button[id=next]')
+		await expect_to_be(page, 'Will Smith, Harrison Ford')
+		await expectToContain(page, `"hasPreviousPage":true`)
+		await expectToContain(page, `"hasNextPage":true`)
+
+		// Cursor stack re-issues a forward query with the prior cursor
+		await locator_click(page, 'button[id=previous]')
+		await expect_to_be(page, 'Morgan Freeman, Tom Hanks')
+		await expectToContain(page, `"hasPreviousPage":true`)
+		await expectToContain(page, `"hasNextPage":true`)
+
+		await locator_click(page, 'button[id=previous]')
+		await expect_to_be(page, 'Bruce Willis, Samuel Jackson')
+		await expectToContain(page, `"hasPreviousPage":false`)
+		await expectToContain(page, `"hasNextPage":true`)
+	})
+})

--- a/e2e/react/src/utils/routes.ts
+++ b/e2e/react/src/utils/routes.ts
@@ -15,6 +15,8 @@ export const routes = {
 	pagination_dedupe: '/pagination/query/dedupe',
 	pagination_query_offset_singlepage: '/pagination/query/offset-singlepage',
 	pagination_query_bidirectional_cursor_singlepage: '/pagination/query/connection-bidirectional-singlepage',
+	pagination_query_forwards_cursor_singlepage: '/pagination/query/connection-forwards-singlepage',
+	pagination_query_backwards_cursor_singlepage: '/pagination/query/connection-backwards-singlepage',
 	pagination_query_offset_variable: '/pagination/query/offset-variable/2',
 	optimistic_keys: '/optimistic-keys',
 	node_plugin: '/node-plugin',

--- a/packages/houdini-core/plugin/documents/artifacts/selection.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection.go
@@ -880,7 +880,7 @@ func stringifySelection(
 func keyField(field *collected.Selection, paginatedMode *string) string {
 	if len(field.Arguments) == 0 {
 		paginationSuffix := ""
-		if paginatedMode != nil {
+		if paginatedMode != nil && *paginatedMode == graphql.PaginationModeInfinite {
 			paginationSuffix = "::paginated"
 		}
 		return `"` + *field.Alias + paginationSuffix + `"`
@@ -909,7 +909,7 @@ func keyField(field *collected.Selection, paginatedMode *string) string {
 	}
 
 	paginationSuffix := ""
-	if paginatedMode != nil {
+	if paginatedMode != nil && *paginatedMode == graphql.PaginationModeInfinite {
 		paginationSuffix = "::paginated"
 	}
 
@@ -946,11 +946,14 @@ func stringifyFieldSelection(
 			paginatedMode = &selection.List.Mode
 		}
 		updates = []string{}
-		if selection.List.SupportsForward {
-			updates = append(updates, "append")
-		}
-		if selection.List.SupportsBackward {
-			updates = append(updates, "prepend")
+		// SinglePage pagination uses replace semantics — never accumulate edges
+		if !selection.List.Paginated || selection.List.Mode != graphql.PaginationModeSinglePage {
+			if selection.List.SupportsForward {
+				updates = append(updates, "append")
+			}
+			if selection.List.SupportsBackward {
+				updates = append(updates, "prepend")
+			}
 		}
 
 		// @paginate always wins over @list when both appear in the same document

--- a/packages/houdini-core/plugin/documents/artifacts/selection_lists_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_lists_test.go
@@ -806,7 +806,7 @@ export type TestQuery$artifact = typeof artifact
         "fields": {
             "usersByCursor": {
                 "type": "UserConnection",
-                "keyRaw": "usersByCursor(after: $after, before: $before, first: $first, last: $last)::paginated",
+                "keyRaw": "usersByCursor(after: $after, before: $before, first: $first, last: $last)",
 
                 "directives": [{
                     "name": "paginate",
@@ -838,7 +838,6 @@ export type TestQuery$artifact = typeof artifact
                         "edges": {
                             "type": "UserEdge",
                             "keyRaw": "edges",
-                            "updates": ["append", "prepend"],
 
                             "selection": {
                                 "fields": {
@@ -895,7 +894,6 @@ export type TestQuery$artifact = typeof artifact
                                     "endCursor": {
                                         "type": "String",
                                         "keyRaw": "endCursor",
-                                        "updates": ["append"],
                                         "nullable": true,
                                         "visible": true,
                                     },
@@ -903,21 +901,18 @@ export type TestQuery$artifact = typeof artifact
                                     "hasNextPage": {
                                         "type": "Boolean",
                                         "keyRaw": "hasNextPage",
-                                        "updates": ["append"],
                                         "visible": true,
                                     },
 
                                     "hasPreviousPage": {
                                         "type": "Boolean",
                                         "keyRaw": "hasPreviousPage",
-                                        "updates": ["prepend"],
                                         "visible": true,
                                     },
 
                                     "startCursor": {
                                         "type": "String",
                                         "keyRaw": "startCursor",
-                                        "updates": ["prepend"],
                                         "nullable": true,
                                         "visible": true,
                                     },

--- a/packages/houdini-core/plugin/documents/artifacts/selection_pagination_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_pagination_test.go
@@ -398,7 +398,7 @@ export type PaginatedFragment$artifact = typeof artifact
 
             "friendsByCursor": {
                 "type": "UserConnection",
-                "keyRaw": "friendsByCursor(filter: \"hello\", first: 10)::paginated",
+                "keyRaw": "friendsByCursor(filter: \"hello\", first: 10)",
                 "nullable": true,
 
                 "directives": [{
@@ -422,7 +422,6 @@ export type PaginatedFragment$artifact = typeof artifact
                         "edges": {
                             "type": "UserEdge",
                             "keyRaw": "edges",
-                            "updates": ["append", "prepend"],
 
                             "selection": {
                                 "fields": {
@@ -474,7 +473,6 @@ export type PaginatedFragment$artifact = typeof artifact
                                     "endCursor": {
                                         "type": "String",
                                         "keyRaw": "endCursor",
-                                        "updates": ["append"],
                                         "nullable": true,
                                         "visible": true,
                                     },
@@ -482,21 +480,18 @@ export type PaginatedFragment$artifact = typeof artifact
                                     "hasNextPage": {
                                         "type": "Boolean",
                                         "keyRaw": "hasNextPage",
-                                        "updates": ["append"],
                                         "visible": true,
                                     },
 
                                     "hasPreviousPage": {
                                         "type": "Boolean",
                                         "keyRaw": "hasPreviousPage",
-                                        "updates": ["prepend"],
                                         "visible": true,
                                     },
 
                                     "startCursor": {
                                         "type": "String",
                                         "keyRaw": "startCursor",
-                                        "updates": ["prepend"],
                                         "nullable": true,
                                         "visible": true,
                                     },
@@ -1840,7 +1835,7 @@ export type TestQuery$artifact = typeof artifact
 
                         "moves": {
                             "type": "SpeciesMoveConnection",
-                            "keyRaw": "moves(after: $after, first: $first)::paginated",
+                            "keyRaw": "moves(after: $after, first: $first)",
 
                             "directives": [{
                                 "name": "paginate",
@@ -1863,7 +1858,6 @@ export type TestQuery$artifact = typeof artifact
                                     "edges": {
                                         "type": "SpeciesMoveEdge",
                                         "keyRaw": "edges",
-                                        "updates": ["append"],
 
                                         "selection": {
                                             "fields": {
@@ -1920,7 +1914,6 @@ export type TestQuery$artifact = typeof artifact
                                                 "endCursor": {
                                                     "type": "String",
                                                     "keyRaw": "endCursor",
-                                                    "updates": ["append"],
                                                     "nullable": true,
                                                     "visible": true,
                                                 },
@@ -1928,14 +1921,12 @@ export type TestQuery$artifact = typeof artifact
                                                 "hasNextPage": {
                                                     "type": "Boolean",
                                                     "keyRaw": "hasNextPage",
-                                                    "updates": ["append"],
                                                     "visible": true,
                                                 },
 
                                                 "hasPreviousPage": {
                                                     "type": "Boolean",
                                                     "keyRaw": "hasPreviousPage",
-                                                    "updates": ["prepend"],
                                                     "visible": true,
                                                 },
 

--- a/packages/houdini-react/runtime/hooks/useDocumentHandle.ts
+++ b/packages/houdini-react/runtime/hooks/useDocumentHandle.ts
@@ -33,6 +33,9 @@ export function useDocumentHandle<
 }): DocumentHandle<_Artifact, _Data, _Input> & { fetch: FetchFn<_Data, _Input> } {
 	const [forwardPending, setForwardPending] = React.useState(false)
 	const [backwardPending, setBackwardPending] = React.useState(false)
+	// Stable cursor stacks for SinglePage pagination — must survive re-renders caused by store updates
+	const previousCursorsRef = React.useRef<(string | null)[]>([])
+	const nextCursorsRef = React.useRef<(string | null)[]>([])
 	const location = useLocation()
 
 	// grab the current session value
@@ -127,6 +130,8 @@ export function useDocumentHandle<
 				getState: () => storeValue.data,
 				getVariables: () => storeValue.variables!,
 				fetch: fetchQuery,
+				previousCursors: previousCursorsRef.current,
+				nextCursors: nextCursorsRef.current,
 				fetchUpdate: (args, updates) => {
 					return paginationObserver!.send({
 						...args,

--- a/packages/houdini/src/runtime/pagination.ts
+++ b/packages/houdini/src/runtime/pagination.ts
@@ -22,6 +22,8 @@ export function cursorHandlers<
 	getState,
 	getVariables,
 	getSession,
+	previousCursors = [],
+	nextCursors = [],
 }: {
 	artifact: QueryArtifact
 	getState: () => _Data | null
@@ -29,7 +31,10 @@ export function cursorHandlers<
 	getSession: () => Promise<App.Session>
 	fetch: FetchFn<_Data, _Input>
 	fetchUpdate: (arg: SendParams, updates: string[]) => ReturnType<FetchFn<_Data, _Input>>
+	previousCursors?: (string | null)[]
+	nextCursors?: (string | null)[]
 }): CursorHandlers<_Data, _Input> {
+
 	// dry up the page-loading logic
 	const loadPage = async ({
 		pageSizeVar,
@@ -89,6 +94,38 @@ export function cursorHandlers<
 			fetch?: typeof globalThis.fetch
 			metadata?: {}
 		} = {}) => {
+			const isSinglePage = artifact.refetch?.mode === 'SinglePage'
+			const direction = artifact.refetch?.direction
+
+			// Backward-only SinglePage: use nextCursors stack to re-issue a backward query
+			if (isSinglePage && direction === 'backward') {
+				if (nextCursors.length === 0) {
+					return Promise.resolve({
+						data: getState(),
+						errors: null,
+						fetching: false,
+						partial: false,
+						stale: false,
+						source: DataSource.Cache,
+						variables: getVariables(),
+					})
+				}
+				const beforeCursor = nextCursors.pop()!
+				return loadPage({
+					pageSizeVar: 'last',
+					functionName: 'loadNextPage',
+					input: {
+						before: beforeCursor,
+						last: first ?? artifact.refetch!.pageSize,
+						first: null,
+						after: null,
+					} as unknown as _Input,
+					fetch,
+					metadata,
+					where: 'start',
+				})
+			}
+
 			// we need to find the connection object holding the current page info
 			const currentPageInfo = getPageInfo()
 			// if there is no next page, we're done
@@ -102,6 +139,11 @@ export function cursorHandlers<
 					source: DataSource.Cache,
 					variables: getVariables(),
 				})
+			}
+
+			// Forward-only SinglePage: push current 'after' so we can navigate back later
+			if (isSinglePage && direction === 'forward') {
+				previousCursors.push((getVariables() as any)?.after ?? null)
 			}
 
 			// only specify the page count if we're given one
@@ -133,10 +175,42 @@ export function cursorHandlers<
 			fetch?: typeof globalThis.fetch
 			metadata?: {}
 		} = {}) => {
+			const isSinglePage = artifact.refetch?.mode === 'SinglePage'
+			const direction = artifact.refetch?.direction
+
+			// Forward-only SinglePage: use previousCursors stack to re-issue a forward query
+			if (isSinglePage && direction === 'forward') {
+				if (previousCursors.length === 0) {
+					return Promise.resolve({
+						data: getState(),
+						errors: null,
+						fetching: false,
+						partial: false,
+						stale: false,
+						source: DataSource.Cache,
+						variables: getVariables(),
+					})
+				}
+				const afterCursor = previousCursors.pop()!
+				return loadPage({
+					pageSizeVar: 'first',
+					functionName: 'loadPreviousPage',
+					input: {
+						after: afterCursor,
+						first: last ?? artifact.refetch!.pageSize,
+						before: null,
+						last: null,
+					} as unknown as _Input,
+					fetch,
+					metadata,
+					where: 'end',
+				})
+			}
+
 			// we need to find the connection object holding the current page info
 			const currentPageInfo = getPageInfo()
 
-			// if there is no next page, we're done
+			// if there is no previous page, we're done
 			if (!currentPageInfo.hasPreviousPage) {
 				return Promise.resolve({
 					data: getState(),
@@ -147,6 +221,11 @@ export function cursorHandlers<
 					source: DataSource.Cache,
 					variables: getVariables(),
 				})
+			}
+
+			// Backward-only SinglePage: push current 'before' so we can navigate forward later
+			if (isSinglePage && direction === 'backward') {
+				nextCursors.push((getVariables() as any)?.before ?? null)
 			}
 
 			// only specify the page count if we're given one

--- a/packages/houdini/src/runtime/pagination.ts
+++ b/packages/houdini/src/runtime/pagination.ts
@@ -34,7 +34,6 @@ export function cursorHandlers<
 	previousCursors?: (string | null)[]
 	nextCursors?: (string | null)[]
 }): CursorHandlers<_Data, _Input> {
-
 	// dry up the page-loading logic
 	const loadPage = async ({
 		pageSizeVar,


### PR DESCRIPTION
SinglePage pagination was incorrectly using accumulation semantics — the ::paginated cache key suffix and append/prepend edge updates that exist for Infinite mode were leaking into SinglePage, causing pages to stack rather than replace each other.

Now, when a forward-only API is paginated in SinglePage mode, loadPreviousPage now re-issues a forward query using a client-side stack of prior cursors rather than sending before/last args the server doesn't understand. Backward-only APIs get the symmetric treatment for loadNextPage.
