### PR TITLE
Add @refetch directive to refetch a record after a mutation or subscription

### DIFF
--- a/.changeset/refetch-directive.md
+++ b/.changeset/refetch-directive.md
@@ -1,0 +1,6 @@
+---
+'houdini': minor
+'houdini-core': minor
+---
+
+Add the `@refetch` directive to mark a record in a mutation or subscription response so the cache refetches every document that depends on it once the response is written.

--- a/docs/react/04-updating-data/01-mutations.mdx
+++ b/docs/react/04-updating-data/01-mutations.mdx
@@ -4,6 +4,7 @@ description: Sending mutations in Houdini's React framework
 ---
 
 import Dedupe from '@shared/_partials/dedupe.mdx'
+import Refetch from '@shared/_partials/refetch.mdx'
 
 The `useMutation` hook wraps a GraphQL mutation and returns a tuple of `[mutate, pending]`. Call `mutate` with your variables to execute it.
 
@@ -65,6 +66,10 @@ try {
 After a successful mutation, Houdini automatically updates any cached fields that appear in the mutation's response. If the mutation returns a type that's already in the cache, fields are merged and any components watching those fields re-render.
 
 For mutations that add or remove items from lists, see [Updating Lists](~/updating-data/updating-lists).
+
+## Refetching Changed Data
+
+<Refetch />
 
 ## Optimistic Updates
 

--- a/docs/shared/01-core/06-cache.mdx
+++ b/docs/shared/01-core/06-cache.mdx
@@ -255,6 +255,29 @@ user.refresh()
 Unlike `markStale` (which waits for the next fetch to reload the data), `refresh`
 triggers the network requests immediately.
 
+### Refreshing from a mutation response
+
+If a mutation already returns the record that changed, you can skip the imperative
+call and tag the field with `@refetch`. Once the response is written to the cache,
+every document that depends on that record refetches itself over the network —
+the same behavior as calling `refresh()` on it:
+
+```graphql
+mutation FavoriteBook($id: ID!) {
+	favoriteBook(id: $id) {
+		book @refetch {
+			id
+		}
+	}
+}
+```
+
+`@refetch` goes on the field that returns the record (not on its `id`), so Houdini
+knows which record to reload. It can be used in a mutation or subscription, on a
+field that returns a single keyable object — not on lists or `@paginate`/`@list`
+fields. To refresh records inside a list, place `@refetch` on the element field
+within the list's selection.
+
 ## Lists
 
 Another primitive provided by the `cache` instance is `List` and it provide a programatic

--- a/docs/shared/01-core/06-cache.mdx
+++ b/docs/shared/01-core/06-cache.mdx
@@ -255,28 +255,9 @@ user.refresh()
 Unlike `markStale` (which waits for the next fetch to reload the data), `refresh`
 triggers the network requests immediately.
 
-### Refreshing from a mutation response
-
-If a mutation already returns the record that changed, you can skip the imperative
-call and tag the field with `@refetch`. Once the response is written to the cache,
-every document that depends on that record refetches itself over the network —
-the same behavior as calling `refresh()` on it:
-
-```graphql
-mutation FavoriteBook($id: ID!) {
-	favoriteBook(id: $id) {
-		book @refetch {
-			id
-		}
-	}
-}
-```
-
-`@refetch` goes on the field that returns the record (not on its `id`), so Houdini
-knows which record to reload. It can be used in a mutation or subscription, on any
-field that returns a keyable object — including a list of them, in which case every
-record in the list is refreshed. It cannot be combined with `@list` or `@paginate`,
-which have their own cache machinery.
+If a mutation or subscription already returns the record that changed, you can get
+this same behavior declaratively by tagging the field with `@refetch` instead of
+calling `refresh()` yourself — see [Refetching Changed Data](~/updating-data/mutations#refetching-changed-data).
 
 ## Lists
 

--- a/docs/shared/01-core/06-cache.mdx
+++ b/docs/shared/01-core/06-cache.mdx
@@ -273,10 +273,10 @@ mutation FavoriteBook($id: ID!) {
 ```
 
 `@refetch` goes on the field that returns the record (not on its `id`), so Houdini
-knows which record to reload. It can be used in a mutation or subscription, on a
-field that returns a single keyable object — not on lists or `@paginate`/`@list`
-fields. To refresh records inside a list, place `@refetch` on the element field
-within the list's selection.
+knows which record to reload. It can be used in a mutation or subscription, on any
+field that returns a keyable object — including a list of them, in which case every
+record in the list is refreshed. It cannot be combined with `@list` or `@paginate`,
+which have their own cache machinery.
 
 ## Lists
 

--- a/docs/shared/_partials/refetch.mdx
+++ b/docs/shared/_partials/refetch.mdx
@@ -1,0 +1,24 @@
+Almost always, you are best off including the changed fields as part of your mutation,
+either explicitly or by using the fragments from your various components. Doing this saves
+any additional network requests and produces the fastest experience. However, this isn't
+always possible and can sometimes be unwieldy. In those situations, you can leverage the
+`@refetch` directive to tell Houdini to look for the queries (and subscriptions) in your
+application that depend on the returned entity and cause them to refetch.
+
+```graphql
+mutation FavoriteBook($id: ID!) {
+	favoriteBook(id: $id) {
+		book @refetch {
+			id
+		}
+	}
+}
+```
+
+A few things to keep in mind:
+
+- `@refetch` goes on the field that **returns the entity**, not on its `id` — that's how
+  Houdini knows which record changed.
+- It also works on a field that returns a **list** of entities, in which case every record
+  in the list is refreshed.
+- It can't be combined with `@list` or `@paginate`, which already keep their data in sync.

--- a/docs/shared/_partials/refetch.mdx
+++ b/docs/shared/_partials/refetch.mdx
@@ -1,9 +1,9 @@
-Almost always, you are best off including the changed fields as part of your mutation,
-either explicitly or by using the fragments from your various components. Doing this saves
-any additional network requests and produces the fastest experience. However, this isn't
-always possible and can sometimes be unwieldy. In those situations, you can leverage the
-`@refetch` directive to tell Houdini to look for the queries (and subscriptions) in your
-application that depend on the returned entity and cause them to refetch.
+Most of the time, you're best off including the changed fields in the mutation itself,
+either by requesting them directly or by spreading the fragments your components already
+define. That keeps everything to a single round trip and gives the fastest experience.
+Sometimes that isn't possible, though, or it gets unwieldy. In those cases you can use the
+`@refetch` directive, which tells Houdini to find the queries that depend on the returned
+entity and refetch them.
 
 ```graphql
 mutation FavoriteBook($id: ID!) {

--- a/docs/svelte/04-updating-data/01-mutations.mdx
+++ b/docs/svelte/04-updating-data/01-mutations.mdx
@@ -4,6 +4,7 @@ description: Mutations in Houdini
 ---
 
 import Dedupe from '@shared/_partials/dedupe.mdx'
+import Refetch from '@shared/_partials/refetch.mdx'
 
 Send a mutation to the server and update your client-side cache with any changes.
 
@@ -112,6 +113,10 @@ Here's a typical pattern combining a fragment with a mutation in the same compon
 	<label for={$data.text}>{$data.text}</label>
 </li>
 ```
+
+## Refetching Changed Data
+
+<Refetch />
 
 ## Deduplication
 

--- a/e2e/kit/src/lib/utils/routes.ts
+++ b/e2e/kit/src/lib/utils/routes.ts
@@ -15,6 +15,7 @@ export const routes = {
 	loading_state: '/loading-state',
 	required_field: '/required-field',
 	Cache_Refresh: '/cache/refresh',
+	Cache_Refetch: '/cache/refetch',
 
 	Lists_fragment: '/lists/fragment',
 	Lists_mutation_insert: '/lists/mutation-insert',

--- a/e2e/kit/src/lib/utils/routes.ts
+++ b/e2e/kit/src/lib/utils/routes.ts
@@ -16,6 +16,7 @@ export const routes = {
 	required_field: '/required-field',
 	Cache_Refresh: '/cache/refresh',
 	Cache_Refetch: '/cache/refetch',
+	Cache_Refetch_Subscription: '/cache/refetch-subscription',
 
 	Lists_fragment: '/lists/fragment',
 	Lists_mutation_insert: '/lists/mutation-insert',

--- a/e2e/kit/src/routes/cache/refetch-subscription/+page.svelte
+++ b/e2e/kit/src/routes/cache/refetch-subscription/+page.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+import { graphql } from '$houdini'
+import { onMount } from 'svelte'
+import UserDetails from './UserDetails.svelte'
+
+const store = graphql(`
+	query RefetchSubQuery {
+		user(id: "1", snapshot: "cache-refetch-sub") {
+			id
+			...RefetchSubUserDetails
+		}
+	}
+`)
+
+// the subscription returns only the id, so it never writes a new name to the
+// cache. with @refetch, the arriving event makes the query reload from the API
+const updates = graphql(`
+	subscription RefetchSubSubscription {
+		userUpdate(id: "1", snapshot: "cache-refetch-sub") @refetch {
+			id
+		}
+	}
+`)
+
+// the mutation returns only the id too, so it doesn't patch the name either —
+// it just changes the server value and publishes the subscription event
+const update = graphql(`
+	mutation RefetchSubMutation($name: String!) {
+		updateUser(id: "1", snapshot: "cache-refetch-sub", name: $name) {
+			id
+		}
+	}
+`)
+
+onMount(() => {
+	store.fetch()
+})
+</script>
+
+<h1>Cache Refetch (subscription)</h1>
+
+<button id="listen" on:click={() => updates.listen()}>listen</button>
+<button id="mutate" on:click={() => update.mutate({ name: 'Samuel Jackson' })}>mutate</button>
+
+{#if $store.data}
+	<UserDetails user={$store.data.user} />
+{/if}

--- a/e2e/kit/src/routes/cache/refetch-subscription/UserDetails.svelte
+++ b/e2e/kit/src/routes/cache/refetch-subscription/UserDetails.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+import { fragment, graphql, type RefetchSubUserDetails } from '$houdini'
+
+export let user: RefetchSubUserDetails | null
+
+$: data = fragment(
+	user,
+	graphql(`
+		fragment RefetchSubUserDetails on User {
+			name
+		}
+	`)
+)
+</script>
+
+<div id="user-name">{$data?.name}</div>

--- a/e2e/kit/src/routes/cache/refetch-subscription/spec.ts
+++ b/e2e/kit/src/routes/cache/refetch-subscription/spec.ts
@@ -1,0 +1,24 @@
+import { test } from '@playwright/test'
+import { sleep } from '$lib/utils/sleep'
+import { routes } from '../../../lib/utils/routes.js'
+import { expect_to_be, goto_expect_n_gql } from '../../../lib/utils/testsHelper.js'
+
+test.describe('cache @refetch in a subscription', () => {
+	test('a subscription with @refetch refetches the dependent query', async ({ page }) => {
+		// load the page and wait for the initial query
+		await goto_expect_n_gql(page, routes.Cache_Refetch_Subscription, 1)
+		await expect_to_be(page, 'Bruce Willis', 'div[id=user-name]')
+
+		// start listening to the subscription
+		await page.click('#listen')
+		await sleep(100)
+
+		// change the user on the server and publish the subscription event. neither
+		// the mutation nor the subscription returns `name`, so the only way the query
+		// can show the new name is by refetching — which @refetch triggers
+		await page.click('#mutate')
+		await sleep(300)
+
+		await expect_to_be(page, 'Samuel Jackson', 'div[id=user-name]')
+	})
+})

--- a/e2e/kit/src/routes/cache/refetch/+page.svelte
+++ b/e2e/kit/src/routes/cache/refetch/+page.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+import { graphql } from '$houdini'
+import { onMount } from 'svelte'
+import UserDetails from './UserDetails.svelte'
+
+const store = graphql(`
+	query RefetchCacheQuery {
+		user(id: "1", snapshot: "cache-refetch") {
+			id
+			...RefetchCacheUserDetails
+		}
+	}
+`)
+
+const update = graphql(`
+	mutation RefetchCacheMutation {
+		updateUser(id: "1", snapshot: "cache-refetch", name: "Samuel Jackson") @refetch {
+			id
+		}
+	}
+`)
+
+onMount(() => {
+	store.fetch()
+})
+</script>
+
+<h1>Cache Refetch</h1>
+
+{#if $store.data}
+	<UserDetails user={$store.data.user} />
+{/if}
+
+<button id="mutate" on:click={() => update.mutate(null)}>mutate</button>

--- a/e2e/kit/src/routes/cache/refetch/UserDetails.svelte
+++ b/e2e/kit/src/routes/cache/refetch/UserDetails.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+import { fragment, graphql, type RefetchCacheUserDetails } from '$houdini'
+
+export let user: RefetchCacheUserDetails | null
+
+$: data = fragment(
+	user,
+	graphql(`
+		fragment RefetchCacheUserDetails on User {
+			name
+		}
+	`)
+)
+</script>
+
+<div id="user-name">{$data?.name}</div>

--- a/e2e/kit/src/routes/cache/refetch/spec.ts
+++ b/e2e/kit/src/routes/cache/refetch/spec.ts
@@ -1,0 +1,23 @@
+import { test } from '@playwright/test'
+import { routes } from '../../../lib/utils/routes.js'
+import { expect_n_gql, expect_to_be, goto_expect_n_gql } from '../../../lib/utils/testsHelper.js'
+
+test.describe('cache @refetch', () => {
+	test('a mutation with @refetch refetches the query that depends on the record', async ({
+		page,
+	}) => {
+		// load the page and wait for the initial query
+		await goto_expect_n_gql(page, routes.Cache_Refetch, 1)
+
+		// the fragment renders the user's name behind the query's mask
+		await expect_to_be(page, 'Bruce Willis', 'div[id=user-name]')
+
+		// clicking fires the mutation and, because the response is tagged with
+		// @refetch, the query that depends on the user refetches itself: two
+		// network requests in total
+		await expect_n_gql(page, 'button[id=mutate]', 2)
+
+		// the refetched query renders the updated name
+		await expect_to_be(page, 'Samuel Jackson', 'div[id=user-name]')
+	})
+})

--- a/packages/houdini-core/plugin/documents/artifacts/selection.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection.go
@@ -600,6 +600,18 @@ func (pb *PathBuilder) Current() []string {
 	return result
 }
 
+// FieldPath returns the response path ending at the given field, making sure the
+// field's own alias is the final segment. inline fragments invoke
+// stringifyFieldSelection without pushing the field onto the builder, so we append
+// it when it isn't already there. shared by @refetch and pagination (@list/@paginate).
+func (pb *PathBuilder) FieldPath(selection *collected.Selection) []string {
+	current := pb.Current()
+	if len(current) == 0 || current[len(current)-1] != *selection.Alias {
+		current = append(current, *selection.Alias)
+	}
+	return current
+}
+
 // Len returns the current path depth
 func (pb *PathBuilder) Len() int {
 	return len(pb.path)
@@ -1025,7 +1037,7 @@ func stringifyFieldSelection(
 			flags.RootOperations = append(flags.RootOperations, RootOperation{
 				Action: "refetch",
 				Type:   selection.FieldType,
-				Path:   pathBuilder.Current(),
+				Path:   pathBuilder.FieldPath(selection),
 			})
 			break
 		}
@@ -1053,17 +1065,8 @@ func stringifyFieldSelection(
 		// @paginate always wins over @list when both appear in the same document
 		if flags.Refetch == nil || selection.List.Paginated {
 			// use the computed path for list operations (both paginated and non-paginated)
-			currentPath := pathBuilder.Current()
-
-			// For list fields (both @list and @paginate), ensure the field is included in the path
-			// This handles cases where fragments don't include the field in the path
-			fullPath := currentPath
-			if len(currentPath) == 0 || currentPath[len(currentPath)-1] != *selection.Alias {
-				fullPath = append(currentPath, *selection.Alias)
-			}
-
 			flags.Refetch = &RefetchSpec{
-				Path:       fullPath,
+				Path:       pathBuilder.FieldPath(selection),
 				Paginated:  selection.List.Paginated,
 				PageSize:   selection.List.PageSize,
 				Mode:       RefetchMode(selection.List.Mode),

--- a/packages/houdini-core/plugin/documents/artifacts/selection.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection.go
@@ -412,6 +412,38 @@ func GenerateSelectionDocument(
     "enableLoadingState": "%s",`, flags.HasLoading)
 	}
 
+	// document-level operations (eg @refetch) collected during the walk
+	operations := ""
+	if len(flags.RootOperations) > 0 {
+		var opBuilder strings.Builder
+		for i, op := range flags.RootOperations {
+			if i > 0 {
+				opBuilder.WriteString(", ")
+			}
+
+			var pathBuilder strings.Builder
+			pathBuilder.WriteByte('[')
+			for j, field := range op.Path {
+				if j > 0 {
+					pathBuilder.WriteByte(',')
+				}
+				pathBuilder.WriteByte('"')
+				pathBuilder.WriteString(field)
+				pathBuilder.WriteByte('"')
+			}
+			pathBuilder.WriteByte(']')
+
+			opBuilder.WriteString(fmt.Sprintf(`{
+        "action": "%s",
+        "type": "%s",
+        "path": %s
+    }`, op.Action, op.Type, pathBuilder.String()))
+		}
+		operations = fmt.Sprintf(`
+
+    "operations": [%s],`, opBuilder.String())
+	}
+
 	// compute the type definitions
 	unmaskedSelection, err := FlattenSelection(ctx, docs, name, false, sortKeys)
 	if err != nil {
@@ -440,7 +472,7 @@ const artifact = {
     "rootType": "%s",
     "stripVariables": %s as Array<string>,
 
-    "selection": %s,
+    "selection": %s,%s
 
     "pluginData": %s,%s%s%s%s%s%s%s
 } as const
@@ -459,6 +491,7 @@ export default artifact
 		doc.TypeCondition,
 		string(stripVariables),
 		selectionValues,
+		operations,
 		string(marshaledData),
 		componentFields,
 		dedupe,
@@ -984,6 +1017,19 @@ func stringifyFieldSelection(
 	indent4 := strings.Repeat(spacing, level+3)
 	indent5 := strings.Repeat(spacing, level+4)
 	indent6 := strings.Repeat(spacing, level+5)
+
+	// @refetch is a document-level operation: record the path to this field's
+	// record so the runtime can refresh every dependent document after the write
+	for _, directive := range selection.Directives {
+		if directive.Name == graphql.RefetchDirective {
+			flags.RootOperations = append(flags.RootOperations, RootOperation{
+				Action: "refetch",
+				Type:   selection.FieldType,
+				Path:   pathBuilder.Current(),
+			})
+			break
+		}
+	}
 
 	// figure out the pagination state
 	var paginatedMode *string
@@ -1773,6 +1819,17 @@ type ArtifactFlags struct {
 	Refetch         *RefetchSpec
 	ComponentFields bool
 	HasLoading      string
+	// document-level operations collected during the walk (eg @refetch)
+	RootOperations []RootOperation
+}
+
+// RootOperation is a side effect applied after a document's response is written
+// to the cache. @refetch records the path to a record that every dependent
+// document should refetch.
+type RootOperation struct {
+	Action string
+	Type   string
+	Path   []string
 }
 
 type SelectionFlags struct {

--- a/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
@@ -21,7 +21,11 @@ func TestArtifactOperationsGeneration(t *testing.T) {
         users: [User!]!
       }
 
-      type User {
+      interface Node {
+        id: ID!
+      }
+
+      type User implements Node {
         id: ID!
         firstName: String!
         field(filter: String): String
@@ -29,6 +33,8 @@ func TestArtifactOperationsGeneration(t *testing.T) {
 
       type AddFriendOutput {
         friend: User!
+        friends: [User!]!
+        node: Node
       }
 
       type DeleteUserOutput {
@@ -3068,6 +3074,271 @@ export type RefetchFriend$unmasked = {
 export type RefetchFriend$artifact = typeof artifact
 
 "HoudiniHash=f21fe997186bd64751f7dd8e9ef3d9329716175a963e5004be685010e2e4c9c0"`),
+				},
+			},
+			{
+				Name: "Refetch operation on a list field",
+				Pass: true,
+				Input: []string{
+					`mutation RefetchFriends {
+              addFriend {
+                friends @refetch {
+                  firstName
+                }
+              }
+            }`,
+				},
+				Extra: map[string]any{
+					"RefetchFriends": tests.Dedent(`const artifact = {
+    "name": "RefetchFriends",
+    "kind": "HoudiniMutation",
+    "hash": "7f70b1e558ec001cd81ed64bb326ac7dd4d2aacc7da7406ee18b44d85279915e",
+    "raw": ` + "`" + `mutation RefetchFriends {
+    addFriend {
+        friends {
+            firstName
+            __typename
+            id
+        }
+        __typename
+    }
+}
+` + "`" + `,
+
+    "rootType": "Mutation",
+    "stripVariables": [] as Array<string>,
+
+    "selection": {
+        "fields": {
+            "addFriend": {
+                "type": "AddFriendOutput",
+                "keyRaw": "addFriend",
+
+                "selection": {
+                    "fields": {
+                        "__typename": {
+                            "type": "String",
+                            "keyRaw": "__typename",
+                        },
+
+                        "friends": {
+                            "type": "User",
+                            "keyRaw": "friends",
+
+                            "directives": [{
+                                "name": "refetch",
+                                "arguments": {}
+                            }],
+
+
+                            "selection": {
+                                "fields": {
+                                    "__typename": {
+                                        "type": "String",
+                                        "keyRaw": "__typename",
+                                    },
+
+                                    "firstName": {
+                                        "type": "String",
+                                        "keyRaw": "firstName",
+                                        "visible": true,
+                                    },
+
+                                    "id": {
+                                        "type": "ID",
+                                        "keyRaw": "id",
+                                    },
+                                },
+                            },
+
+                            "visible": true,
+                        },
+                    },
+                },
+
+                "visible": true,
+            },
+        },
+    },
+
+    "operations": [{
+        "action": "refetch",
+        "type": "User",
+        "path": ["addFriend","friends"]
+    }],
+
+    "pluginData": {},
+} as const
+
+export default artifact
+
+export type RefetchFriends = {
+	readonly "input"?: RefetchFriends$input;
+	readonly "result": RefetchFriends$result;
+};
+
+export type RefetchFriends$result = {
+	readonly addFriend: {
+		readonly friends: ({
+			readonly firstName: string;
+		})[];
+	};
+};
+
+export type RefetchFriends$input = null | undefined;
+
+export type RefetchFriends$optimistic = {
+	readonly addFriend?: {
+		readonly friends?: {
+			readonly firstName?: string;
+		};
+	};
+};
+
+export type RefetchFriends$unmasked = {
+	readonly addFriend: {
+		readonly __typename: "AddFriendOutput";
+		readonly friends: ({
+			readonly __typename: "User";
+			readonly firstName: string;
+			readonly id: string;
+		})[];
+	};
+};
+
+export type RefetchFriends$artifact = typeof artifact
+
+"HoudiniHash=7f70b1e558ec001cd81ed64bb326ac7dd4d2aacc7da7406ee18b44d85279915e"`),
+				},
+			},
+			{
+				Name: "Refetch operation on an abstract field",
+				Pass: true,
+				Input: []string{
+					`mutation RefetchNode {
+              addFriend {
+                node @refetch {
+                  id
+                }
+              }
+            }`,
+				},
+				Extra: map[string]any{
+					"RefetchNode": tests.Dedent(`const artifact = {
+    "name": "RefetchNode",
+    "kind": "HoudiniMutation",
+    "hash": "a14605e70bb3c9355b59c44980d48021846cd58ccb53506de70b73ceb85571ed",
+    "raw": ` + "`" + `mutation RefetchNode {
+    addFriend {
+        node {
+            id
+            __typename
+        }
+        __typename
+    }
+}
+` + "`" + `,
+
+    "rootType": "Mutation",
+    "stripVariables": [] as Array<string>,
+
+    "selection": {
+        "fields": {
+            "addFriend": {
+                "type": "AddFriendOutput",
+                "keyRaw": "addFriend",
+
+                "selection": {
+                    "fields": {
+                        "__typename": {
+                            "type": "String",
+                            "keyRaw": "__typename",
+                        },
+
+                        "node": {
+                            "type": "Node",
+                            "keyRaw": "node",
+                            "nullable": true,
+
+                            "directives": [{
+                                "name": "refetch",
+                                "arguments": {}
+                            }],
+
+
+                            "selection": {
+                                "fields": {
+                                    "__typename": {
+                                        "type": "String",
+                                        "keyRaw": "__typename",
+                                    },
+
+                                    "id": {
+                                        "type": "ID",
+                                        "keyRaw": "id",
+                                        "visible": true,
+                                    },
+                                },
+                            },
+
+                            "abstract": true,
+                            "visible": true,
+                        },
+                    },
+                },
+
+                "visible": true,
+            },
+        },
+    },
+
+    "operations": [{
+        "action": "refetch",
+        "type": "Node",
+        "path": ["addFriend","node"]
+    }],
+
+    "pluginData": {},
+} as const
+
+export default artifact
+
+export type RefetchNode = {
+	readonly "input"?: RefetchNode$input;
+	readonly "result": RefetchNode$result;
+};
+
+export type RefetchNode$result = {
+	readonly addFriend: {
+		readonly node: {
+			readonly id: string;
+		} | null;
+	};
+};
+
+export type RefetchNode$input = null | undefined;
+
+export type RefetchNode$optimistic = {
+	readonly addFriend?: {
+		readonly node?: {
+			readonly id?: string;
+		} | null;
+	};
+};
+
+export type RefetchNode$unmasked = {
+	readonly addFriend: {
+		readonly __typename: "AddFriendOutput";
+		readonly node: {
+			readonly __typename: string;
+			readonly id: string;
+		} | null;
+	};
+};
+
+export type RefetchNode$artifact = typeof artifact
+
+"HoudiniHash=a14605e70bb3c9355b59c44980d48021846cd58ccb53506de70b73ceb85571ed"`),
 				},
 			},
 		},

--- a/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
@@ -29,6 +29,7 @@ func TestArtifactOperationsGeneration(t *testing.T) {
         id: ID!
         firstName: String!
         field(filter: String): String
+        bestFriend: User
       }
 
       type AddFriendOutput {
@@ -3077,6 +3078,185 @@ export type RefetchFriend$artifact = typeof artifact
 				},
 			},
 			{
+				Name: "Multiple refetch operations",
+				Pass: true,
+				Input: []string{
+					`mutation MultiRefetch {
+              addFriend {
+                friend @refetch {
+                  id
+                }
+                node @refetch {
+                  id
+                }
+              }
+            }`,
+				},
+				Extra: map[string]any{
+					"MultiRefetch": tests.Dedent(`const artifact = {
+    "name": "MultiRefetch",
+    "kind": "HoudiniMutation",
+    "hash": "3ed4e4fd600d09b8b921ab5e0b7fea29f00a0204d5fed08832d14a9aef665433",
+    "raw": ` + "`" + `mutation MultiRefetch {
+    addFriend {
+        friend {
+            id
+            __typename
+        }
+        node {
+            id
+            __typename
+        }
+        __typename
+    }
+}
+` + "`" + `,
+
+    "rootType": "Mutation",
+    "stripVariables": [] as Array<string>,
+
+    "selection": {
+        "fields": {
+            "addFriend": {
+                "type": "AddFriendOutput",
+                "keyRaw": "addFriend",
+
+                "selection": {
+                    "fields": {
+                        "__typename": {
+                            "type": "String",
+                            "keyRaw": "__typename",
+                        },
+
+                        "friend": {
+                            "type": "User",
+                            "keyRaw": "friend",
+
+                            "directives": [{
+                                "name": "refetch",
+                                "arguments": {}
+                            }],
+
+
+                            "selection": {
+                                "fields": {
+                                    "__typename": {
+                                        "type": "String",
+                                        "keyRaw": "__typename",
+                                    },
+
+                                    "id": {
+                                        "type": "ID",
+                                        "keyRaw": "id",
+                                        "visible": true,
+                                    },
+                                },
+                            },
+
+                            "visible": true,
+                        },
+
+                        "node": {
+                            "type": "Node",
+                            "keyRaw": "node",
+                            "nullable": true,
+
+                            "directives": [{
+                                "name": "refetch",
+                                "arguments": {}
+                            }],
+
+
+                            "selection": {
+                                "fields": {
+                                    "__typename": {
+                                        "type": "String",
+                                        "keyRaw": "__typename",
+                                    },
+
+                                    "id": {
+                                        "type": "ID",
+                                        "keyRaw": "id",
+                                        "visible": true,
+                                    },
+                                },
+                            },
+
+                            "abstract": true,
+                            "visible": true,
+                        },
+                    },
+                },
+
+                "visible": true,
+            },
+        },
+    },
+
+    "operations": [{
+        "action": "refetch",
+        "type": "User",
+        "path": ["addFriend","friend"]
+    }, {
+        "action": "refetch",
+        "type": "Node",
+        "path": ["addFriend","node"]
+    }],
+
+    "pluginData": {},
+} as const
+
+export default artifact
+
+export type MultiRefetch = {
+	readonly "input"?: MultiRefetch$input;
+	readonly "result": MultiRefetch$result;
+};
+
+export type MultiRefetch$result = {
+	readonly addFriend: {
+		readonly friend: {
+			readonly id: string;
+		};
+		readonly node: {
+			readonly id: string;
+		} | null;
+	};
+};
+
+export type MultiRefetch$input = null | undefined;
+
+export type MultiRefetch$optimistic = {
+	readonly addFriend?: {
+		readonly friend?: {
+			readonly id?: string;
+		};
+		readonly node?: {
+			readonly id?: string;
+		} | null;
+	};
+};
+
+export type MultiRefetch$unmasked = {
+	readonly addFriend: {
+		readonly __typename: "AddFriendOutput";
+		readonly friend: {
+			readonly __typename: "User";
+			readonly id: string;
+		};
+		readonly node: {
+			readonly __typename: string;
+			readonly id: string;
+		} | null;
+	};
+};
+
+export type MultiRefetch$artifact = typeof artifact
+
+"HoudiniHash=3ed4e4fd600d09b8b921ab5e0b7fea29f00a0204d5fed08832d14a9aef665433"`),
+				},
+			},
+			{
 				Name: "Refetch operation on a list field",
 				Pass: true,
 				Input: []string{
@@ -3209,6 +3389,197 @@ export type RefetchFriends$unmasked = {
 export type RefetchFriends$artifact = typeof artifact
 
 "HoudiniHash=7f70b1e558ec001cd81ed64bb326ac7dd4d2aacc7da7406ee18b44d85279915e"`),
+				},
+			},
+			{
+				Name: "Refetch operation inside an inline fragment",
+				Pass: true,
+				Input: []string{
+					`mutation RefetchInline {
+              addFriend {
+                node {
+                  ... on User {
+                    bestFriend @refetch {
+                      id
+                    }
+                  }
+                }
+              }
+            }`,
+				},
+				Extra: map[string]any{
+					"RefetchInline": tests.Dedent(`const artifact = {
+    "name": "RefetchInline",
+    "kind": "HoudiniMutation",
+    "hash": "a5616a6e70fbdd95a904e71965656212df5aac6f06d25e3a0451d82b1776964c",
+    "raw": ` + "`" + `mutation RefetchInline {
+    addFriend {
+        node {
+            ... on User {
+                bestFriend {
+                    id
+                    __typename
+                }
+                __typename
+                id
+            }
+            __typename
+            id
+        }
+        __typename
+    }
+}
+` + "`" + `,
+
+    "rootType": "Mutation",
+    "stripVariables": [] as Array<string>,
+
+    "selection": {
+        "fields": {
+            "addFriend": {
+                "type": "AddFriendOutput",
+                "keyRaw": "addFriend",
+
+                "selection": {
+                    "fields": {
+                        "__typename": {
+                            "type": "String",
+                            "keyRaw": "__typename",
+                        },
+
+                        "node": {
+                            "type": "Node",
+                            "keyRaw": "node",
+                            "nullable": true,
+
+                            "selection": {
+                                "fields": {
+                                    "__typename": {
+                                        "type": "String",
+                                        "keyRaw": "__typename",
+                                    },
+
+                                    "id": {
+                                        "type": "ID",
+                                        "keyRaw": "id",
+                                    },
+                                },
+                                "abstractFields": {
+                                    "fields": {
+                                        "User": {
+                                            "__typename": {
+                                                "type": "String",
+                                                "keyRaw": "__typename",
+                                            },
+                                            "bestFriend": {
+                                                "type": "User",
+                                                "keyRaw": "bestFriend",
+                                                "nullable": true,
+
+                                                "directives": [{
+                                                    "name": "refetch",
+                                                    "arguments": {}
+                                                }],
+
+
+                                                "selection": {
+                                                    "fields": {
+                                                        "__typename": {
+                                                            "type": "String",
+                                                            "keyRaw": "__typename",
+                                                        },
+
+                                                        "id": {
+                                                            "type": "ID",
+                                                            "keyRaw": "id",
+                                                            "visible": true,
+                                                        },
+                                                    },
+                                                },
+
+                                                "visible": true,
+                                            },
+                                            "id": {
+                                                "type": "ID",
+                                                "keyRaw": "id",
+                                            },
+                                        },
+                                    },
+
+                                    "typeMap": {},
+                                },
+                            },
+
+                            "abstract": true,
+                            "visible": true,
+                        },
+                    },
+                },
+
+                "visible": true,
+            },
+        },
+    },
+
+    "operations": [{
+        "action": "refetch",
+        "type": "User",
+        "path": ["addFriend","node","bestFriend"]
+    }],
+
+    "pluginData": {},
+} as const
+
+export default artifact
+
+export type RefetchInline = {
+	readonly "input"?: RefetchInline$input;
+	readonly "result": RefetchInline$result;
+};
+
+export type RefetchInline$result = {
+	readonly addFriend: {
+		readonly node: {} & (({
+			readonly bestFriend: {
+				readonly id: string;
+			} | null;
+			readonly id: string;
+			readonly __typename: "User";
+		})) | null;
+	};
+};
+
+export type RefetchInline$input = null | undefined;
+
+export type RefetchInline$optimistic = {
+	readonly addFriend?: {
+		readonly node?: {} & (({
+			readonly bestFriend: {
+				readonly id: string;
+			} | null;
+			readonly id: string;
+			readonly __typename: "User";
+		})) | null;
+	};
+};
+
+export type RefetchInline$unmasked = {
+	readonly addFriend: {
+		readonly __typename: "AddFriendOutput";
+		readonly node: {} & (({
+			readonly bestFriend: {
+				readonly __typename: "User";
+				readonly id: string;
+			} | null;
+			readonly id: string;
+			readonly __typename: "User";
+		})) | null;
+	};
+};
+
+export type RefetchInline$artifact = typeof artifact
+
+"HoudiniHash=a5616a6e70fbdd95a904e71965656212df5aac6f06d25e3a0451d82b1776964c"`),
 				},
 			},
 			{

--- a/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
@@ -2935,6 +2935,141 @@ export type A$artifact = typeof artifact
 "HoudiniHash=425691bbfea3900b92488e1ab1c9d6ee50242cadb1de2336342766d9577656f1"`),
 				},
 			},
+			{
+				Name: "Refetch operation",
+				Pass: true,
+				Input: []string{
+					`mutation RefetchFriend {
+              addFriend {
+                friend @refetch {
+                  firstName
+                }
+              }
+            }`,
+				},
+				Extra: map[string]any{
+					"RefetchFriend": tests.Dedent(`const artifact = {
+    "name": "RefetchFriend",
+    "kind": "HoudiniMutation",
+    "hash": "f21fe997186bd64751f7dd8e9ef3d9329716175a963e5004be685010e2e4c9c0",
+    "raw": ` + "`" + `mutation RefetchFriend {
+    addFriend {
+        friend {
+            firstName
+            __typename
+            id
+        }
+        __typename
+    }
+}
+` + "`" + `,
+
+    "rootType": "Mutation",
+    "stripVariables": [] as Array<string>,
+
+    "selection": {
+        "fields": {
+            "addFriend": {
+                "type": "AddFriendOutput",
+                "keyRaw": "addFriend",
+
+                "selection": {
+                    "fields": {
+                        "__typename": {
+                            "type": "String",
+                            "keyRaw": "__typename",
+                        },
+
+                        "friend": {
+                            "type": "User",
+                            "keyRaw": "friend",
+
+                            "directives": [{
+                                "name": "refetch",
+                                "arguments": {}
+                            }],
+
+
+                            "selection": {
+                                "fields": {
+                                    "__typename": {
+                                        "type": "String",
+                                        "keyRaw": "__typename",
+                                    },
+
+                                    "firstName": {
+                                        "type": "String",
+                                        "keyRaw": "firstName",
+                                        "visible": true,
+                                    },
+
+                                    "id": {
+                                        "type": "ID",
+                                        "keyRaw": "id",
+                                    },
+                                },
+                            },
+
+                            "visible": true,
+                        },
+                    },
+                },
+
+                "visible": true,
+            },
+        },
+    },
+
+    "operations": [{
+        "action": "refetch",
+        "type": "User",
+        "path": ["addFriend","friend"]
+    }],
+
+    "pluginData": {},
+} as const
+
+export default artifact
+
+export type RefetchFriend = {
+	readonly "input"?: RefetchFriend$input;
+	readonly "result": RefetchFriend$result;
+};
+
+export type RefetchFriend$result = {
+	readonly addFriend: {
+		readonly friend: {
+			readonly firstName: string;
+		};
+	};
+};
+
+export type RefetchFriend$input = null | undefined;
+
+export type RefetchFriend$optimistic = {
+	readonly addFriend?: {
+		readonly friend?: {
+			readonly firstName?: string;
+		};
+	};
+};
+
+export type RefetchFriend$unmasked = {
+	readonly addFriend: {
+		readonly __typename: "AddFriendOutput";
+		readonly friend: {
+			readonly __typename: "User";
+			readonly firstName: string;
+			readonly id: string;
+		};
+	};
+};
+
+export type RefetchFriend$artifact = typeof artifact
+
+"HoudiniHash=f21fe997186bd64751f7dd8e9ef3d9329716175a963e5004be685010e2e4c9c0"`),
+				},
+			},
 		},
 	})
 }

--- a/packages/houdini-core/plugin/documents/validate.go
+++ b/packages/houdini-core/plugin/documents/validate.go
@@ -10,8 +10,6 @@ import (
 	"sort"
 	"strings"
 
-	
-
 	"code.houdinigraphql.com/packages/houdini-core/config"
 	"code.houdinigraphql.com/packages/houdini-core/plugin/schema"
 	"code.houdinigraphql.com/plugins"
@@ -1755,6 +1753,133 @@ func ValidateOptimisticKeyOnScalar(
 				{Filepath: filepath, Line: row, Column: column},
 			},
 		})
+	})
+	if err != nil {
+		errs.Append(plugins.WrapError(err))
+	}
+}
+
+func ValidateRefetchDirective(
+	ctx context.Context,
+	db plugins.DatabasePool[config.PluginConfig],
+	errs *plugins.ErrorList,
+) {
+	// @refetch marks a record in a response so the cache refetches every document
+	// that depends on it. that only makes sense on a singular field that returns a
+	// keyable object/abstract type, so we reject scalars, lists, keyless types, and
+	// fields that already carry the list/pagination machinery.
+	query := `
+	SELECT
+	  s.field_name,
+	  tf.type_modifiers,
+	  t.kind AS fieldTypeKind,
+	  COALESCE(tc.keys, c.default_keys) AS keys,
+	  rd.filepath,
+	  sr.row,
+	  sr.column,
+	  d.name AS documentName,
+	  d.kind AS documentKind,
+	  EXISTS(
+	    SELECT 1 FROM selection_directives sd2
+	    WHERE sd2.selection_id = s.id AND sd2.directive IN ($list_directive, $paginate_directive)
+	  ) AS hasListDirective
+	FROM selections s
+	  JOIN selection_directives sd ON s.id = sd.selection_id
+	  JOIN type_fields tf ON s.type = tf.id
+	  JOIN types t ON tf.type = t.name
+	  LEFT JOIN type_configs tc ON tc.name = tf.type
+	  CROSS JOIN config c
+	  JOIN selection_refs sr ON sr.child_id = s.id
+	  JOIN documents d ON d.id = sr.document
+	  JOIN raw_documents rd ON rd.id = d.raw_document
+	WHERE sd.directive = $refetch_directive
+	  AND (rd.current_task = $task_id OR $task_id IS NULL)
+	`
+
+	bindings := map[string]any{
+		"refetch_directive":  graphql.RefetchDirective,
+		"list_directive":     graphql.ListDirective,
+		"paginate_directive": graphql.PaginationDirective,
+	}
+
+	err := db.StepQuery(ctx, query, bindings, func(stmt plugins.Row) {
+		fieldName := stmt.ColumnText(0)
+		typeModifiers := stmt.ColumnText(1)
+		fieldTypeKind := stmt.ColumnText(2)
+		keys := strings.TrimSpace(stmt.ColumnText(3))
+		filepath := stmt.ColumnText(4)
+		row := int(stmt.ColumnInt(5))
+		column := int(stmt.ColumnInt(6))
+		docName := stmt.ColumnText(7)
+		docKind := stmt.ColumnText(8)
+		hasListDirective := stmt.ColumnInt(9) != 0
+
+		location := []*plugins.ErrorLocation{{Filepath: filepath, Line: row, Column: column}}
+
+		// @refetch is a side effect of writing a response; it belongs on a mutation
+		// or subscription. on a query it would refetch the document itself.
+		if docKind != "mutation" && docKind != "subscription" {
+			errs.Append(&plugins.Error{
+				Message: fmt.Sprintf(
+					"@%s can only be used in a mutation or subscription, but field %q appears in %s %q",
+					graphql.RefetchDirective, fieldName, docKind, docName,
+				),
+				Kind:      plugins.ErrorKindValidation,
+				Locations: location,
+			})
+			return
+		}
+
+		// the field has to return an object/abstract type so we can identify a record
+		if fieldTypeKind != "OBJECT" && fieldTypeKind != "INTERFACE" && fieldTypeKind != "UNION" {
+			errs.Append(&plugins.Error{
+				Message: fmt.Sprintf(
+					"@%s can only be used on fields that return an object type, but field %q in document %q returns a %s",
+					graphql.RefetchDirective, fieldName, docName, fieldTypeKind,
+				),
+				Kind:      plugins.ErrorKindValidation,
+				Locations: location,
+			})
+			return
+		}
+
+		// refetch operates on a single record so list fields are not allowed
+		if strings.Contains(typeModifiers, "]") {
+			errs.Append(&plugins.Error{
+				Message: fmt.Sprintf(
+					"@%s cannot be used on list fields (field %q in document %q); place it on the element you want to refetch instead",
+					graphql.RefetchDirective, fieldName, docName,
+				),
+				Kind:      plugins.ErrorKindValidation,
+				Locations: location,
+			})
+			return
+		}
+
+		// @list / @paginate fields have their own machinery and aren't single records
+		if hasListDirective {
+			errs.Append(&plugins.Error{
+				Message: fmt.Sprintf(
+					"@%s cannot be combined with @%s or @%s (field %q in document %q)",
+					graphql.RefetchDirective, graphql.ListDirective, graphql.PaginationDirective, fieldName, docName,
+				),
+				Kind:      plugins.ErrorKindValidation,
+				Locations: location,
+			})
+			return
+		}
+
+		// we need keys to identify the record to refetch
+		if keys == "" || keys == "[]" {
+			errs.Append(&plugins.Error{
+				Message: fmt.Sprintf(
+					"@%s can only be used on types with keys, but field %q in document %q returns a keyless type",
+					graphql.RefetchDirective, fieldName, docName,
+				),
+				Kind:      plugins.ErrorKindValidation,
+				Locations: location,
+			})
+		}
 	})
 	if err != nil {
 		errs.Append(plugins.WrapError(err))

--- a/packages/houdini-core/plugin/documents/validate.go
+++ b/packages/houdini-core/plugin/documents/validate.go
@@ -1764,10 +1764,10 @@ func ValidateRefetchDirective(
 	db plugins.DatabasePool[config.PluginConfig],
 	errs *plugins.ErrorList,
 ) {
-	// @refetch marks a record in a response so the cache refetches every document
-	// that depends on it. that only makes sense on a singular field that returns a
-	// keyable object/abstract type, so we reject scalars, lists, keyless types, and
-	// fields that already carry the list/pagination machinery.
+	// @refetch marks the record(s) returned by a field so the cache refetches every
+	// document that depends on them. the field has to return a keyable object/abstract
+	// type (a list of them is fine — we refresh each), so we reject scalars, keyless
+	// types, and fields that already carry the list/pagination machinery.
 	query := `
 	SELECT
 	  s.field_name,
@@ -1804,7 +1804,6 @@ func ValidateRefetchDirective(
 
 	err := db.StepQuery(ctx, query, bindings, func(stmt plugins.Row) {
 		fieldName := stmt.ColumnText(0)
-		typeModifiers := stmt.ColumnText(1)
 		fieldTypeKind := stmt.ColumnText(2)
 		keys := strings.TrimSpace(stmt.ColumnText(3))
 		filepath := stmt.ColumnText(4)
@@ -1836,19 +1835,6 @@ func ValidateRefetchDirective(
 				Message: fmt.Sprintf(
 					"@%s can only be used on fields that return an object type, but field %q in document %q returns a %s",
 					graphql.RefetchDirective, fieldName, docName, fieldTypeKind,
-				),
-				Kind:      plugins.ErrorKindValidation,
-				Locations: location,
-			})
-			return
-		}
-
-		// refetch operates on a single record so list fields are not allowed
-		if strings.Contains(typeModifiers, "]") {
-			errs.Append(&plugins.Error{
-				Message: fmt.Sprintf(
-					"@%s cannot be used on list fields (field %q in document %q); place it on the element you want to refetch instead",
-					graphql.RefetchDirective, fieldName, docName,
 				),
 				Kind:      plugins.ErrorKindValidation,
 				Locations: location,

--- a/packages/houdini-core/plugin/schema/generateDefinitions_test.go
+++ b/packages/houdini-core/plugin/schema/generateDefinitions_test.go
@@ -120,6 +120,9 @@ directive @loading(cascade: Boolean, count: Int) on FIELD | FRAGMENT_DEFINITION 
 """@required makes a nullable field always non-null by making the parent null when the field is"""
 directive @required on FIELD
 
+"""@refetch marks a record in a mutation response so the cache refetches every document that depends on it"""
+directive @refetch on FIELD
+
 """@componentField is used to mark a field as a component field"""
 directive @componentField(field: String, prop: String) on FIELD_DEFINITION | FRAGMENT_DEFINITION | INLINE_FRAGMENT
 

--- a/packages/houdini-core/plugin/schema/write.go
+++ b/packages/houdini-core/plugin/schema/write.go
@@ -1018,6 +1018,23 @@ then the request will never be deduplicated.`,
 		return err
 	}
 
+	// @refetch on FIELD
+	err = db.ExecStatement(statements.InsertInternalDirective, map[string]any{
+		"name":        graphql.RefetchDirective,
+		"description": "@refetch marks a record in a mutation response so the cache refetches every document that depends on it",
+		"visible":     true,
+	})
+	if err != nil {
+		return err
+	}
+	err = db.ExecStatement(statements.InsertDirectiveLocation, map[string]any{
+		"directive": graphql.RefetchDirective,
+		"location":  "FIELD",
+	})
+	if err != nil {
+		return err
+	}
+
 	// @componentField(prop: String, field: String) on FRAGMENT_DEFINITION | INLINE_FRAGMENT | FIELD_DEFINITION
 	err = db.ExecStatement(statements.InsertInternalDirective, map[string]any{
 		"name":        graphql.ComponentFieldDirective,

--- a/packages/houdini-core/plugin/validate.go
+++ b/packages/houdini-core/plugin/validate.go
@@ -46,6 +46,7 @@ func (p *HoudiniCore) Validate(ctx context.Context) error {
 		documents.ValidateRequiredDirective,
 		documents.ValidateOptimisticKeyFullSelection,
 		documents.ValidateOptimisticKeyOnScalar,
+		documents.ValidateRefetchDirective,
 		lists.DiscoverListsThenValidate,
 		lists.ValidateConflictingParentIDAllLists,
 		lists.ValidateConflictingPrependAppend,

--- a/packages/houdini-core/plugin/validate_test.go
+++ b/packages/houdini-core/plugin/validate_test.go
@@ -93,6 +93,7 @@ func TestValidate_Houdini(t *testing.T) {
 				addFriend: AddFriendOutput!
 				deleteUser(id: ID!): DeleteUserOutput!
 				updateGhost: Ghost!
+				updateNode: Node
 			}
 
 			union Human = User
@@ -2550,6 +2551,17 @@ func TestValidate_Houdini(t *testing.T) {
 							friend {
 								firstName @refetch
 							}
+						}
+					}`,
+				},
+			},
+			{
+				Name: "@refetch on an abstract field (positive)",
+				Pass: true,
+				Input: []string{
+					`mutation RefetchNode {
+						updateNode @refetch {
+							id
 						}
 					}`,
 				},

--- a/packages/houdini-core/plugin/validate_test.go
+++ b/packages/houdini-core/plugin/validate_test.go
@@ -37,6 +37,7 @@ func TestValidate_Houdini(t *testing.T) {
 			type Subscription {
 				newMessage: String
 				anotherMessage: String
+				userUpdate: User
 			}
 
 			type Cat {
@@ -2501,6 +2502,90 @@ func TestValidate_Houdini(t *testing.T) {
 					    ...frag
 				    }
 			   }`,
+				},
+			},
+			{
+				Name: "@refetch on an object field (positive)",
+				Pass: true,
+				Input: []string{
+					`mutation RefetchFriend {
+						addFriend {
+							friend @refetch {
+								firstName
+							}
+						}
+					}`,
+				},
+			},
+			{
+				Name: "@refetch in a subscription (positive)",
+				Pass: true,
+				Input: []string{
+					`subscription RefetchSub {
+						userUpdate @refetch {
+							id
+						}
+					}`,
+				},
+			},
+			{
+				Name: "@refetch outside a mutation (negative)",
+				Pass: false,
+				Input: []string{
+					`query RefetchQuery {
+						user(name: "foo") {
+							bestFriend @refetch {
+								id
+							}
+						}
+					}`,
+				},
+			},
+			{
+				Name: "@refetch on a scalar field (negative)",
+				Pass: false,
+				Input: []string{
+					`mutation RefetchScalar {
+						addFriend {
+							friend {
+								firstName @refetch
+							}
+						}
+					}`,
+				},
+			},
+			{
+				Name: "@refetch on a list field (negative)",
+				Pass: false,
+				Input: []string{
+					`mutation RefetchList {
+						addFriend {
+							friend {
+								friends @refetch {
+									id
+								}
+							}
+						}
+					}`,
+				},
+			},
+			{
+				Name: "@refetch combined with @paginate (negative)",
+				Pass: false,
+				Input: []string{
+					`mutation RefetchAndPaginate {
+						addFriend {
+							friend {
+								believers @refetch @paginate {
+									edges {
+										node {
+											id
+										}
+									}
+								}
+							}
+						}
+					}`,
 				},
 			},
 		},

--- a/packages/houdini-core/plugin/validate_test.go
+++ b/packages/houdini-core/plugin/validate_test.go
@@ -2555,8 +2555,8 @@ func TestValidate_Houdini(t *testing.T) {
 				},
 			},
 			{
-				Name: "@refetch on a list field (negative)",
-				Pass: false,
+				Name: "@refetch on a plain list field (positive)",
+				Pass: true,
 				Input: []string{
 					`mutation RefetchList {
 						addFriend {

--- a/packages/houdini-core/runtime/plugins/cache.ts
+++ b/packages/houdini-core/runtime/plugins/cache.ts
@@ -6,6 +6,32 @@ import cache from '../cache.js'
 
 const serverSide = typeof globalThis.window === 'undefined'
 
+// walk the response data along a path collecting the record object(s) at the end.
+// a path segment can resolve to a list (eg a @refetch field nested under a list)
+// so each step may fan out to multiple records.
+export function recordsAtPath(
+	data: GraphQLObject | null,
+	path: readonly string[]
+): GraphQLObject[] {
+	let current: any[] = data ? [data] : []
+	for (const key of path) {
+		const next: any[] = []
+		for (const entry of current) {
+			if (entry == null) {
+				continue
+			}
+			const value = entry[key]
+			if (Array.isArray(value)) {
+				next.push(...value.flat(Infinity))
+			} else if (value != null) {
+				next.push(value)
+			}
+		}
+		current = next
+	}
+	return current.filter((entry) => entry && typeof entry === 'object')
+}
+
 export const cachePolicy =
 	({
 		enabled,
@@ -159,6 +185,33 @@ export const cachePolicy =
 						data: value.data,
 						variables: marshalVariables(ctx),
 					})
+
+					// document-level operations run once the response has been written.
+					// @refetch asks every document that depends on a record to reload
+					// itself. only mutations and subscriptions trigger this so a query
+					// can't refetch itself.
+					if (
+						(ctx.artifact.kind === ArtifactKind.Mutation ||
+							ctx.artifact.kind === ArtifactKind.Subscription) &&
+						ctx.artifact.operations?.length &&
+						!ctx.cacheParams?.disableWrite
+					) {
+						for (const operation of ctx.artifact.operations) {
+							if (operation.action !== 'refetch') {
+								continue
+							}
+
+							for (const record of recordsAtPath(value.data, operation.path)) {
+								const id = targetCache._internal_unstable.id(
+									(record.__typename as string) ?? operation.type,
+									record
+								)
+								if (id) {
+									targetCache.refresh(id)
+								}
+							}
+						}
+					}
 
 					// we need to embed the fragment context values in our response
 					// and apply masking other value transforms. In order to do that,

--- a/packages/houdini-core/runtime/plugins/cache.ts
+++ b/packages/houdini-core/runtime/plugins/cache.ts
@@ -196,6 +196,9 @@ export const cachePolicy =
 						ctx.artifact.operations?.length &&
 						!ctx.cacheParams?.disableWrite
 					) {
+						// gather every record id tagged with @refetch, deduped, so a
+						// document that depends on several of them only refetches once
+						const refreshIDs = new Set<string>()
 						for (const operation of ctx.artifact.operations) {
 							if (operation.action !== 'refetch') {
 								continue
@@ -207,9 +210,13 @@ export const cachePolicy =
 									record
 								)
 								if (id) {
-									targetCache.refresh(id)
+									refreshIDs.add(id)
 								}
 							}
+						}
+
+						if (refreshIDs.size > 0) {
+							targetCache.refresh([...refreshIDs])
 						}
 					}
 

--- a/packages/houdini-core/runtime/plugins/fragment.ts
+++ b/packages/houdini-core/runtime/plugins/fragment.ts
@@ -45,6 +45,7 @@ export const fragment = (cache: Cache) =>
 					// save the new subscription spec
 					subscriptionSpec = {
 						rootType: ctx.artifact.rootType,
+						kind: ctx.artifact.kind,
 						selection: ctx.artifact.selection,
 						variables: () => variables,
 						parentID: ctx.stuff.parentID,

--- a/packages/houdini-core/runtime/plugins/query.ts
+++ b/packages/houdini-core/runtime/plugins/query.ts
@@ -70,6 +70,7 @@ export const query = (cache: Cache) =>
 					// save the new subscription spec
 					subscriptionSpec = {
 						rootType: ctx.artifact.rootType,
+						kind: ctx.artifact.kind,
 						selection: ctx.artifact.selection,
 						variables: () => variables,
 						onMessage: (message) => {

--- a/packages/houdini-core/runtime/public/tests/refetchPath.test.ts
+++ b/packages/houdini-core/runtime/public/tests/refetchPath.test.ts
@@ -4,19 +4,14 @@ import { recordsAtPath } from '../../plugins/cache.js'
 
 test('walks a path to a singular record', () => {
 	const data = { addFriend: { friend: { __typename: 'User', id: '1' } } }
-	expect(recordsAtPath(data, ['addFriend', 'friend'])).toEqual([
-		{ __typename: 'User', id: '1' },
-	])
+	expect(recordsAtPath(data, ['addFriend', 'friend'])).toEqual([{ __typename: 'User', id: '1' }])
 })
 
 test('fans out when a path segment is a list', () => {
 	const data = {
 		updateUsers: [{ bestFriend: { id: '2' } }, { bestFriend: { id: '3' } }],
 	}
-	expect(recordsAtPath(data, ['updateUsers', 'bestFriend'])).toEqual([
-		{ id: '2' },
-		{ id: '3' },
-	])
+	expect(recordsAtPath(data, ['updateUsers', 'bestFriend'])).toEqual([{ id: '2' }, { id: '3' }])
 })
 
 test('flattens nested lists along the path', () => {

--- a/packages/houdini-core/runtime/public/tests/refetchPath.test.ts
+++ b/packages/houdini-core/runtime/public/tests/refetchPath.test.ts
@@ -7,6 +7,19 @@ test('walks a path to a singular record', () => {
 	expect(recordsAtPath(data, ['addFriend', 'friend'])).toEqual([{ __typename: 'User', id: '1' }])
 })
 
+test('returns every record when the @refetch field itself is a list', () => {
+	const data = {
+		updateFriends: [
+			{ __typename: 'User', id: '1' },
+			{ __typename: 'User', id: '2' },
+		],
+	}
+	expect(recordsAtPath(data, ['updateFriends'])).toEqual([
+		{ __typename: 'User', id: '1' },
+		{ __typename: 'User', id: '2' },
+	])
+})
+
 test('fans out when a path segment is a list', () => {
 	const data = {
 		updateUsers: [{ bestFriend: { id: '2' } }, { bestFriend: { id: '3' } }],

--- a/packages/houdini-core/runtime/public/tests/refetchPath.test.ts
+++ b/packages/houdini-core/runtime/public/tests/refetchPath.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from 'vitest'
+
+import { recordsAtPath } from '../../plugins/cache.js'
+
+test('walks a path to a singular record', () => {
+	const data = { addFriend: { friend: { __typename: 'User', id: '1' } } }
+	expect(recordsAtPath(data, ['addFriend', 'friend'])).toEqual([
+		{ __typename: 'User', id: '1' },
+	])
+})
+
+test('fans out when a path segment is a list', () => {
+	const data = {
+		updateUsers: [{ bestFriend: { id: '2' } }, { bestFriend: { id: '3' } }],
+	}
+	expect(recordsAtPath(data, ['updateUsers', 'bestFriend'])).toEqual([
+		{ id: '2' },
+		{ id: '3' },
+	])
+})
+
+test('flattens nested lists along the path', () => {
+	const data = { groups: [[{ user: { id: 'a' } }], [{ user: { id: 'b' } }]] }
+	expect(recordsAtPath(data, ['groups', 'user'])).toEqual([{ id: 'a' }, { id: 'b' }])
+})
+
+test('skips null links without throwing', () => {
+	expect(recordsAtPath({ addFriend: null }, ['addFriend', 'friend'])).toEqual([])
+	expect(recordsAtPath(null, ['addFriend'])).toEqual([])
+})

--- a/packages/houdini/src/runtime/cache/index.ts
+++ b/packages/houdini/src/runtime/cache/index.ts
@@ -18,7 +18,7 @@ import type {
 	ValueMap,
 	ValueNode,
 } from '../types.js'
-import { fragmentKey } from '../types.js'
+import { ArtifactKind, fragmentKey } from '../types.js'
 import { GarbageCollector } from './gc.js'
 import type { ListCollection } from './lists.js'
 import { ListManager, opaqueListID } from './lists.js'
@@ -214,6 +214,11 @@ export class Cache {
 			for (const [spec] of this._internal_unstable.subscriptions.getAll(recordID, {
 				includeMaskedParents: true,
 			})) {
+				// subscriptions are a live stream from the server — they are never
+				// asked to refetch (their data arrives by being pushed, not pulled)
+				if (spec.kind === ArtifactKind.Subscription) {
+					continue
+				}
 				if (!notified.has(spec.onMessage)) {
 					notified.add(spec.onMessage)
 					spec.onMessage({ kind: 'refetch' })

--- a/packages/houdini/src/runtime/cache/index.ts
+++ b/packages/houdini/src/runtime/cache/index.ts
@@ -198,30 +198,36 @@ export class Cache {
 		}
 	}
 
-	// ask every document whose data contains the record to refetch itself.
-	// this includes documents that only contain the record behind a masked
-	// boundary (a fragment spread) thanks to their masked parent subscriptions
-	refresh(id: string) {
-		// when an optimistic key resolves we might know the record by two ids
-		const recordIDs = [this._internal_unstable.storage.idMaps[id], id].filter(
-			Boolean
-		) as string[]
+	// ask every document whose data contains the record(s) to refetch itself.
+	// this includes documents that only contain a record behind a masked
+	// boundary (a fragment spread) thanks to their masked parent subscriptions.
+	// passing several ids notifies each document at most once, even if it
+	// depends on more than one of them (eg a list returned by a mutation).
+	refresh(id: string | string[]) {
+		const ids = Array.isArray(id) ? id : [id]
 
-		// a document can be subscribed to multiple fields of the record so make
-		// sure we only send the message once per set
+		// a document can be subscribed to multiple fields, multiple records, or
+		// know a record by two ids (optimistic key) — only send one message per set
 		const notified = new Set<SubscriptionSpec['onMessage']>()
-		for (const recordID of recordIDs) {
-			for (const [spec] of this._internal_unstable.subscriptions.getAll(recordID, {
-				includeMaskedParents: true,
-			})) {
-				// subscriptions are a live stream from the server — they are never
-				// asked to refetch (their data arrives by being pushed, not pulled)
-				if (spec.kind === ArtifactKind.Subscription) {
-					continue
-				}
-				if (!notified.has(spec.onMessage)) {
-					notified.add(spec.onMessage)
-					spec.onMessage({ kind: 'refetch' })
+		for (const baseID of ids) {
+			// when an optimistic key resolves we might know the record by two ids
+			const recordIDs = [this._internal_unstable.storage.idMaps[baseID], baseID].filter(
+				Boolean
+			) as string[]
+
+			for (const recordID of recordIDs) {
+				for (const [spec] of this._internal_unstable.subscriptions.getAll(recordID, {
+					includeMaskedParents: true,
+				})) {
+					// subscriptions are a live stream from the server — they are never
+					// asked to refetch (their data arrives by being pushed, not pulled)
+					if (spec.kind === ArtifactKind.Subscription) {
+						continue
+					}
+					if (!notified.has(spec.onMessage)) {
+						notified.add(spec.onMessage)
+						spec.onMessage({ kind: 'refetch' })
+					}
 				}
 			}
 		}

--- a/packages/houdini/src/runtime/cache/tests/refresh.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/refresh.test.ts
@@ -143,6 +143,67 @@ test('refresh never asks a subscription document to refetch', () => {
 	expect(subscriptionSet).not.toHaveBeenCalled()
 })
 
+test('refreshing many records notifies a dependent document only once', () => {
+	const cache = new Cache(config)
+
+	const listSelection: SubscriptionSelection = {
+		fields: {
+			viewer: {
+				type: 'User',
+				visible: true,
+				keyRaw: 'viewer',
+				selection: {
+					fields: {
+						id: { type: 'ID', visible: true, keyRaw: 'id' },
+						friends: {
+							type: 'User',
+							visible: true,
+							keyRaw: 'friends',
+							selection: {
+								fields: {
+									id: { type: 'ID', visible: true, keyRaw: 'id' },
+									firstName: {
+										type: 'String',
+										visible: true,
+										keyRaw: 'firstName',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cache.write({
+		selection: listSelection,
+		data: {
+			viewer: {
+				id: '1',
+				friends: [
+					{ id: '2', firstName: 'jane' },
+					{ id: '3', firstName: 'mark' },
+				],
+			},
+		},
+	})
+
+	const set = vi.fn()
+	cache.subscribe({
+		rootType: 'Query',
+		kind: ArtifactKind.Query,
+		selection: listSelection,
+		onMessage: set,
+	})
+
+	// both friends changed, but the one document that lists them refetches once
+	cache.refresh(['User:2', 'User:3'])
+
+	expect(set).toHaveBeenCalledTimes(1)
+	expect(set).toHaveBeenCalledWith({ kind: 'refetch' })
+})
+
 test('refresh reaches documents that only contain the record behind a mask', () => {
 	const cache = new Cache(config)
 

--- a/packages/houdini/src/runtime/cache/tests/refresh.test.ts
+++ b/packages/houdini/src/runtime/cache/tests/refresh.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, vi } from 'vitest'
 
 import { testConfigFile } from '../../../test/index.js'
+import { ArtifactKind } from '../../types.js'
 import type { SubscriptionSelection } from '../../types.js'
 import { Cache } from '../index.js'
 import { rootID } from '../stuff.js'
@@ -103,6 +104,43 @@ test('refresh notifies documents subscribed to the record', () => {
 	cache.refresh(rootID)
 	expect(set).toHaveBeenCalledTimes(1)
 	expect(set).toHaveBeenCalledWith({ kind: 'refetch' })
+})
+
+test('refresh never asks a subscription document to refetch', () => {
+	const cache = new Cache(config)
+
+	cache.write({
+		selection: visibleSelection,
+		data: {
+			viewer: {
+				id: '1',
+				firstName: 'bob',
+			},
+		},
+	})
+
+	// a query and a subscription both contain the record
+	const querySet = vi.fn()
+	cache.subscribe({
+		rootType: 'Query',
+		selection: visibleSelection,
+		onMessage: querySet,
+	})
+
+	const subscriptionSet = vi.fn()
+	cache.subscribe({
+		rootType: 'Subscription',
+		kind: ArtifactKind.Subscription,
+		selection: visibleSelection,
+		onMessage: subscriptionSet,
+	})
+
+	cache.refresh('User:1')
+
+	// the query refetches but the subscription is left alone — a live stream is
+	// pushed from the server, never pulled
+	expect(querySet).toHaveBeenCalledWith({ kind: 'refetch' })
+	expect(subscriptionSet).not.toHaveBeenCalled()
 })
 
 test('refresh reaches documents that only contain the record behind a mask', () => {

--- a/packages/houdini/src/runtime/types.ts
+++ b/packages/houdini/src/runtime/types.ts
@@ -130,8 +130,17 @@ export type BaseCompiledDocument<_Kind extends ArtifactKinds> = Readonly<{
 		direction: 'forward' | 'backward' | 'both'
 		mode: PaginateModes
 	}
+	// document-level operations applied after the response is written to the cache.
+	// @refetch records the path to a record that every dependent document should refetch.
+	operations?: readonly RootOperation[]
 	pluginData: Record<string, any>
 }>
+
+export type RootOperation = {
+	action: 'refetch'
+	type: string
+	path: readonly string[]
+}
 
 export type HoudiniFetchContext = {
 	variables: () => {}
@@ -286,6 +295,9 @@ export type CacheMessage<_Data = any> =
 
 export type SubscriptionSpec = Readonly<{
 	rootType: string
+	// the kind of document that registered this subscription. used to decide
+	// which documents a cache.refresh() should ask to refetch.
+	kind?: ArtifactKinds
 	selection: SubscriptionSelection
 	onMessage: (message: CacheMessage) => void
 	parentID?: string

--- a/plugins/graphql/conventions.go
+++ b/plugins/graphql/conventions.go
@@ -50,6 +50,8 @@ const ComponentFieldDirective = "componentField"
 
 const RuntimeScalarDirective = "__houdini__runtimeScalar"
 
+const RefetchDirective = "refetch"
+
 const ListOperationSuffixInsert = "_insert"
 
 const ListOperationSuffixRemove = "_remove"


### PR DESCRIPTION
This PR adds a `@refetch` directive that tags a record in a mutation or subscription response. Once that response is written to the cache, every document that depends on the record — including documents that only hold it behind a fragment mask — refetches itself over the network
 
  ```graphql
  mutation FavoriteBook($id: ID!) {
    favoriteBook(id: $id) {
      book @refetch {
        id
      }
    }
  }
```

closes #1298.
