### PR TITLE
more fragment argument fixes

### DIFF
--- a/.changeset/funny-ducks-give.md
+++ b/.changeset/funny-ducks-give.md
@@ -1,0 +1,6 @@
+---
+"houdini-core": patch
+"houdini": patch
+---
+
+More fixes for example fragment variables

--- a/packages/houdini-core/plugin/fragmentArguments/transform.go
+++ b/packages/houdini-core/plugin/fragmentArguments/transform.go
@@ -341,41 +341,42 @@ func processDocument[PluginConfig any](
 
 		// the first thing we have to do is compute the set of values being passed to the processedFragments
 		fragmentHashArgs := map[string]string{}
-		documentScope := map[string]DocArg{}
 		fragmentScopeVariables := []DocArg{}
-		for _, arg := range docArgs {
-			if arg.DefaultValue != 0 {
-				documentScope[arg.Name] = arg
-			}
-		}
 		fragmentScope := map[string]int64{}
+		coveredArgs := map[string]bool{}
 		for _, arg := range withArgs {
+			coveredArgs[arg.Name] = true
 			// if the argument kind is a variable then we have 2 options, we either use the
 			// parent scope or we have a default value
 			if arg.Kind == "Variable" {
-				for _, docArg := range docArgs {
-					if arg.Name == docArg.Name {
-						fragmentScopeVariables = append(fragmentScopeVariables, docArg)
-					}
-				}
-
-				// Hash the fragment variant by the caller's variable name so that
-				// @with(name: $x) and @with(name: $y) produce distinct clones.
+				// Hash by the caller's variable name so @with(name: $x) and @with(name: $y)
+				// produce distinct clones.
 				fragmentHashArgs[arg.Name] = arg.Raw
 
-				// Find the fragment's own variable reference so CopyScope produces an
-				// identical copy in the clone. ReplaceVariables swaps the clone's value
-				// for that copy (same kind/raw), leaving the variable intact.
-				db.BindStatement(statements.FragmentOwnVariableSearch, map[string]any{
-					"raw": arg.Name,
-					"doc": fragmentDocID,
-				})
-				db.StepStatement(ctx, statements.FragmentOwnVariableSearch, func() {
-					fragmentScope[arg.Name] = statements.FragmentOwnVariableSearch.GetInt64("id")
-				})
+				callerVal, inScope := scope[arg.Raw]
+				if !inScope {
+					// ReplaceVariables already ran on this document, so the variable may have
+					// been renamed (e.g. $outerName → $userId). arg.Value is the current
+					// argument_value ID in this document, which already holds the right value.
+					callerVal = arg.Value
+				}
+				fragmentScope[arg.Name] = callerVal
+				for _, docArg := range docArgs {
+					if docArg.Name == arg.Name {
+						fragmentScopeVariables = append(fragmentScopeVariables, docArg)
+						break
+					}
+				}
 			} else {
 				fragmentScope[arg.Name] = arg.Value
 				fragmentHashArgs[arg.Name] = arg.Raw
+			}
+		}
+		// Inline defaults for any declared fragment args that @with didn't cover.
+		for _, docArg := range docArgs {
+			if !coveredArgs[docArg.Name] && docArg.DefaultValue != 0 {
+				fragmentScope[docArg.Name] = docArg.DefaultValue
+				fragmentHashArgs[docArg.Name] = docArg.Raw
 			}
 		}
 
@@ -1095,7 +1096,6 @@ type transformStatements[PluginConfig any] struct {
 	DirectiveArgumentSearch            plugins.Stmt
 	UpdateDirectiveArgument            plugins.Stmt
 	NoSelectionArgsDirectiveArgsSearch plugins.Stmt
-	FragmentOwnVariableSearch          plugins.Stmt
 	nullValue                          int64
 }
 
@@ -1145,8 +1145,7 @@ func (s *transformStatements[PluginConfig]) CopyScope(
         END as children
       FROM args 
         LEFT JOIN argument_value_children on argument_value_children.parent = args.id
-      GROUP BY args.id 
-      ORDER BY args.id DESC
+      GROUP BY args.id
   `, whereIn))
 	if err != nil {
 		return nil, err
@@ -1607,13 +1606,6 @@ func prepareTransformStatements[PluginConfig any](
 		return nil, err
 	}
 
-	fragmentOwnVariableSearch, err := conn.Prepare(`
-    SELECT id FROM argument_values WHERE kind = 'Variable' AND raw = $raw AND document = $doc LIMIT 1
-  `)
-	if err != nil {
-		return nil, err
-	}
-
 	return &transformStatements[PluginConfig]{
 		WithSpreadsInDocument:              withSpreadsInDocument,
 		DeleteValue:                        deleteValue,
@@ -1629,7 +1621,6 @@ func prepareTransformStatements[PluginConfig any](
 		DirectiveArgumentSearch:            directiveArgVariables,
 		UpdateDirectiveArgument:            updateDirectiveArgument,
 		NoSelectionArgsDirectiveArgsSearch: noArgSelectionsDirectiveArgsSearch,
-		FragmentOwnVariableSearch:          fragmentOwnVariableSearch,
 		InsertArgumentValue:                insertArgumentValue,
 		InsertArgumentValueChildren:        insertArgumentValueChildren,
 		InsertDocumentVariable:             insertDocumentVariable,
@@ -1669,7 +1660,6 @@ func (s *transformStatements[PluginConfig]) Finalize() {
 	s.UpdateDirectiveArgument.Finalize()
 	s.NoSelectionArgsDirectiveArgsSearch.Finalize()
 	s.CopyArgumentValue.Finalize()
-	s.FragmentOwnVariableSearch.Finalize()
 }
 
 func (s *transformStatements[PluginConfig]) ReplaceVariables(

--- a/packages/houdini-core/plugin/fragmentArguments/transform_test.go
+++ b/packages/houdini-core/plugin/fragmentArguments/transform_test.go
@@ -22,7 +22,8 @@ func TestFragmentArgumentTransform(t *testing.T) {
 
       type User {
         firstName: String!
-        friends(name: String): [User!]!
+        friends(name: String, limit: Int, offset: Int): [User!]!
+        friendsByNames(names: [String!]): [User!]!
         id: ID!
       }
     `,
@@ -72,10 +73,10 @@ func TestFragmentArgumentTransform(t *testing.T) {
 						Type:          "String",
 						TypeModifiers: "!",
 					}),
-				},
 			},
-			{
-				Name: "Passes argument values to generated fragments",
+		},
+		{
+			Name: "Passes argument values to generated fragments",
 				Pass: true,
 				Input: []string{
 					`
@@ -369,6 +370,109 @@ func TestFragmentArgumentTransform(t *testing.T) {
 				},
 			},
 			{
+				Name: "Default value is inlined when arg omitted from @with",
+				Pass: true,
+				Input: []string{
+					`query Q($limit: Int!) { user { ...F @with(limit: $limit) } }`,
+					`fragment F on User @arguments(limit: {type: "Int!"}, offset: {type: "Int", default: 5}) { friends(limit: $limit, offset: $offset) { firstName } }`,
+				},
+				Expected: []tests.ExpectedDocument{
+					tests.ExpectedDoc(
+						`query Q($limit: Int!) { user { ...F_2quo11 @with(limit: $limit) __typename id } }`,
+					),
+					tests.ExpectedDoc(
+						`fragment F_2quo11 on User { friends(limit: $limit, offset: 5) { firstName id __typename } id __typename }`,
+					).WithVariables(tests.ExpectedOperationVariable{Name: "limit", Type: "Int", TypeModifiers: "!"}),
+				},
+			},
+			{
+				Name: "Omitting a defaulted arg and passing the same value explicitly produce the same clone",
+				Pass: true,
+				Input: []string{
+					`query Implicit($limit: Int!) { user { ...F @with(limit: $limit) } }`,
+					`query Explicit($limit: Int!) { user { ...F @with(limit: $limit, offset: 5) } }`,
+					`fragment F on User @arguments(limit: {type: "Int!"}, offset: {type: "Int", default: 5}) { friends(limit: $limit, offset: $offset) { firstName } }`,
+				},
+				Expected: []tests.ExpectedDocument{
+					tests.ExpectedDoc(
+						`query Implicit($limit: Int!) { user { ...F_2quo11 @with(limit: $limit) __typename id } }`,
+					),
+					tests.ExpectedDoc(
+						`query Explicit($limit: Int!) { user { ...F_2quo11 @with(limit: $limit, offset: 5) __typename id } }`,
+					),
+					tests.ExpectedDoc(
+						`fragment F_2quo11 on User { friends(limit: $limit, offset: 5) { firstName id __typename } id __typename }`,
+					).WithVariables(tests.ExpectedOperationVariable{Name: "limit", Type: "Int", TypeModifiers: "!"}),
+				},
+			},
+			{
+				Name: "Mixed literal and variable args in the same @with",
+				Pass: true,
+				Input: []string{
+					`query Q($userName: String!) { user { ...F @with(name: $userName, limit: 10) } }`,
+					`fragment F on User @arguments(name: {type: "String!"}, limit: {type: "Int!"}) { friends(name: $name, limit: $limit) { firstName } }`,
+				},
+				Expected: []tests.ExpectedDocument{
+					tests.ExpectedDoc(
+						`query Q($userName: String!) { user { ...F_1CaZGl @with(name: $userName, limit: 10) __typename id } }`,
+					),
+					tests.ExpectedDoc(
+						`fragment F_1CaZGl on User { friends(name: $userName, limit: 10) { firstName id __typename } id __typename }`,
+					).WithVariables(tests.ExpectedOperationVariable{Name: "name", Type: "String", TypeModifiers: "!"}),
+				},
+			},
+			{
+				Name: "Same fragment spread twice with different literal values produces distinct clones",
+				Pass: true,
+				Input: []string{
+					`query Q { user { friendsA: friends { ...F @with(name: "alice") } friendsB: friends { ...F @with(name: "bob") } } }`,
+					`fragment F on User @arguments(name: {type: "String!"}) { friends(name: $name) { firstName } }`,
+				},
+				Expected: []tests.ExpectedDocument{
+					tests.ExpectedDoc(
+						`query Q { user { friendsA: friends { ...F_4p6st7 @with(name: "alice") __typename id } friendsB: friends { ...F_16H5UA @with(name: "bob") __typename id } __typename id } }`,
+					),
+					tests.ExpectedDoc(
+						`fragment F_4p6st7 on User { friends(name: "alice") { firstName id __typename } id __typename }`,
+					),
+					tests.ExpectedDoc(
+						`fragment F_16H5UA on User { friends(name: "bob") { firstName id __typename } id __typename }`,
+					),
+				},
+			},
+			{
+				Name: "List literal argument is inlined into the clone",
+				Pass: true,
+				Input: []string{
+					`query Q { user { ...F @with(names: ["alice", "bob"]) } }`,
+					`fragment F on User @arguments(names: {type: "[String!]!"}) { friendsByNames(names: $names) { firstName } }`,
+				},
+				Expected: []tests.ExpectedDocument{
+					tests.ExpectedDoc(
+						`query Q { user { ...F_TXXm0 @with(names: ["alice", "bob"]) __typename id } }`,
+					),
+					tests.ExpectedDoc(
+						`fragment F_TXXm0 on User { friendsByNames(names: ["alice", "bob"]) { firstName id __typename } id __typename }`,
+					),
+				},
+			},
+			{
+				Name: "String default value is inlined when arg omitted from @with",
+				Pass: true,
+				Input: []string{
+					`query Q($limit: Int!) { user { ...F @with(limit: $limit) } }`,
+					`fragment F on User @arguments(limit: {type: "Int!"}, name: {type: "String", default: "all"}) { friends(name: $name, limit: $limit) { firstName } }`,
+				},
+				Expected: []tests.ExpectedDocument{
+					tests.ExpectedDoc(
+						`query Q($limit: Int!) { user { ...F_3qSBKq @with(limit: $limit) __typename id } }`,
+					),
+					tests.ExpectedDoc(
+						`fragment F_3qSBKq on User { friends(name: "all", limit: $limit) { firstName id __typename } id __typename }`,
+					).WithVariables(tests.ExpectedOperationVariable{Name: "limit", Type: "Int", TypeModifiers: "!"}),
+				},
+			},
+			{
 				Name: "Argument variable can have arbitrary name",
 				Pass: true,
 				Input: []string{
@@ -380,14 +484,90 @@ func TestFragmentArgumentTransform(t *testing.T) {
 						`query Info($userName: String!) { user { ...UserInfo_qDNpv @with(name: $userName) id __typename } }`,
 					),
 					tests.ExpectedDoc(
-						`fragment UserInfo_qDNpv on User { friends(name: $name) { firstName id __typename } id __typename  }`,
-					).WithVariables(
-						tests.ExpectedOperationVariable{
-							Name:          "name",
-							Type:          "String",
-							TypeModifiers: "!",
-						},
+						`fragment UserInfo_qDNpv on User { friends(name: $userName) { firstName id __typename } id __typename  }`,
+					).WithVariables(tests.ExpectedOperationVariable{
+						Name:          "name",
+						Type:          "String",
+						TypeModifiers: "!",
+					}),
+				},
+			},
+			{
+				Name: "Mixed same-name and renamed variable arguments",
+				Pass: true,
+				Input: []string{
+					`query Q($shared: String!, $renamed: String!) { user { ...F @with(a: $shared, b: $renamed) } }`,
+					`fragment F on User @arguments(a: {type: "String!"}, b: {type: "String!"}) { friendsA: friends(name: $a) { firstName } friendsB: friends(name: $b) { firstName } }`,
+				},
+				Expected: []tests.ExpectedDocument{
+					tests.ExpectedDoc(
+						`query Q($shared: String!, $renamed: String!) { user { ...F_3fkJCt @with(a: $shared, b: $renamed) id __typename } }`,
 					),
+					tests.ExpectedDoc(
+						`fragment F_3fkJCt on User { friendsA: friends(name: $shared) { firstName id __typename } friendsB: friends(name: $renamed) { firstName id __typename } id __typename }`,
+					).WithVariables(
+						tests.ExpectedOperationVariable{Name: "a", Type: "String", TypeModifiers: "!"},
+						tests.ExpectedOperationVariable{Name: "b", Type: "String", TypeModifiers: "!"},
+					),
+				},
+			},
+			{
+				Name: "Same fragment spread with two different variable names produces distinct clones",
+				Pass: true,
+				Input: []string{
+					`query Q($x: String!, $y: String!) { user { ...F @with(name: $x) friends { ...F @with(name: $y) } } }`,
+					`fragment F on User @arguments(name: {type: "String!"}) { friends(name: $name) { firstName } }`,
+				},
+				Expected: []tests.ExpectedDocument{
+					tests.ExpectedDoc(
+						`query Q($x: String!, $y: String!) { user { ...F_bdaPf @with(name: $x) friends { ...F_2bkMuv @with(name: $y) id __typename } id __typename } }`,
+					),
+					tests.ExpectedDoc(
+						`fragment F_bdaPf on User { friends(name: $x) { firstName id __typename } id __typename }`,
+					).WithVariables(tests.ExpectedOperationVariable{Name: "name", Type: "String", TypeModifiers: "!"}),
+					tests.ExpectedDoc(
+						`fragment F_2bkMuv on User { friends(name: $y) { firstName id __typename } id __typename }`,
+					).WithVariables(tests.ExpectedOperationVariable{Name: "name", Type: "String", TypeModifiers: "!"}),
+				},
+			},
+			{
+				Name: "Fragment spreads fragment with variable argument",
+				Pass: true,
+				Input: []string{
+					`query Q($name: String!) { user { ...Outer @with(name: $name) } }`,
+					`fragment Outer on User @arguments(name: {type: "String!"}) { ...Inner @with(name: $name) }`,
+					`fragment Inner on User @arguments(name: {type: "String!"}) { friends(name: $name) { firstName } }`,
+				},
+				Expected: []tests.ExpectedDocument{
+					tests.ExpectedDoc(
+						`query Q($name: String!) { user { ...Outer_4E9dx0 @with(name: $name) id __typename } }`,
+					),
+					tests.ExpectedDoc(
+						`fragment Outer_4E9dx0 on User { ...Inner_4E9dx0 @with(name: $name) id __typename }`,
+					).WithVariables(tests.ExpectedOperationVariable{Name: "name", Type: "String", TypeModifiers: "!"}),
+					tests.ExpectedDoc(
+						`fragment Inner_4E9dx0 on User { friends(name: $name) { firstName id __typename } id __typename }`,
+					).WithVariables(tests.ExpectedOperationVariable{Name: "name", Type: "String", TypeModifiers: "!"}),
+				},
+			},
+			{
+				Name: "Fragment spreads fragment with renamed variable argument",
+				Pass: true,
+				Input: []string{
+					`query Q($userId: String!) { user { ...Outer @with(outerName: $userId) } }`,
+					`fragment Outer on User @arguments(outerName: {type: "String!"}) { ...Inner @with(innerName: $outerName) }`,
+					`fragment Inner on User @arguments(innerName: {type: "String!"}) { friends(name: $innerName) { firstName } }`,
+				},
+				Expected: []tests.ExpectedDocument{
+					tests.ExpectedDoc(
+						`query Q($userId: String!) { user { ...Outer_2KfY5k @with(outerName: $userId) id __typename } }`,
+					),
+					tests.ExpectedDoc(
+						`fragment Outer_2KfY5k on User { ...Inner_1YmyDS @with(innerName: $userId) id __typename }`,
+					).WithVariables(tests.ExpectedOperationVariable{Name: "outerName", Type: "String", TypeModifiers: "!"}),
+					tests.ExpectedDoc(
+						`fragment Inner_1YmyDS on User { friends(name: $userId) { firstName id __typename } id __typename }`,
+					).WithVariables(tests.ExpectedOperationVariable{Name: "innerName", Type: "String", TypeModifiers: "!"}),
 				},
 			},
 		},
@@ -478,8 +658,8 @@ func TestFragmentArgumentTransform_multipleRuns(t *testing.T) {
 							TypeModifiers: "!",
 						},
 					),
-				},
 			},
 		},
+	},
 	})
 }

--- a/packages/houdini-core/plugin/validate_test.go
+++ b/packages/houdini-core/plugin/validate_test.go
@@ -1007,6 +1007,123 @@ func TestValidate_Houdini(t *testing.T) {
 				},
 			},
 			{
+				Name: "@with providing all required arguments passes validation",
+				Pass: true,
+				Input: []string{
+					`fragment Fragment on User @arguments(
+					limit: { type: "Int!" }
+				) {
+					friends(limit: $limit) { id }
+				}`,
+					`query Test {
+					user(name: "foo") {
+						...Fragment @with(limit: 10)
+					}
+				}`,
+				},
+			},
+			{
+				Name: "@with omitting a required argument fails validation",
+				Pass: false,
+				Input: []string{
+					`fragment Fragment on User @arguments(
+					limit: { type: "Int!" },
+					offset: { type: "Int" }
+				) {
+					friends(limit: $limit, offset: $offset) { id }
+				}`,
+					`query Test {
+					user(name: "foo") {
+						...Fragment @with(offset: 5)
+					}
+				}`,
+				},
+			},
+			{
+				Name: "@with omitting a required String! argument fails validation",
+				Pass: false,
+				Input: []string{
+					`fragment Fragment on User @arguments(
+					name: { type: "String!" },
+					limit: { type: "Int" }
+				) {
+					friends(name: $name, limit: $limit) { id }
+				}`,
+					`query Test {
+					user(name: "foo") {
+						...Fragment @with(limit: 10)
+					}
+				}`,
+				},
+			},
+			{
+				Name: "optional fragment argument with default can be passed explicitly via @with",
+				Pass: true,
+				Input: []string{
+					`fragment Fragment on User @arguments(
+					limit: { type: "Int", default: 10 }
+				) {
+					friends(limit: $limit) { id }
+				}`,
+					`query Test {
+					user(name: "foo") {
+						...Fragment @with(limit: 5)
+					}
+				}`,
+				},
+			},
+			{
+				Name: "spreading without @with when all args have defaults passes validation",
+				Pass: true,
+				Input: []string{
+					`fragment Fragment on User @arguments(
+					limit: { type: "Int", default: 10 },
+					offset: { type: "Int", default: 0 }
+				) {
+					friends(limit: $limit, offset: $offset) { id }
+				}`,
+					`query Test {
+					user(name: "foo") {
+						...Fragment
+					}
+				}`,
+				},
+			},
+			{
+				Name: "required argument alongside optional default — required must be passed",
+				Pass: false,
+				Input: []string{
+					`fragment Fragment on User @arguments(
+					limit: { type: "Int!" },
+					offset: { type: "Int", default: 0 }
+				) {
+					friends(limit: $limit, offset: $offset) { id }
+				}`,
+					`query Test {
+					user(name: "foo") {
+						...Fragment @with(offset: 5)
+					}
+				}`,
+				},
+			},
+			{
+				Name: "required argument alongside optional default — passing only required is valid",
+				Pass: true,
+				Input: []string{
+					`fragment Fragment on User @arguments(
+					limit: { type: "Int!" },
+					offset: { type: "Int", default: 0 }
+				) {
+					friends(limit: $limit, offset: $offset) { id }
+				}`,
+					`query Test {
+					user(name: "foo") {
+						...Fragment @with(limit: 10)
+					}
+				}`,
+				},
+			},
+			{
 				Name: "@with rejects mistyped fields nested in input objects",
 				Pass: false,
 				Input: []string{

--- a/plugins/tests/expected.go
+++ b/plugins/tests/expected.go
@@ -5,10 +5,11 @@ package tests
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	
+
 
 	"code.houdinigraphql.com/plugins"
 )
@@ -1003,7 +1004,7 @@ func findArgumentValue[PluginConfig any](
 	    NULL AS parent_id,
 	    NULL AS child_name,
 	    0 AS level,
-	    CAST(av.id AS TEXT) AS path
+	    0 AS child_ref_id
 	  FROM argument_values av
 	  WHERE av.id = $value_id AND av.document = $document
 
@@ -1017,7 +1018,7 @@ func findArgumentValue[PluginConfig any](
 	    avc.parent AS parent_id,
 	    avc.name AS child_name,
 	    at.level + 1 AS level,
-	    at.path || ',' || child_av.id AS path
+	    avc.id AS child_ref_id
 	  FROM arg_tree at
 	    JOIN argument_value_children avc ON avc.parent = at.id
 	    JOIN argument_values child_av ON child_av.id = avc.value
@@ -1027,13 +1028,14 @@ func findArgumentValue[PluginConfig any](
 
 	// Define an internal type to represent nodes in the tree.
 	type argNode struct {
-		id        int
-		kind      string
-		raw       string
-		parentID  *int // nil for the root
-		childName string
-		level     int
-		children  []*argNode
+		id         int
+		kind       string
+		raw        string
+		parentID   *int // nil for the root
+		childName  string
+		level      int
+		childRefID int // argument_value_children row id; reflects insertion order
+		children   []*argNode
 	}
 
 	// Use a map to keep track of nodes by id.
@@ -1054,14 +1056,16 @@ func findArgumentValue[PluginConfig any](
 			}
 			childName := s.ColumnText(4)
 			level := int(s.ColumnInt(5))
+			childRefID := int(s.ColumnInt(6))
 
 			node := &argNode{
-				id:        id,
-				kind:      kind,
-				raw:       raw,
-				parentID:  parentID,
-				childName: childName,
-				level:     level,
+				id:         id,
+				kind:       kind,
+				raw:        raw,
+				parentID:   parentID,
+				childName:  childName,
+				level:      level,
+				childRefID: childRefID,
 			}
 			nodes[id] = node
 		},
@@ -1086,6 +1090,19 @@ func findArgumentValue[PluginConfig any](
 	if root == nil {
 		return nil
 	}
+
+	// Sort children by their argument_value_children row id so list elements
+	// appear in their original insertion order regardless of argument_value ids.
+	var sortChildren func(node *argNode)
+	sortChildren = func(node *argNode) {
+		sort.Slice(node.children, func(i, j int) bool {
+			return node.children[i].childRefID < node.children[j].childRefID
+		})
+		for _, child := range node.children {
+			sortChildren(child)
+		}
+	}
+	sortChildren(root)
 
 	// Recursively convert the tree of argNodes into ExpectedArgumentValue structures.
 	var convert func(node *argNode) *ExpectedArgumentValue

--- a/plugins/tests/parse.go
+++ b/plugins/tests/parse.go
@@ -37,8 +37,8 @@ func transformValue(val *ast.Value) *ExpectedArgumentValue {
 		Kind: kind,
 		Raw:  val.Raw,
 	}
-	// If the value is an object, process its children.
-	if val.Kind == ast.ObjectValue && val.Children != nil {
+	// Process children for objects and lists.
+	if (val.Kind == ast.ObjectValue || val.Kind == ast.ListValue) && val.Children != nil {
 		for _, child := range val.Children {
 			ev.Children = append(ev.Children, ExpectedArgumentValueChildren{
 				Name:  child.Name,


### PR DESCRIPTION
This PR adds a lot more fragment argument tests in an attempt to harden one of the more brittle parts of the new compilter. Along the way, I found a few issues which have now been fixed