### PR TITLE
Route-level response headers via headers() export

### DIFF
--- a/.changeset/route-response-headers.md
+++ b/.changeset/route-response-headers.md
@@ -1,0 +1,6 @@
+---
+'houdini': minor
+'houdini-react': minor
+---
+
+Pages and layouts can now export a `headers()` function to set HTTP response headers for a route. Headers from the page and its layout chain are merged before streaming, with the page taking precedence over its layouts.

--- a/docs/react/02-routing/01-pages-and-layouts.mdx
+++ b/docs/react/02-routing/01-pages-and-layouts.mdx
@@ -69,6 +69,23 @@ export function headers() {
 export default () => <div>Hello Houdini!</div>
 ```
 
-When a page renders, Houdini evaluates the `headers()` exports of the page and every layout in its chain, then merges the results. On a conflict the page wins over its layouts, and an inner layout wins over an outer one. The function runs on the server before the response is streamed, so it can't depend on query data — headers must be statically determinable from the request.
+When a page renders, Houdini evaluates the `headers()` exports of the page and every layout in its chain, then merges the results. On a conflict the page wins over its layouts, and an inner layout wins over an outer one.
+
+Because layouts apply to everything beneath them, the root `+layout.jsx` is the natural place for app-wide headers like `Content-Security-Policy`, `Strict-Transport-Security`, or `X-Frame-Options` that you want on every document response:
+
+```jsx title="src/routes/+layout.tsx&typescriptToggle=true"
+export function headers() {
+  return {
+    'Content-Security-Policy': "default-src 'self'",
+    'Strict-Transport-Security': 'max-age=63072000',
+  }
+}
+```
+
+These headers apply to the page (document) responses Houdini renders. They do not affect responses from your GraphQL endpoint, which is handled separately.
+
+<Notice variant="info">
+  `headers()` only ever runs on the server (it is stripped from the client bundle), so it's safe to read server-only secrets or environment variables inside it. It runs before the response is streamed, so it can't depend on query data; headers must be determinable from the request alone.
+</Notice>
 
 

--- a/docs/react/02-routing/01-pages-and-layouts.mdx
+++ b/docs/react/02-routing/01-pages-and-layouts.mdx
@@ -54,4 +54,21 @@ Dynamic segments are marked with square brackets:
 
 Optional parameters cannot follow rest parameters — the rest segment is greedy and will consume everything after it.
 
+## Response Headers
+
+A `+page.jsx` or `+layout.jsx` can export a `headers()` function to set HTTP response headers for the route. This is the place for cache directives, security headers, and anything else you'd otherwise have to configure at the CDN or adapter level:
+
+```jsx title="src/routes/+page.tsx&typescriptToggle=true"
+export function headers() {
+  return {
+    'Cache-Control': 'public, max-age=3600',
+    'X-Frame-Options': 'DENY',
+  }
+}
+
+export default () => <div>Hello Houdini!</div>
+```
+
+When a page renders, Houdini evaluates the `headers()` exports of the page and every layout in its chain, then merges the results. On a conflict the page wins over its layouts, and an inner layout wins over an outer one. The function runs on the server before the response is streamed, so it can't depend on query data — headers must be statically determinable from the request.
+
 

--- a/docs/react/02-routing/03-file-conventions.mdx
+++ b/docs/react/02-routing/03-file-conventions.mdx
@@ -16,6 +16,8 @@ These files go inside `src/routes/` and can appear in any route directory.
 | `+page.gql` | GraphQL query (or queries) for this page. Each query's result is passed as a prop named after the query. |
 | `+layout.gql` | GraphQL query for this layout. Results are available to the layout component and all of its descendants. |
 
+A `+page.jsx` or `+layout.jsx` can also export a `headers()` function to set [response headers](~/routing/pages-and-layouts#response-headers) for the route.
+
 ## API Files
 
 These files go in `src/api/` and are only relevant if you're using a [local GraphQL server](~/loading-data/graphql-server).

--- a/e2e/react/src/routes/response-headers/+layout.tsx
+++ b/e2e/react/src/routes/response-headers/+layout.tsx
@@ -1,0 +1,12 @@
+import type { LayoutProps } from './$types'
+
+export function headers() {
+	return {
+		'X-Houdini-Layout': 'layout-value',
+		'X-Houdini-Shared': 'from-layout',
+	}
+}
+
+export default function ResponseHeadersLayout({ children }: LayoutProps) {
+	return <>{children}</>
+}

--- a/e2e/react/src/routes/response-headers/+page.tsx
+++ b/e2e/react/src/routes/response-headers/+page.tsx
@@ -1,0 +1,10 @@
+export function headers() {
+	return {
+		'X-Houdini-Page': 'page-value',
+		'X-Houdini-Shared': 'from-page',
+	}
+}
+
+export default function ResponseHeadersPage() {
+	return <div id="result">response headers</div>
+}

--- a/e2e/react/src/routes/response-headers/test.ts
+++ b/e2e/react/src/routes/response-headers/test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test'
+import { routes } from '~/utils/routes'
+import { goto } from '~/utils/testsHelper.js'
+
+test('headers() exports are merged into the response', async ({ page }) => {
+	const response = await goto(page, routes.response_headers)
+	const headers = response?.headers() ?? {}
+
+	// the layout-only header is present
+	expect(headers['x-houdini-layout']).toBe('layout-value')
+	// the page-only header is present
+	expect(headers['x-houdini-page']).toBe('page-value')
+	// on a conflict the page wins over the layout
+	expect(headers['x-houdini-shared']).toBe('from-page')
+
+	// the page still rendered normally
+	await expect(page.textContent('#result')).resolves.toEqual('response headers')
+})

--- a/e2e/react/src/utils/routes.ts
+++ b/e2e/react/src/utils/routes.ts
@@ -34,4 +34,5 @@ export const routes = {
 	routing_errors_redirect_target: '/routing-errors/redirect-target',
 	routing_errors_static_404: '/routing-errors/does-not-exist',
 	error_loop: '/error-loop/doesnt-exist',
+	response_headers: '/response-headers',
 } as const

--- a/packages/_scripts/buildUtils.js
+++ b/packages/_scripts/buildUtils.js
@@ -4,7 +4,9 @@ import fs from 'node:fs/promises'
  * Write a package.json file with consistent formatting
  */
 export async function writePackageJson(filePath, packageJson) {
-	await fs.writeFile(filePath, JSON.stringify(packageJson, null, 4))
+	// include a trailing newline so recompiling doesn't leave a spurious diff
+	// against the committed (newline-terminated) package.json files
+	await fs.writeFile(filePath, JSON.stringify(packageJson, null, 4) + '\n')
 }
 
 /**

--- a/packages/houdini-react/package/vite/index.ts
+++ b/packages/houdini-react/package/vite/index.ts
@@ -6,7 +6,7 @@ import {
 	client_build_directory,
 } from 'houdini/router/conventions'
 import { load_manifest, type ProjectManifest } from 'houdini/router/manifest'
-import { type RouterManifest } from 'houdini/router/types'
+import { type RouterManifest, type RouterPageManifest } from 'houdini/router/types'
 import { VitePluginContext } from 'houdini/vite'
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
@@ -188,7 +188,7 @@ export default function (ctx: VitePluginContext): PluginOption {
 			cfCache = null
 		},
 
-		async transform(code: string, filepath: string) {
+		async transform(code: string, filepath: string, options?: { ssr?: boolean }) {
 			filepath = path.posixify(filepath)
 
 			if (filepath.startsWith('/src/')) {
@@ -198,6 +198,10 @@ export default function (ctx: VitePluginContext): PluginOption {
 			if (!ctx.config.includeFile(filepath)) {
 				return
 			}
+
+			// headers() is server-only; strip it from the client build of route
+			// views so it never reaches the browser bundle (see transform_file).
+			const stripHeaders = !options?.ssr && /(?:^|\/)\+(?:page|layout)\.[jt]sx?$/.test(filepath)
 
 			if (cfCache === null) {
 				try {
@@ -216,7 +220,8 @@ export default function (ctx: VitePluginContext): PluginOption {
 					filepath: path.posixify(filepath),
 					watch_file: this.addWatchFile.bind(this),
 				},
-				cfCache
+				cfCache,
+				{ stripHeaders }
 			)
 		},
 
@@ -367,9 +372,20 @@ mount_static_app(App, manifest)
 					return
 				}
 
-				const { default: router_manifest } = (await server.ssrLoadModule(
+				const manifest_module = (await server.ssrLoadModule(
 					path.join(plugin_dir(ctx.config, 'houdini-react'), 'runtime', 'manifest.ts')
-				)) as { default: RouterManifest<React.Component> }
+				)) as {
+					default: RouterManifest<React.Component>
+					route_headers?: Record<string, RouterPageManifest<React.Component>['headers']>
+				}
+				const router_manifest = manifest_module.default
+				// route_headers is a server-only export; attach it to the manifest so the
+				// request handler can evaluate headers() before streaming
+				for (const id of Object.keys(manifest_module.route_headers ?? {})) {
+					if (router_manifest.pages[id]) {
+						router_manifest.pages[id].headers = manifest_module.route_headers![id]
+					}
+				}
 
 				const { createServerAdapter } = (await server.ssrLoadModule(
 					adapter_config_path(ctx.config)

--- a/packages/houdini-react/package/vite/strip-headers.test.ts
+++ b/packages/houdini-react/package/vite/strip-headers.test.ts
@@ -1,0 +1,48 @@
+import { parseJS, printJS } from 'houdini'
+import { test, expect, describe } from 'vitest'
+
+import { strip_named_export } from './strip-headers.js'
+
+async function strip(code: string): Promise<string> {
+	const script = parseJS(code, { plugins: ['jsx'] })
+	strip_named_export(script, 'headers')
+	const { code: out } = await printJS(script)
+	return out.trim()
+}
+
+describe('strip_named_export', () => {
+	test('removes an exported function declaration', async () => {
+		const out = await strip(
+			`export function headers() { return { 'X-A': 'b' } }\nexport default () => null`
+		)
+		expect(out).not.toContain('headers')
+		expect(out).toContain('export default')
+	})
+
+	test('removes an exported const declaration', async () => {
+		const out = await strip(`export const headers = () => ({})\nexport default () => null`)
+		expect(out).not.toContain('headers')
+		expect(out).toContain('export default')
+	})
+
+	test('removes a headers specifier from an export list but keeps the others', async () => {
+		const out = await strip(
+			`const headers = () => ({})\nconst other = 1\nexport { headers, other }\nexport default () => null`
+		)
+		expect(out).not.toMatch(/export\s*\{[^}]*headers/)
+		expect(out).toContain('other')
+	})
+
+	test('removes an aliased headers export', async () => {
+		const out = await strip(
+			`const fn = () => ({})\nexport { fn as headers }\nexport default () => null`
+		)
+		expect(out).not.toMatch(/as headers/)
+	})
+
+	test('leaves unrelated exports untouched', async () => {
+		const out = await strip(`export const other = 1\nexport default () => null`)
+		expect(out).toContain('other')
+		expect(out).toContain('export default')
+	})
+})

--- a/packages/houdini-react/package/vite/strip-headers.ts
+++ b/packages/houdini-react/package/vite/strip-headers.ts
@@ -1,0 +1,39 @@
+// strip_named_export removes a top-level named export (declaration or specifier)
+// from a parsed program in place. It is used to drop the server-only headers()
+// export of a +page/+layout from the client build.
+export function strip_named_export(script: any, name: string): void {
+	const body = script.body
+	for (let i = body.length - 1; i >= 0; i--) {
+		const node = body[i]
+		if (node.type !== 'ExportNamedDeclaration') {
+			continue
+		}
+
+		// export function headers() {} / export const headers = ...
+		if (node.declaration) {
+			const decl = node.declaration
+			if (decl.type === 'FunctionDeclaration' && decl.id?.name === name) {
+				body.splice(i, 1)
+				continue
+			}
+			if (decl.type === 'VariableDeclaration') {
+				decl.declarations = decl.declarations.filter(
+					(d: any) => !(d.id?.type === 'Identifier' && d.id.name === name)
+				)
+				if (decl.declarations.length === 0) {
+					body.splice(i, 1)
+				}
+				continue
+			}
+			continue
+		}
+
+		// export { headers } / export { foo as headers }
+		if (node.specifiers?.length) {
+			node.specifiers = node.specifiers.filter((s: any) => s.exported?.name !== name)
+			if (node.specifiers.length === 0) {
+				body.splice(i, 1)
+			}
+		}
+	}
+}

--- a/packages/houdini-react/package/vite/transform.ts
+++ b/packages/houdini-react/package/vite/transform.ts
@@ -13,13 +13,16 @@ import { componentField_unit_path, houdini_root } from 'houdini/router/conventio
 import * as recast from 'recast'
 import type { SourceMapInput } from 'rollup'
 
+import { strip_named_export } from './strip-headers.js'
+
 const AST = recast.types.builders
 
 export type ComponentFieldRow = { type: string; field: string; fragment: string }
 
 export async function transform_file(
 	page: TransformPage,
-	cfRows: ComponentFieldRow[]
+	cfRows: ComponentFieldRow[],
+	opts: { stripHeaders?: boolean } = {}
 ): Promise<{ code: string; map?: SourceMapInput }> {
 	const isJSX = page.filepath.endsWith('.tsx') || page.filepath.endsWith('.jsx')
 	if (!isJSX && !page.filepath.endsWith('.ts') && !page.filepath.endsWith('.js')) {
@@ -27,6 +30,15 @@ export async function transform_file(
 	}
 
 	const script = parseJS(page.content, isJSX ? { plugins: ['jsx'] } : {})
+
+	// The headers() export of a +page/+layout only ever runs on the server. When
+	// building for the client we strip it so server-only logic (secrets, env
+	// vars) it might read never ends up in the browser bundle. Rollup keeps it
+	// otherwise: route views become preserved-signature chunks, so an unused
+	// export isn't tree-shaken away on its own.
+	if (opts.stripHeaders) {
+		strip_named_export(script, 'headers')
+	}
 
 	const cfMap: Record<string, Record<string, string>> = {}
 	for (const row of cfRows) {

--- a/packages/houdini-react/plugin/generate.go
+++ b/packages/houdini-react/plugin/generate.go
@@ -537,6 +537,16 @@ import router_manifest from '$houdini/plugins/houdini-react/runtime/manifest'
 
 import config from '%s/houdini.config.js'
 
+// route_headers maps a page id to its ordered headers() loaders. It is a
+// server-only export so headers() stays out of the client bundle; attach it to
+// the manifest here so the request handler can evaluate it before streaming.
+import * as manifest_module from '$houdini/plugins/houdini-react/runtime/manifest'
+for (const id of Object.keys(manifest_module.route_headers ?? {})) {
+	if (router_manifest.pages[id]) {
+		router_manifest.pages[id].headers = manifest_module.route_headers[id]
+	}
+}
+
 export const on_render =
 	({ assetPrefix, pipe, production, documentPremable, cssLinks }) =>
 	async ({

--- a/packages/houdini-react/plugin/generate.go
+++ b/packages/houdini-react/plugin/generate.go
@@ -546,6 +546,7 @@ export const on_render =
 		session,
 		manifest,
 		componentCache,
+		headers,
 	}) => {
 		const cache = new Cache({
 			disabled: false,
@@ -593,12 +594,19 @@ export const on_render =
 	` + "`" + `)
 
 		if (pipeTo && pipe) {
+			// route headers must be set on the underlying response before any of
+			// the stream is written
+			if (headers && typeof pipe.setHeader === 'function') {
+				for (const [key, value] of Object.entries(headers)) {
+					pipe.setHeader(key, value)
+				}
+			}
 			pipeTo(pipe)
 			return true
 		} else if (statusRef.location) {
-			return new Response(null, { status: statusRef.status, headers: { Location: statusRef.location } })
+			return new Response(null, { status: statusRef.status, headers: { ...headers, Location: statusRef.location } })
 		} else {
-			return new Response(readable, { status: statusRef.status })
+			return new Response(readable, { status: statusRef.status, headers })
 		}
 	}
 

--- a/packages/houdini-react/plugin/manifest.go
+++ b/packages/houdini-react/plugin/manifest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -38,6 +39,9 @@ type PageManifest struct {
 	Path          string                    `json:"path"`
 	ErrorPath     string                    `json:"error_path"`
 	Params        map[string]*ParamTypeInfo `json:"params"`
+	// Headers is true when the view file exports a `headers()` function whose
+	// result should be merged into the HTTP response before streaming.
+	Headers bool `json:"headers"`
 }
 
 // ParamTypeInfo describes the GraphQL type of a URL route parameter.
@@ -206,6 +210,7 @@ func (p *HoudiniReact) LoadManifest(ctx context.Context) (ProjectManifest, error
 				Layouts:       clone(state.availableLayouts),
 				Path:          relPath,
 				Params:        buildParams(url, newVariables),
+				Headers:       info.layoutHeaders,
 			}
 			newLayoutIDs = append(newLayoutIDs, id)
 		}
@@ -254,6 +259,7 @@ func (p *HoudiniReact) LoadManifest(ctx context.Context) (ProjectManifest, error
 				Path:          relPath,
 				ErrorPath:     errorPath,
 				Params:        buildParams(url, allVars),
+				Headers:       info.pageHeaders,
 			}
 		}
 
@@ -389,6 +395,8 @@ type viewInfo struct {
 	pageViewPath   string // absolute path to +page.tsx or +page.jsx, empty if absent
 	layoutViewPath string // absolute path to +layout.tsx or +layout.jsx, empty if absent
 	errorViewPath  string // absolute path to +error.tsx or +error.jsx, empty if absent
+	pageHeaders    bool   // +page view exports a headers() function
+	layoutHeaders  bool   // +layout view exports a headers() function
 }
 
 // discoverViewFiles uses the parallel glob walker to find all +page and +layout view
@@ -422,12 +430,24 @@ func (p *HoudiniReact) discoverViewFiles(ctx context.Context, routesDir string) 
 		absPath := filepath.Join(routesDir, relPath)
 		base := filepath.Base(relPath)
 
+		// +page and +layout views may export a headers() function whose result is
+		// merged into the HTTP response. Detect it statically so the manifest only
+		// references modules that actually contribute headers.
+		hasHeaders := false
+		if strings.HasPrefix(base, "+page") || strings.HasPrefix(base, "+layout") {
+			if content, err := afero.ReadFile(p.Filesystem(), absPath); err == nil {
+				hasHeaders = fileExportsHeaders(string(content))
+			}
+		}
+
 		mu.Lock()
 		info := views[dir]
 		if strings.HasPrefix(base, "+page") {
 			info.pageViewPath = absPath
+			info.pageHeaders = hasHeaders
 		} else if strings.HasPrefix(base, "+layout") {
 			info.layoutViewPath = absPath
+			info.layoutHeaders = hasHeaders
 		} else {
 			info.errorViewPath = absPath
 		}
@@ -436,6 +456,35 @@ func (p *HoudiniReact) discoverViewFiles(ctx context.Context, routesDir string) 
 		return nil
 	})
 	return views, err
+}
+
+var (
+	headerFuncRe = regexp.MustCompile(`(?m)^\s*export\s+(?:async\s+)?function\s+headers\b`)
+	headerDeclRe = regexp.MustCompile(`(?m)^\s*export\s+(?:const|let|var)\s+headers\b`)
+	headerListRe = regexp.MustCompile(`(?ms)\bexport\s*\{([^}]*)\}`)
+)
+
+// fileExportsHeaders reports whether a route view module exports a value named
+// `headers`. It handles `export function headers`, `export const headers`, and
+// named export lists (`export { headers }` / `export { foo as headers }`).
+func fileExportsHeaders(content string) bool {
+	if headerFuncRe.MatchString(content) || headerDeclRe.MatchString(content) {
+		return true
+	}
+	for _, match := range headerListRe.FindAllStringSubmatch(content, -1) {
+		for _, clause := range strings.Split(match[1], ",") {
+			// The exported name is the alias after `as`, or the identifier itself.
+			fields := strings.Fields(clause)
+			if len(fields) == 0 {
+				continue
+			}
+			name := fields[len(fields)-1]
+			if name == "headers" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // dirKeyToURL converts a routesDir-relative directory key (e.g. "(subRoute)/nested")

--- a/packages/houdini-react/plugin/manifest_test.go
+++ b/packages/houdini-react/plugin/manifest_test.go
@@ -459,7 +459,62 @@ func TestLoadManifest(t *testing.T) {
 				},
 			},
 			{
-				Name: "+error.tsx propagates to child pages when no sibling +page.tsx",
+				Name: "headers() export sets Headers on page and layout manifests",
+					Pass: true,
+					Extra: map[string]any{
+						"views": map[string]string{
+							"src/routes/+layout.tsx":     "export function headers() { return { 'X-From': 'layout' } }\nexport default ({children}) => <div>{children}</div>",
+							"src/routes/+page.tsx":       "export const headers = () => ({ 'X-From': 'page' })\nexport default () => <div>hello</div>",
+							"src/routes/plain/+page.tsx": mockView([]string{}),
+						},
+						"expected": plugin.ProjectManifest{
+							Pages: map[string]plugin.PageManifest{
+								"_": {
+									ID:            "_",
+									Queries:       []string{},
+									QueryOptions:  []string{},
+									LayoutQueries: []string{},
+									URL:           "/",
+									Layouts:       []string{"_"},
+									Path:          "src/routes/+page.tsx",
+									Params:        map[string]*plugin.ParamTypeInfo{},
+									Headers:       true,
+								},
+								"_plain": {
+									ID:            "_plain",
+									Queries:       []string{},
+									QueryOptions:  []string{},
+									LayoutQueries: []string{},
+									URL:           "/plain",
+									Layouts:       []string{"_"},
+									Path:          "src/routes/plain/+page.tsx",
+									Params:        map[string]*plugin.ParamTypeInfo{},
+								},
+							},
+							Layouts: map[string]plugin.PageManifest{
+								"_": {
+									ID:            "_",
+									Queries:       []string{},
+									QueryOptions:  []string{},
+									LayoutQueries: []string{},
+									URL:           "/",
+									Layouts:       []string{},
+									Path:          "src/routes/+layout.tsx",
+									Params:        map[string]*plugin.ParamTypeInfo{},
+									Headers:       true,
+								},
+							},
+							PageQueries:     map[string]plugin.QueryManifest{},
+							LayoutQueries:   map[string]plugin.QueryManifest{},
+							Artifacts:       []string{},
+							LocalSchema:     false,
+							LocalYoga:       false,
+							ComponentFields: map[string]plugin.ComponentFieldInfo{},
+						},
+					},
+				},
+				{
+					Name: "+error.tsx propagates to child pages when no sibling +page.tsx",
 				Pass: true,
 				Input: []string{
 					mockQuery("RootQuery", false),

--- a/packages/houdini-react/plugin/runtime.go
+++ b/packages/houdini-react/plugin/runtime.go
@@ -753,6 +753,32 @@ func formatManifest(
 
 		sb.WriteString(fmt.Sprintf("\t\t\tcomponent: () => import(%q),\n", filepath.ToSlash(componentRel)))
 
+		// Headers block: ordered loaders for every segment in the layout chain
+		// (outermost first) and then the page itself that export a headers()
+		// function. The server calls them in order and merges the results so the
+		// page wins over layouts and inner layouts win over outer ones.
+		var headerSources []string
+		for _, layoutID := range page.Layouts {
+			if layout, ok := manifest.Layouts[layoutID]; ok && layout.Headers {
+				headerSources = append(headerSources, layout.Path)
+			}
+		}
+		if page.Headers {
+			headerSources = append(headerSources, page.Path)
+		}
+		if len(headerSources) > 0 {
+			sb.WriteString("\t\t\theaders: [\n")
+			for _, src := range headerSources {
+				srcAbs := stripViewExt(filepath.Join(projectRoot, src))
+				srcRel, err := filepath.Rel(runtimeDir, srcAbs)
+				if err != nil {
+					return "", err
+				}
+				sb.WriteString(fmt.Sprintf("\t\t\t\t() => import(%q).then(m => m.headers),\n", filepath.ToSlash(srcRel)))
+			}
+			sb.WriteString("\t\t\t],\n")
+		}
+
 		sb.WriteString("\t\t},\n")
 	}
 

--- a/packages/houdini-react/plugin/runtime.go
+++ b/packages/houdini-react/plugin/runtime.go
@@ -701,6 +701,13 @@ func formatManifest(
 	sb.WriteString("export default {\n")
 	sb.WriteString("\tpages: {\n")
 
+	// Accumulate the ordered headers() loaders per page. These are emitted as a
+	// separate `route_headers` export (below) rather than nested in the manifest
+	// so that the client bundle, which only imports the default manifest, never
+	// references the source modules' headers() exports — letting dead-code
+	// elimination strip them from the client build.
+	headerLoadersByID := map[string][]string{}
+
 	for _, id := range sortedKeys(manifest.Pages) {
 		page := manifest.Pages[id]
 
@@ -753,10 +760,12 @@ func formatManifest(
 
 		sb.WriteString(fmt.Sprintf("\t\t\tcomponent: () => import(%q),\n", filepath.ToSlash(componentRel)))
 
-		// Headers block: ordered loaders for every segment in the layout chain
-		// (outermost first) and then the page itself that export a headers()
-		// function. The server calls them in order and merges the results so the
-		// page wins over layouts and inner layouts win over outer ones.
+		sb.WriteString("\t\t},\n")
+
+		// Collect the ordered headers() loaders for every segment in the layout
+		// chain (outermost first) and then the page itself. The server calls them
+		// in order and merges the results so the page wins over layouts and inner
+		// layouts win over outer ones.
 		var headerSources []string
 		for _, layoutID := range page.Layouts {
 			if layout, ok := manifest.Layouts[layoutID]; ok && layout.Headers {
@@ -766,24 +775,37 @@ func formatManifest(
 		if page.Headers {
 			headerSources = append(headerSources, page.Path)
 		}
-		if len(headerSources) > 0 {
-			sb.WriteString("\t\t\theaders: [\n")
-			for _, src := range headerSources {
-				srcAbs := stripViewExt(filepath.Join(projectRoot, src))
-				srcRel, err := filepath.Rel(runtimeDir, srcAbs)
-				if err != nil {
-					return "", err
-				}
-				sb.WriteString(fmt.Sprintf("\t\t\t\t() => import(%q).then(m => m.headers),\n", filepath.ToSlash(srcRel)))
+		var loaders []string
+		for _, src := range headerSources {
+			srcAbs := stripViewExt(filepath.Join(projectRoot, src))
+			srcRel, err := filepath.Rel(runtimeDir, srcAbs)
+			if err != nil {
+				return "", err
 			}
-			sb.WriteString("\t\t\t],\n")
+			loaders = append(loaders, fmt.Sprintf("() => import(%q).then(m => m.headers)", filepath.ToSlash(srcRel)))
 		}
-
-		sb.WriteString("\t\t},\n")
+		if len(loaders) > 0 {
+			headerLoadersByID[id] = loaders
+		}
 	}
 
 	sb.WriteString("\t},\n")
 	sb.WriteString("} as const satisfies RouterManifest<any>\n")
+
+	// route_headers is a server-only export: it maps a page id to the ordered
+	// list of headers() loaders for that page and its layout chain. It is kept
+	// out of the default manifest so the client build can tree-shake it away.
+	if len(headerLoadersByID) > 0 {
+		sb.WriteString("\nexport const route_headers = {\n")
+		for _, id := range sortedKeys(headerLoadersByID) {
+			sb.WriteString(fmt.Sprintf("\t%q: [\n", id))
+			for _, loader := range headerLoadersByID[id] {
+				sb.WriteString(fmt.Sprintf("\t\t%s,\n", loader))
+			}
+			sb.WriteString("\t],\n")
+		}
+		sb.WriteString("}\n")
+	}
 
 	// Export a name→TS-type map for custom scalars so Link.tsx can resolve
 	// _TSType<"DateTime"> → Date without any per-project codegen in the jsx file.

--- a/packages/houdini-react/plugin/runtime_test.go
+++ b/packages/houdini-react/plugin/runtime_test.go
@@ -874,13 +874,16 @@ func TestGenerateRuntime(t *testing.T) {
 									documents: {
 									},
 									component: () => import("../units/entries/_"),
-									headers: [
-										() => import("../../../../src/routes/+layout").then(m => m.headers),
-										() => import("../../../../src/routes/+page").then(m => m.headers),
-									],
 								},
 							},
 						} as const satisfies RouterManifest<any>
+
+						export const route_headers = {
+							"_": [
+								() => import("../../../../src/routes/+layout").then(m => m.headers),
+								() => import("../../../../src/routes/+page").then(m => m.headers),
+							],
+						}
 
 						export type RouteScalars = {
 						}

--- a/packages/houdini-react/plugin/runtime_test.go
+++ b/packages/houdini-react/plugin/runtime_test.go
@@ -854,6 +854,40 @@ func TestGenerateRuntime(t *testing.T) {
 				},
 			},
 			{
+				Name: "headers() exports emit a headers loader array",
+				Pass: true,
+				Extra: map[string]any{
+					"views": map[string]string{
+						"src/routes/+layout.tsx": "export function headers() { return { 'X-From': 'layout' } }\nexport default ({children}) => <div>{children}</div>",
+						"src/routes/+page.tsx":   "export const headers = () => ({ 'X-From': 'page' })\nexport default () => <div>hello</div>",
+					},
+					"expected": tests.Dedent(`
+						import type { RouterManifest } from 'houdini/runtime'
+
+						export default {
+							pages: {
+								"_": {
+									id: "_",
+									url: "/",
+									pattern: /^\/$/,
+									params: [],
+									documents: {
+									},
+									component: () => import("../units/entries/_"),
+									headers: [
+										() => import("../../../../src/routes/+layout").then(m => m.headers),
+										() => import("../../../../src/routes/+page").then(m => m.headers),
+									],
+								},
+							},
+						} as const satisfies RouterManifest<any>
+
+						export type RouteScalars = {
+						}
+					`) + "\n",
+				},
+			},
+			{
 				Name: "subscription appears as optional MockValue field in mock",
 				Pass: true,
 				Input: []string{

--- a/packages/houdini/src/router/server.test.ts
+++ b/packages/houdini/src/router/server.test.ts
@@ -1,0 +1,58 @@
+import { test, expect, describe } from 'vitest'
+
+import { collect_response_headers } from './server.js'
+
+describe('collect_response_headers', () => {
+	test('returns an empty object when there are no headers loaders', async () => {
+		expect(await collect_response_headers(null)).toEqual({})
+		expect(await collect_response_headers({})).toEqual({})
+		expect(await collect_response_headers({ headers: [] })).toEqual({})
+	})
+
+	test('merges every loaded headers() result', async () => {
+		const headers = [
+			() => Promise.resolve(() => ({ 'X-Layout': 'outer', 'X-From': 'layout' })),
+			() => Promise.resolve(() => ({ 'X-Page': 'page' })),
+		]
+
+		expect(await collect_response_headers({ headers })).toEqual({
+			'X-Layout': 'outer',
+			'X-From': 'layout',
+			'X-Page': 'page',
+		})
+	})
+
+	test('later loaders win so the page overrides its layouts', async () => {
+		const headers = [
+			() => Promise.resolve(() => ({ 'X-From': 'outer-layout' })),
+			() => Promise.resolve(() => ({ 'X-From': 'inner-layout' })),
+			() => Promise.resolve(() => ({ 'X-From': 'page' })),
+		]
+
+		expect(await collect_response_headers({ headers })).toEqual({
+			'X-From': 'page',
+		})
+	})
+
+	test('awaits async headers() functions and coerces values to strings', async () => {
+		const headers = [
+			() => Promise.resolve(async () => ({ 'Cache-Control': 'public', 'X-Count': 1 as any })),
+		]
+
+		expect(await collect_response_headers({ headers })).toEqual({
+			'Cache-Control': 'public',
+			'X-Count': '1',
+		})
+	})
+
+	test('skips loaders whose module does not export a headers function', async () => {
+		const headers = [
+			() => Promise.resolve(undefined),
+			() => Promise.resolve(() => ({ 'X-From': 'page' })),
+		]
+
+		expect(await collect_response_headers({ headers })).toEqual({
+			'X-From': 'page',
+		})
+	})
+})

--- a/packages/houdini/src/router/server.ts
+++ b/packages/houdini/src/router/server.ts
@@ -40,6 +40,7 @@ export function _serverHandler<ComponentType = unknown>({
 		manifest: RouterManifest<unknown>
 		session: App.Session
 		componentCache: Record<string, any>
+		headers: Record<string, string>
 	}) => Response | Promise<Response | undefined> | undefined
 	config_file: ConfigFile
 } & Omit<YogaServerOptions, 'schema'>) {
@@ -120,6 +121,10 @@ export function _serverHandler<ComponentType = unknown>({
 		const is404 = !exactMatch
 		const match = exactMatch ?? find_prefix_match(manifest, url)
 
+		// evaluate the headers() exports for this page and its layout chain so the
+		// adapter can apply them before streaming begins
+		const headers = await collect_response_headers(match)
+
 		// call the framework-specific render hook with the latest session
 		const rendered = await on_render({
 			url,
@@ -128,6 +133,7 @@ export function _serverHandler<ComponentType = unknown>({
 			session: await get_session(request.headers, session_keys),
 			manifest,
 			componentCache,
+			headers,
 		})
 		if (rendered) {
 			return rendered
@@ -142,6 +148,30 @@ export const serverAdapterFactory = (
 	args: Parameters<typeof _serverHandler>[0]
 ): ReturnType<typeof createServerAdapter> => {
 	return createServerAdapter(_serverHandler(args))
+}
+
+// collect_response_headers evaluates the headers() exports for the matched page
+// and its layout chain (outermost first) and merges them into a single record.
+// Because the loaders are ordered outermost → page, later writes overwrite
+// earlier ones, so the page wins over its layouts and an inner layout wins over
+// an outer one.
+export async function collect_response_headers(
+	match: { headers?: Array<() => Promise<(() => unknown) | undefined>> } | null
+): Promise<Record<string, string>> {
+	const merged: Record<string, string> = {}
+	for (const load of match?.headers ?? []) {
+		const fn = await load()
+		if (typeof fn !== 'function') {
+			continue
+		}
+		const result = await fn()
+		if (result && typeof result === 'object') {
+			for (const [key, value] of Object.entries(result)) {
+				merged[key] = String(value)
+			}
+		}
+	}
+	return merged
 }
 
 export type ServerAdapterFactory = typeof serverAdapterFactory

--- a/packages/houdini/src/router/types.ts
+++ b/packages/houdini/src/router/types.ts
@@ -34,4 +34,15 @@ export type RouterPageManifest<_ComponentType> = {
 		}
 	>
 	component: () => Promise<{ default: _ComponentType }>
+
+	// loaders for the headers() functions exported by this page and its layout
+	// chain (outermost first). They are evaluated and merged before streaming so
+	// the page wins over layouts and inner layouts win over outer ones.
+	headers?: Array<() => Promise<RouteHeaderFunction | undefined>>
 }
+
+// the shape of a route's headers() export: a function returning the response
+// headers to merge for the matched page.
+export type RouteHeaderFunction = () => RouteHeaders | Promise<RouteHeaders>
+
+export type RouteHeaders = Record<string, string>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
 		include: [
 			'./packages/*/src/**/*.test.{ts,js}',
 			'./packages/houdini-react/runtime/**/*.test.{ts,js}',
+			'./packages/houdini-react/package/**/*.test.{ts,js}',
 			'./packages/houdini-core/runtime/public/**/*.test.{ts,js}',
 			'./site/**/*.test.{ts,js}',
 		],


### PR DESCRIPTION
This PR adds a `headers()` named export to `+page.tsx` and `+layout.tsx` for setting HTTP response headers per route:
  
  ```tsx
  // src/routes/+layout.tsx
  export function headers() {
    return {
      'Cache-Control': 'public, max-age=3600',
      'X-Frame-Options': 'DENY',
    }
  }
```

When a page renders, Houdini evaluates the headers() exports of the page and every layout in its chain and merges them. On a conflict the page wins over its layouts, and an inner layout wins over an outer one.

Closes #1673 
