### PR TITLE
Fix enum serialization and single-page fragment pagination flash

### DIFF
--- a/.changeset/fix-serialized-enums.md
+++ b/.changeset/fix-serialized-enums.md
@@ -1,0 +1,5 @@
+---
+'houdini-core': patch
+---
+
+Fixed enum literals inside object and list arguments being serialized as quoted strings in printed queries.

--- a/.changeset/fix-singlepage-pagination.md
+++ b/.changeset/fix-singlepage-pagination.md
@@ -1,0 +1,7 @@
+---
+'houdini': patch
+'houdini-react': patch
+'houdini-svelte': patch
+---
+
+Fixed a flash of intermediate data during single-page fragment pagination and unnecessary network requests on backward navigation by suppressing partial cache hits and preserving marshaled variables across consecutive sends.

--- a/packages/houdini-core/plugin/documents/artifacts/print.go
+++ b/packages/houdini-core/plugin/documents/artifacts/print.go
@@ -355,6 +355,28 @@ func printValue(value *collected.ArgumentValue, usedVariables map[string]bool) s
 	switch value.Kind {
 	case "Enum":
 		return value.Raw
+	case "Object":
+		var resultBuilder strings.Builder
+		resultBuilder.WriteRune('{')
+		for i, v := range value.Children {
+			fmt.Fprintf(&resultBuilder, "%s: %s", v.Name, printValue(v.Value, usedVariables))
+			if i != len(value.Children)-1 {
+				resultBuilder.WriteString(", ")
+			}
+		}
+		resultBuilder.WriteRune('}')
+		return resultBuilder.String()
+	case "List":
+		var resultBuilder strings.Builder
+		resultBuilder.WriteRune('[')
+		for i, v := range value.Children {
+			resultBuilder.WriteString(printValue(v.Value, usedVariables))
+			if i != len(value.Children)-1 {
+				resultBuilder.WriteString(", ")
+			}
+		}
+		resultBuilder.WriteRune(']')
+		return resultBuilder.String()
 	default:
 		return stringifyValue(value, usedVariables)
 	}

--- a/packages/houdini-core/plugin/documents/artifacts/print_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/print_test.go
@@ -91,6 +91,7 @@ func TestDocumentCollectAndPrint(t *testing.T) {
       input ObjectInput {
         key: String
         block: String
+        site: Site
       }
 
       scalar ComplexType
@@ -372,6 +373,28 @@ func TestDocumentCollectAndPrint(t *testing.T) {
 						    node(ids: $ids)
 						}
 					`),
+				},
+			},
+			{
+				Name: "Enum literal inside object argument is not quoted",
+				Pass: true,
+				Input: []string{
+					`
+					fragment EnumObjFrag on Friend @arguments(size: {type: "String"}, b: {type: "String"}) {
+					  foo(
+					    size: $size
+					    bar: $b
+					    obj: {key: "value", site: MOBILE}
+					  )
+					}
+				`,
+				},
+				Extra: map[string]any{
+					"EnumObjFrag": tests.Dedent(`
+					fragment EnumObjFrag on Friend {
+					    foo(bar: $b, obj: {key: "value", site: MOBILE}, size: $size)
+					}
+				`),
 				},
 			},
 			{

--- a/packages/houdini-core/runtime/plugins/cache.ts
+++ b/packages/houdini-core/runtime/plugins/cache.ts
@@ -49,8 +49,12 @@ export const cachePolicy =
 						// we can only use the result if its not a partial result
 						const allowed =
 							!value.partial ||
-							// or the artifact allows for partial responses
-							(artifact.kind === ArtifactKind.Query && artifact.partial)
+							// or the artifact allows for partial responses, and the caller
+							// hasn't opted out (e.g. SinglePage pagination suppresses partial
+							// cache hits to avoid flashing intermediate states)
+							(artifact.kind === ArtifactKind.Query &&
+								artifact.partial &&
+								!ctx.cacheParams?.disablePartial)
 
 						// if the policy is cacheOnly and we got this far, we need to return null (no network request will be sent)
 						if (policy === CachePolicy.CacheOnly) {

--- a/packages/houdini-react/runtime/hooks/useFragmentHandle.ts
+++ b/packages/houdini-react/runtime/hooks/useFragmentHandle.ts
@@ -9,7 +9,6 @@ import type {
 import * as React from 'react'
 
 import { useClient, useSession } from '../routing/Router.js'
-import type { DocumentHandle } from './useDocumentHandle.js'
 import { fragmentReference, useFragment } from './useFragment.js'
 
 // useFragmentHandle is just like useFragment except it also returns an imperative handle
@@ -24,10 +23,7 @@ export function useFragmentHandle<
 	reference: _Data | { ' $fragments': _ReferenceType } | null,
 	document: { artifact: FragmentArtifact; refetchArtifact?: QueryArtifact }
 ): any {
-	// get the fragment values
 	const fragmentData = useFragment<_Data, _ReferenceType, _Input>(reference, document)
-
-	// look at the fragment reference to get the variables
 	const { variables } = fragmentReference<_Data, _Input, _ReferenceType>(reference, document)
 
 	const client = useClient()
@@ -36,30 +32,25 @@ export function useFragmentHandle<
 	const [forwardPending, setForwardPending] = React.useState(false)
 	const [backwardPending, setBackwardPending] = React.useState(false)
 
-	// Stable cursor stacks for SinglePage pagination — must survive re-renders
 	const previousCursorsRef = React.useRef<(string | null)[]>([])
 	const nextCursorsRef = React.useRef<(string | null)[]>([])
 
 	const refetchArtifact = document.refetchArtifact as QueryArtifact | undefined
 	const refetchPath = refetchArtifact?.refetch?.path
 
-	// Dedicated observer for pagination queries — separate from the fragment observer.
-	// cursorHandlers derives entity variables (e.g. { id }) and artifact defaults
-	// automatically via the type config, so no manual variable extraction is needed here.
 	const paginationObserver = React.useMemo(() => {
 		if (!refetchArtifact?.refetch?.paginated) return null
 		return client.observe<_Data, _Input>({ artifact: refetchArtifact })
 	}, [refetchArtifact?.name])
 
-	// Subscribe to the pagination observer so React re-renders whenever a new page is fetched
-	// or served from cache (CacheOrNetwork). The fragment store subscription only watches the
-	// initial page's cache key; the observer is the live source of truth for SinglePage
-	// pagination where each page lives at its own per-cursor cache key.
+	const isSinglePage = refetchArtifact?.refetch?.mode === 'SinglePage'
+
+	// Subscribe to the pagination observer so the component re-renders when a new page lands.
+	// For SinglePage we pass disablePartial so partial cache hits (entity found but connection
+	// not yet fetched) are never resolved back to the observer — we go straight to the network
+	// and update the observer only once we have a complete page.
 	const subscribeToObserver = React.useCallback(
-		(onChange: () => void) => {
-			if (!paginationObserver) return () => {}
-			return paginationObserver.subscribe(onChange)
-		},
+		(fn: () => void) => paginationObserver?.subscribe(() => fn()) ?? (() => {}),
 		[paginationObserver]
 	)
 	const getObserverSnapshot = React.useCallback(
@@ -72,28 +63,13 @@ export function useFragmentHandle<
 		getObserverSnapshot
 	)
 
-	// Extract entity-level data from the pagination query response. For Node targetType
-	// the response is { node: EntityData }; we take the first root field to handle any type.
-	// Guard against partial cache hits (artifact has partial:true): only use the entity once the
-	// paginated connection field at refetch.path[0] is actually present in the response.
 	const paginationEntityData = React.useMemo<_Data | null>(() => {
 		if (!paginationData || !refetchArtifact?.selection?.fields) return null
 		const rootField = Object.keys(refetchArtifact.selection.fields)[0]
 		if (!rootField) return null
-		const entity = (paginationData as any)[rootField]
-		if (!entity) return null
-		const path = refetchArtifact.refetch?.path
-		if (path && path.length > 0 && (entity as any)[path[0]] == null) {
-			return null
-		}
-		return entity as _Data
+		return (paginationData as any)[rootField] ?? null
 	}, [paginationData, refetchArtifact])
 
-	const isSinglePage = refetchArtifact?.refetch?.mode === 'SinglePage'
-
-	// For SinglePage: use the pagination observer's entity data (each page has its own
-	// cache key) once a page fetch has landed. For Infinite: always use fragmentData,
-	// which reads accumulated pages from cache via the fragment's cache subscription.
 	const displayData =
 		isSinglePage && paginationEntityData !== null ? paginationEntityData : fragmentData
 
@@ -120,7 +96,19 @@ export function useFragmentHandle<
 		if (!refetchArtifact?.refetch?.paginated || !paginationObserver) return null
 
 		const fetchFn: FetchFn<_Data, _Input> = (args) => {
-			return paginationObserver.send({ ...args, session })
+			return paginationObserver.send({
+				...args,
+				session,
+				stuff: { silenceLoading: true },
+				cacheParams: {
+					disableSubscriptions: true,
+					// Suppress partial cache hits so an in-flight forward navigation never
+					// briefly resolves with an entity that is missing its connection field.
+					// Full cache hits (partial: false) still resolve, so backward navigation
+					// continues to be served instantly from cache.
+					disablePartial: true,
+				},
+			})
 		}
 
 		const fetchUpdate = (args: any, updates: string[]) => {
@@ -139,8 +127,6 @@ export function useFragmentHandle<
 			const handlers = cursorHandlers<_Data, _Input>({
 				artifact: refetchArtifact,
 				getState: () => displayData as _Data | null,
-				// Use the observer's own variable state so cursor history is preserved
-				// across page navigations without manual tracking in the hook.
 				getVariables: () =>
 					(paginationObserver.state.variables ?? variables) as NonNullable<_Input>,
 				fetch: fetchFn,

--- a/packages/houdini-react/runtime/hooks/useFragmentHandle.ts
+++ b/packages/houdini-react/runtime/hooks/useFragmentHandle.ts
@@ -9,6 +9,7 @@ import type {
 import * as React from 'react'
 
 import { useClient, useSession } from '../routing/Router.js'
+import type { DocumentHandle } from './useDocumentHandle.js'
 import { fragmentReference, useFragment } from './useFragment.js'
 
 // useFragmentHandle is just like useFragment except it also returns an imperative handle

--- a/packages/houdini-svelte/runtime/stores/pagination/fragment.ts
+++ b/packages/houdini-svelte/runtime/stores/pagination/fragment.ts
@@ -258,8 +258,12 @@ export class FragmentStoreCursor<
 					...args,
 					variables: resolvedVars,
 					policy: args?.policy,
+					// suppress loading-state placeholder data during SinglePage transitions
+					// so the current page remains visible while the next page loads
+					stuff: { silenceLoading: true },
 					cacheParams: {
 						disableSubscriptions: true,
+						disablePartial: true,
 					},
 				})
 			},

--- a/packages/houdini/src/runtime/documentStore.ts
+++ b/packages/houdini/src/runtime/documentStore.ts
@@ -607,9 +607,12 @@ class ClientPluginContextWrapper {
 		const firstInit = !ctx.stuff.inputs?.init
 		const hasChanged = Object.keys(changed).length > 0 || firstInit
 		if (hasChanged) {
-			// only marshal the changed variables so we don't double marshal
+			// only marshal the changed variables so we don't double marshal.
+			// Use source.stuff.inputs?.marshaled as the base — ctx.stuff comes from the
+			// caller-supplied `values` object (which starts with marshaled: {}) so it
+			// does not carry the previously-marshaled variables that haven't changed.
 			const newVariables = {
-				...ctx.stuff.inputs?.marshaled,
+				...source.stuff.inputs?.marshaled,
 				...marshalInputs({
 					artifact,
 					input: changed,
@@ -717,6 +720,7 @@ export type ClientPluginContext = {
 		disableWrite?: boolean
 		disableRead?: boolean
 		disableSubscriptions?: boolean
+		disablePartial?: boolean
 		applyUpdates?: string[]
 		serverSideFallback?: boolean
 	}


### PR DESCRIPTION
- Fixed enum literals inside object and list arguments being serialized as quoted strings in printed queries. 
- Fixed a flash of intermediate data and unnecessary backward-navigation network requests in single-page fragment pagination.
