### PR TITLE
Refetchable fragments

### DIFF
--- a/.changeset/refetchable-fragments.md
+++ b/.changeset/refetchable-fragments.md
@@ -1,0 +1,8 @@
+---
+'houdini': minor
+'houdini-core': minor
+'houdini-svelte': minor
+'houdini-react': minor
+---
+
+Add the `@refetchable` directive to mark a fragment as refetchable on its own with new argument values. Use `refetchableFragment` in Svelte or `useFragmentHandle().refetch` in React to re-run it.

--- a/.changeset/refetchable-fragments.md
+++ b/.changeset/refetchable-fragments.md
@@ -5,4 +5,4 @@
 'houdini-react': minor
 ---
 
-Add the `@refetchable` directive to mark a fragment as refetchable on its own with new argument values. Use `refetchableFragment` in Svelte or `useFragmentHandle().refetch` in React to re-run it.
+Add the `@refetchable` directive to mark a fragment as refetchable on its own with new argument values.

--- a/docs/react/03-loading-data/02-fragments.mdx
+++ b/docs/react/03-loading-data/02-fragments.mdx
@@ -138,6 +138,46 @@ export default function ShowsPage({ ShowList: data }) {
 
 A `@plural` fragment has to be spread on a list field, since that's the only place an array of references can come from. Spreading it anywhere else is a codegen error.
 
+## Refetchable Fragments
+
+Sometimes a component needs to reload its own data with different arguments without dragging the route that rendered it into the conversation. Mark the fragment with `@refetchable` and read it with [`useFragmentHandle`](~/api-reference/useFragmentHandle) instead of `useFragment`. The handle hands back a `refetch` method alongside the data:
+
+```tsx
+import { graphql, useFragmentHandle } from '$houdini'
+import type { UserInfo } from '$houdini'
+
+export function UserInfo({ user }: { user: UserInfo }) {
+  const { data, refetch } = useFragmentHandle(user, graphql(`
+    fragment UserInfo on User @refetchable @arguments(filter: { type: "String" }) {
+      friends(filter: $filter) {
+        name
+      }
+    }
+  `))
+
+  return (
+    <>
+      {data?.friends.map((friend) => <div key={friend.name}>{friend.name}</div>)}
+      <button onClick={() => refetch({ filter: 'aki' })}>filter friends</button>
+    </>
+  )
+}
+```
+
+Calling `refetch` re-runs the fragment against the network with the arguments we hand it, layered over whatever it was last loaded with, so we only pass the values we actually want to change. The record's id is figured out for us from the data already on screen.
+
+The initial values come from wherever the fragment is spread, the same as any fragment that takes arguments. The parent passes them with `@with`:
+
+```graphql
+query UserPage {
+  user {
+    ...UserInfo @with(filter: "aki")
+  }
+}
+```
+
+The fragment has to live on a type Houdini can look up on its own, which in practice means one that implements `Node` or has a custom resolver configured. That's the same requirement paginated fragments carry: under the hood we embed the fragment in a query keyed by the record's id and re-run that.
+
 ## Fragment Masking
 
 Fragment masking keeps components properly encapsulated by ensuring they can only access the fields they explicitly declared — not fields pulled in by sibling fragments. For a deeper look at why this matters, see the [Fragment Colocation guide](https://gql-tada.0no.co/guides/fragment-colocation) from gql.tada.

--- a/docs/react/03-loading-data/02-fragments.mdx
+++ b/docs/react/03-loading-data/02-fragments.mdx
@@ -140,7 +140,7 @@ A `@plural` fragment has to be spread on a list field, since that's the only pla
 
 ## Refetchable Fragments
 
-Sometimes a component needs to reload its own data with different arguments without dragging the route that rendered it into the conversation. Mark the fragment with `@refetchable` and read it with [`useFragmentHandle`](~/api-reference/useFragmentHandle) instead of `useFragment`. The handle hands back a `refetch` method alongside the data:
+Sometimes a component needs to reload its own data with different arguments. Mark the fragment with `@refetchable` and read it with [`useFragmentHandle`](~/api-reference/useFragmentHandle) instead of `useFragment`. The handle hands back a `refetch` method alongside the data:
 
 ```tsx
 import { graphql, useFragmentHandle } from '$houdini'

--- a/docs/react/03-loading-data/02-fragments.mdx
+++ b/docs/react/03-loading-data/02-fragments.mdx
@@ -178,6 +178,8 @@ query UserPage {
 
 The fragment has to live on a type Houdini can look up on its own, which in practice means one that implements `Node` or has a custom resolver configured. That's the same requirement paginated fragments carry: under the hood we embed the fragment in a query keyed by the record's id and re-run that.
 
+`@refetchable` can't be combined with `@paginate` on the same fragment — a paginated fragment is already refetchable on its own, so the two together is a compile-time error.
+
 ## Fragment Masking
 
 Fragment masking keeps components properly encapsulated by ensuring they can only access the fields they explicitly declared — not fields pulled in by sibling fragments. For a deeper look at why this matters, see the [Fragment Colocation guide](https://gql-tada.0no.co/guides/fragment-colocation) from gql.tada.

--- a/docs/react/06-api-reference/11-useFragmentHandle.mdx
+++ b/docs/react/06-api-reference/11-useFragmentHandle.mdx
@@ -33,10 +33,33 @@ export function ShowList({ show }: { show: ShowList_show }) {
 }
 ```
 
+## Refetch
+
+When the fragment is marked with `@refetchable`, the handle also carries a `refetch` method that re-runs the fragment with new argument values:
+
+```tsx
+import { graphql, useFragmentHandle } from '$houdini'
+import type { UserInfo } from '$houdini'
+
+export function UserInfo({ user }: { user: UserInfo }) {
+  const { data, refetch } = useFragmentHandle(user, graphql(`
+    fragment UserInfo on User @refetchable @arguments(filter: { type: "String" }) {
+      friends(filter: $filter) {
+        name
+      }
+    }
+  `))
+
+  return <button onClick={() => refetch({ filter: 'aki' })}>filter</button>
+}
+```
+
+We only pass the arguments we want to change; the record's id is derived from the data on screen. See [Refetchable Fragments](~/loading-data/fragments#refetchable-fragments) for the details.
+
 **Signature**
 
 ```ts
 function useFragmentHandle(reference, document): handle
 ```
 
-Returns the same `DocumentHandle` shape as [`useQueryHandle`](~/api-reference/useQueryHandle) — `data`, `fetch`, `variables`, plus pagination methods if the fragment uses `@paginate`.
+Returns the same `DocumentHandle` shape as [`useQueryHandle`](~/api-reference/useQueryHandle) — `data`, `fetch`, `variables`, plus pagination methods if the fragment uses `@paginate`, or a `refetch` method if it uses `@refetchable`.

--- a/docs/svelte/03-loading-data/02-fragments.mdx
+++ b/docs/svelte/03-loading-data/02-fragments.mdx
@@ -188,6 +188,8 @@ query UserPage {
 
 The catch is that the fragment has to live on a type Houdini can look up on its own, which in practice means one that implements `Node` or has a [custom resolver](~/api-reference/config) configured. That's the same requirement paginated fragments carry, and for the same reason: under the hood we embed the fragment in a query keyed by the record's id and re-run that.
 
+`@refetchable` can't be combined with `@paginate` on the same fragment — a paginated fragment is already refetchable on its own, so the two together is a compile-time error.
+
 ## Fragment Masking
 
 Fragment masking keeps components properly encapsulated by ensuring they can only access the fields they explicitly declared — not fields pulled in by sibling fragments. For a deeper look at why this matters, see the [Fragment Colocation guide](https://gql-tada.0no.co/guides/fragment-colocation) from gql.tada.

--- a/docs/svelte/03-loading-data/02-fragments.mdx
+++ b/docs/svelte/03-loading-data/02-fragments.mdx
@@ -145,6 +145,49 @@ query AllUsers {
 
 A `@plural` fragment has to be spread on a list field, since that's the only place the array of references can come from. Spreading it anywhere else is a codegen error.
 
+## Refetchable Fragments
+
+Sometimes a component needs to reload its own data with different arguments without dragging the route that rendered it into the conversation. Mark the fragment with `@refetchable` and load it with `refetchableFragment` instead of `fragment`:
+
+```svelte
+<script>
+	import { refetchableFragment, graphql } from '$houdini'
+	import type { UserInfo } from '$houdini'
+
+	let { user }: { user: UserInfo } = $props()
+
+	const userInfo = $derived(refetchableFragment(user, graphql(`
+		fragment UserInfo on User @refetchable @arguments(filter: { type: "String" }) {
+			friends(filter: $filter) {
+				name
+			}
+		}
+	`)))
+</script>
+
+{#each $userInfo.data.friends as friend}
+	<div>{friend.name}</div>
+{/each}
+
+<button onclick={() => userInfo.refetch({ filter: 'aki' })}>
+	filter friends
+</button>
+```
+
+`refetchableFragment` returns a store carrying the fragment's `data` and `variables`, plus a `refetch` method. Calling `refetch` re-runs the fragment against the network with the arguments we hand it, layered over whatever it was last loaded with, so we only pass the values we actually want to change. The record's id is figured out for us from the data already on screen.
+
+The initial values come from wherever the fragment is spread, the same as any fragment that takes arguments. The parent passes them with `@with`:
+
+```graphql
+query UserPage {
+	user {
+		...UserInfo @with(filter: "aki")
+	}
+}
+```
+
+The catch is that the fragment has to live on a type Houdini can look up on its own, which in practice means one that implements `Node` or has a [custom resolver](~/api-reference/config) configured. That's the same requirement paginated fragments carry, and for the same reason: under the hood we embed the fragment in a query keyed by the record's id and re-run that.
+
 ## Fragment Masking
 
 Fragment masking keeps components properly encapsulated by ensuring they can only access the fields they explicitly declared — not fields pulled in by sibling fragments. For a deeper look at why this matters, see the [Fragment Colocation guide](https://gql-tada.0no.co/guides/fragment-colocation) from gql.tada.

--- a/e2e/_api/graphql.mjs
+++ b/e2e/_api/graphql.mjs
@@ -152,10 +152,21 @@ export const typeDefs = /* GraphQL */ `
 		Get a monkey by its id
 		"""
 		monkey(id: ID!): Monkey
+		"""
+		A non-Node entity resolved by a custom query (exercises @refetchable on a
+		type that is refetchable via a resolve config rather than Node).
+		"""
+		refetchableEntity(id: ID!): RefetchableEntity
 	}
 
 	type Subscription {
 		userUpdate(id: ID!, snapshot: String): User
+	}
+
+	"A non-Node type that is refetchable via a custom resolve query."
+	type RefetchableEntity {
+		id: ID!
+		avatarURL(size: Int): String!
 	}
 
 	type User implements Node {
@@ -519,6 +530,9 @@ export const resolvers = {
 		cities: () => {
 			return cities
 		},
+		refetchableEntity: (_, { id }) => {
+			return { id }
+		},
 		userNodesResult: async (_, args) => {
 			if (args.forceMessage) {
 				return {
@@ -607,6 +621,13 @@ export const resolvers = {
 		},
 		avatarURL: (user, { size }) => {
 			return !size ? user.avatarURL : user.avatarURL + `?size=${size}`
+		},
+	},
+
+	RefetchableEntity: {
+		avatarURL: (entity, { size }) => {
+			const base = `https://entity.test/${entity.id}.jpg`
+			return !size ? base : base + `?size=${size}`
 		},
 	},
 

--- a/e2e/_api/schema.graphql
+++ b/e2e/_api/schema.graphql
@@ -139,10 +139,17 @@ type Query {
 	Get a monkey by its id
 	"""
 	monkey(id: ID!): Monkey
+	refetchableEntity(id: ID!): RefetchableEntity
 }
 
 type Subscription {
 	userUpdate(id: ID!, snapshot: String): User
+}
+
+"A non-Node type that is refetchable via a custom resolve query."
+type RefetchableEntity {
+	id: ID!
+	avatarURL(size: Int): String!
 }
 
 type User implements Node {

--- a/e2e/kit/houdini.config.js
+++ b/e2e/kit/houdini.config.js
@@ -32,6 +32,13 @@ const config = {
 		UnionAorB: {
 			keys: [],
 		},
+		RefetchableEntity: {
+			keys: ['id'],
+			resolve: {
+				queryField: 'refetchableEntity',
+				arguments: (entity) => ({ id: entity.id }),
+			},
+		},
 	},
 
 	plugins: {

--- a/e2e/kit/src/lib/utils/routes.ts
+++ b/e2e/kit/src/lib/utils/routes.ts
@@ -74,6 +74,7 @@ export const routes = {
 	Pagination_fragment_forward_cursor_singlepage: '/pagination/fragment/forward-cursor-singlepage',
 
 	refetchable_fragment: '/refetchable-fragment',
+	refetchable_fragment_custom: '/refetchable-fragment-custom',
 
 	nested_argument_fragments: '/nested-argument-fragments',
 	nested_argument_fragments_masking: '/nested-argument-fragments-masking',

--- a/e2e/kit/src/lib/utils/routes.ts
+++ b/e2e/kit/src/lib/utils/routes.ts
@@ -73,6 +73,8 @@ export const routes = {
 	Pagination_fragment_required_arguments: '/pagination/fragment/required-arguments',
 	Pagination_fragment_forward_cursor_singlepage: '/pagination/fragment/forward-cursor-singlepage',
 
+	refetchable_fragment: '/refetchable-fragment',
+
 	nested_argument_fragments: '/nested-argument-fragments',
 	nested_argument_fragments_masking: '/nested-argument-fragments-masking',
 

--- a/e2e/kit/src/routes/refetchable-fragment-custom/+page.svelte
+++ b/e2e/kit/src/routes/refetchable-fragment-custom/+page.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+import { refetchableFragment, graphql } from '$houdini'
+import type { PageData } from './$types'
+
+export let data: PageData
+
+$: ({ RefetchableCustomQuery: queryResult } = data)
+
+// RefetchableEntity is NOT a Node — it is refetchable via the resolve config in
+// houdini.config.js (queryField: 'refetchableEntity'). This exercises the custom-resolve
+// refetch path end to end.
+$: entity = refetchableFragment(
+	$queryResult.data?.refetchableEntity ?? null,
+	graphql(`
+      fragment RefetchableEntityInfo on RefetchableEntity @refetchable @arguments(size: { type: "Int", default: 50 }) {
+        avatarURL(size: $size)
+      }
+    `)
+)
+</script>
+
+<div id="result">{$entity.data?.avatarURL}</div>
+
+<button id="refetch" on:click={() => entity.refetch({ size: 100 })}>refetch</button>
+<button id="refetch-large" on:click={() => entity.refetch({ size: 200 })}>refetch large</button>

--- a/e2e/kit/src/routes/refetchable-fragment-custom/+page.svelte
+++ b/e2e/kit/src/routes/refetchable-fragment-custom/+page.svelte
@@ -20,6 +20,8 @@ $: entity = refetchableFragment(
 </script>
 
 <div id="result">{$entity.data?.avatarURL}</div>
+<!-- variables expose only the fragment args; the synthetic id (from resolve.arguments) must not leak -->
+<div id="vars">size={$entity.variables?.size};id={($entity.variables as any)?.id ?? 'none'}</div>
 
 <button id="refetch" on:click={() => entity.refetch({ size: 100 })}>refetch</button>
 <button id="refetch-large" on:click={() => entity.refetch({ size: 200 })}>refetch large</button>

--- a/e2e/kit/src/routes/refetchable-fragment-custom/+page.ts
+++ b/e2e/kit/src/routes/refetchable-fragment-custom/+page.ts
@@ -2,9 +2,9 @@ import type { PageLoad } from './$types'
 import { graphql } from '$houdini'
 
 const store = graphql(`
-    query RefetchableFragmentQuery {
-        user(id: "1", snapshot: "refetchable-fragment") {
-            ...RefetchableUserInfo @with(size: 50, param: true)
+    query RefetchableCustomQuery {
+        refetchableEntity(id: "1") {
+            ...RefetchableEntityInfo @with(size: 50)
         }
     }
 `)
@@ -13,6 +13,6 @@ export const load: PageLoad = async (event) => {
 	await store.fetch({ event })
 
 	return {
-		RefetchableFragmentQuery: store,
+		RefetchableCustomQuery: store,
 	}
 }

--- a/e2e/kit/src/routes/refetchable-fragment-custom/spec.ts
+++ b/e2e/kit/src/routes/refetchable-fragment-custom/spec.ts
@@ -9,12 +9,17 @@ test.describe('refetchableFragment (custom resolve)', () => {
 		// the fragment loads with the default size argument
 		await expectToContain(page, '?size=50', 'div[id=result]')
 
+		// variables expose the fragment's args only — the resolve-derived id must not leak
+		await expectToContain(page, 'size=50;id=none', 'div[id=vars]')
+
 		// refetching re-runs the embedded refetchableEntity(id:) query with new arguments
 		await expect_1_gql(page, 'button[id=refetch]')
 		await expectToContain(page, '?size=100', 'div[id=result]')
+		await expectToContain(page, 'size=100;id=none', 'div[id=vars]')
 
 		// a second refetch with a different size also works
 		await expect_1_gql(page, 'button[id=refetch-large]')
 		await expectToContain(page, '?size=200', 'div[id=result]')
+		await expectToContain(page, 'size=200;id=none', 'div[id=vars]')
 	})
 })

--- a/e2e/kit/src/routes/refetchable-fragment-custom/spec.ts
+++ b/e2e/kit/src/routes/refetchable-fragment-custom/spec.ts
@@ -9,7 +9,7 @@ test.describe('refetchableFragment (custom resolve)', () => {
 		// the fragment loads with the default size argument
 		await expectToContain(page, '?size=50', 'div[id=result]')
 
-		// refetching re-runs the embedded customEntity(id:) query with new arguments
+		// refetching re-runs the embedded refetchableEntity(id:) query with new arguments
 		await expect_1_gql(page, 'button[id=refetch]')
 		await expectToContain(page, '?size=100', 'div[id=result]')
 

--- a/e2e/kit/src/routes/refetchable-fragment-custom/spec.ts
+++ b/e2e/kit/src/routes/refetchable-fragment-custom/spec.ts
@@ -1,0 +1,20 @@
+import { test } from '@playwright/test'
+import { routes } from '../../lib/utils/routes.js'
+import { expect_1_gql, expectToContain, goto } from '../../lib/utils/testsHelper.js'
+
+test.describe('refetchableFragment (custom resolve)', () => {
+	test('refetch works on a non-Node type resolved by a custom query', async ({ page }) => {
+		await goto(page, routes.refetchable_fragment_custom)
+
+		// the fragment loads with the default size argument
+		await expectToContain(page, '?size=50', 'div[id=result]')
+
+		// refetching re-runs the embedded customEntity(id:) query with new arguments
+		await expect_1_gql(page, 'button[id=refetch]')
+		await expectToContain(page, '?size=100', 'div[id=result]')
+
+		// a second refetch with a different size also works
+		await expect_1_gql(page, 'button[id=refetch-large]')
+		await expectToContain(page, '?size=200', 'div[id=result]')
+	})
+})

--- a/e2e/kit/src/routes/refetchable-fragment/+page.svelte
+++ b/e2e/kit/src/routes/refetchable-fragment/+page.svelte
@@ -9,15 +9,18 @@ $: ({ RefetchableFragmentQuery: queryResult } = data)
 $: userInfo = refetchableFragment(
 	$queryResult.data?.user ?? null,
 	graphql(`
-      fragment RefetchableUserInfo on User @refetchable @arguments(size: { type: "Int", default: 50 }) {
+      fragment RefetchableUserInfo on User @refetchable @arguments(size: { type: "Int", default: 50 }, param: { type: "Boolean", default: false }) {
         name
         avatarURL(size: $size)
+        testField(someParam: $param)
       }
     `)
 )
 </script>
 
 <div id="result">{$userInfo.data?.avatarURL}</div>
+<!-- testField reflects the `param` argument; we refetch only `size`, so this must survive -->
+<div id="merge">{$userInfo.data?.testField}</div>
 
 <button id="refetch" on:click={() => userInfo.refetch({ size: 100 })}>refetch</button>
 <button id="refetch-large" on:click={() => userInfo.refetch({ size: 200 })}>refetch large</button>

--- a/e2e/kit/src/routes/refetchable-fragment/+page.svelte
+++ b/e2e/kit/src/routes/refetchable-fragment/+page.svelte
@@ -21,6 +21,8 @@ $: userInfo = refetchableFragment(
 <div id="result">{$userInfo.data?.avatarURL}</div>
 <!-- testField reflects the `param` argument; we refetch only `size`, so this must survive -->
 <div id="merge">{$userInfo.data?.testField}</div>
+<!-- variables reflect the fragment's current args (no id key), updated after refetch -->
+<div id="vars">size={$userInfo.variables?.size};param={$userInfo.variables?.param}</div>
 
 <button id="refetch" on:click={() => userInfo.refetch({ size: 100 })}>refetch</button>
 <button id="refetch-large" on:click={() => userInfo.refetch({ size: 200 })}>refetch large</button>

--- a/e2e/kit/src/routes/refetchable-fragment/+page.svelte
+++ b/e2e/kit/src/routes/refetchable-fragment/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+import { refetchableFragment, graphql } from '$houdini'
+import type { PageData } from './$types'
+
+export let data: PageData
+
+$: ({ RefetchableFragmentQuery: queryResult } = data)
+
+$: userInfo = refetchableFragment(
+	$queryResult.data?.user ?? null,
+	graphql(`
+      fragment RefetchableUserInfo on User @refetchable @arguments(size: { type: "Int", default: 50 }) {
+        name
+        avatarURL(size: $size)
+      }
+    `)
+)
+</script>
+
+<div id="result">{$userInfo.data?.avatarURL}</div>
+
+<button id="refetch" on:click={() => userInfo.refetch({ size: 100 })}>refetch</button>
+<button id="refetch-large" on:click={() => userInfo.refetch({ size: 200 })}>refetch large</button>

--- a/e2e/kit/src/routes/refetchable-fragment/+page.ts
+++ b/e2e/kit/src/routes/refetchable-fragment/+page.ts
@@ -1,0 +1,18 @@
+import type { PageLoad } from './$types'
+import { graphql } from '$houdini'
+
+const store = graphql(`
+    query RefetchableFragmentQuery {
+        user(id: "1", snapshot: "refetchable-fragment") {
+            ...RefetchableUserInfo @with(size: 50)
+        }
+    }
+`)
+
+export const load: PageLoad = async (event) => {
+	await store.fetch({ event })
+
+	return {
+		RefetchableFragmentQuery: store,
+	}
+}

--- a/e2e/kit/src/routes/refetchable-fragment/spec.ts
+++ b/e2e/kit/src/routes/refetchable-fragment/spec.ts
@@ -1,0 +1,22 @@
+import { test } from '@playwright/test'
+import { routes } from '../../lib/utils/routes.js'
+import { expect_1_gql, expectToContain, goto } from '../../lib/utils/testsHelper.js'
+
+test.describe('refetchableFragment', () => {
+	test('refetch re-runs the fragment with new arguments', async ({ page }) => {
+		await goto(page, routes.refetchable_fragment)
+
+		// the fragment loads with the default size argument
+		await expectToContain(page, '?size=50', 'div[id=result]')
+
+		// refetching with a new size hits the network and swaps in the result
+		await expect_1_gql(page, 'button[id=refetch]')
+
+		await expectToContain(page, '?size=100', 'div[id=result]')
+
+		// refetching again with a different size works and replaces the result
+		await expect_1_gql(page, 'button[id=refetch-large]')
+
+		await expectToContain(page, '?size=200', 'div[id=result]')
+	})
+})

--- a/e2e/kit/src/routes/refetchable-fragment/spec.ts
+++ b/e2e/kit/src/routes/refetchable-fragment/spec.ts
@@ -12,6 +12,9 @@ test.describe('refetchableFragment', () => {
 		// the `param` argument (passed via @with) drives testField
 		await expectToContain(page, 'Hello world', 'div[id=merge]')
 
+		// the handle exposes the fragment's current args (no synthetic id key)
+		await expectToContain(page, 'size=50;param=true', 'div[id=vars]')
+
 		// refetching with a new size hits the network and swaps in the result
 		await expect_1_gql(page, 'button[id=refetch]')
 
@@ -20,9 +23,14 @@ test.describe('refetchableFragment', () => {
 		// refetch only changed `size`; the previously-set `param` must be preserved (merge)
 		await expectToContain(page, 'Hello world', 'div[id=merge]')
 
+		// variables update with the new size while the merged `param` persists
+		await expectToContain(page, 'size=100;param=true', 'div[id=vars]')
+
 		// refetching again with a different size works and replaces the result
 		await expect_1_gql(page, 'button[id=refetch-large]')
 
 		await expectToContain(page, '?size=200', 'div[id=result]')
+
+		await expectToContain(page, 'size=200;param=true', 'div[id=vars]')
 	})
 })

--- a/e2e/kit/src/routes/refetchable-fragment/spec.ts
+++ b/e2e/kit/src/routes/refetchable-fragment/spec.ts
@@ -9,10 +9,16 @@ test.describe('refetchableFragment', () => {
 		// the fragment loads with the default size argument
 		await expectToContain(page, '?size=50', 'div[id=result]')
 
+		// the `param` argument (passed via @with) drives testField
+		await expectToContain(page, 'Hello world', 'div[id=merge]')
+
 		// refetching with a new size hits the network and swaps in the result
 		await expect_1_gql(page, 'button[id=refetch]')
 
 		await expectToContain(page, '?size=100', 'div[id=result]')
+
+		// refetch only changed `size`; the previously-set `param` must be preserved (merge)
+		await expectToContain(page, 'Hello world', 'div[id=merge]')
 
 		// refetching again with a different size works and replaces the result
 		await expect_1_gql(page, 'button[id=refetch-large]')

--- a/e2e/react/houdini.config.ts
+++ b/e2e/react/houdini.config.ts
@@ -27,6 +27,13 @@ const config: ConfigFile = {
 		Sponsor: {
 			keys: ['name'],
 		},
+		RefetchableEntity: {
+			keys: ['id'],
+			resolve: {
+				queryField: 'refetchableEntity',
+				arguments: (entity) => ({ id: entity.id }),
+			},
+		},
 	},
 
 	plugins: {

--- a/e2e/react/src/api/+schema.js
+++ b/e2e/react/src/api/+schema.js
@@ -144,10 +144,21 @@ export const typeDefs = /* GraphQL */ `
 		Get a monkey by its id
 		"""
 		monkey(id: ID!): Monkey
+		"""
+		A non-Node entity resolved by a custom query (exercises @refetchable on a
+		type that is refetchable via a resolve config rather than Node).
+		"""
+		refetchableEntity(id: ID!): RefetchableEntity
 	}
 
 	type Subscription {
 		userUpdate(id: ID!, snapshot: String): User
+	}
+
+	"A non-Node type that is refetchable via a custom resolve query."
+	type RefetchableEntity {
+		id: ID!
+		avatarURL(size: Int): String!
 	}
 
 	type User implements Node {

--- a/e2e/react/src/routes/refetchable-fragment-custom/+page.gql
+++ b/e2e/react/src/routes/refetchable-fragment-custom/+page.gql
@@ -1,0 +1,5 @@
+query RefetchableCustomQuery {
+	refetchableEntity(id: "1") {
+		...RefetchableEntityInfo @with(size: 50)
+	}
+}

--- a/e2e/react/src/routes/refetchable-fragment-custom/+page.tsx
+++ b/e2e/react/src/routes/refetchable-fragment-custom/+page.tsx
@@ -1,0 +1,28 @@
+import { graphql, useFragmentHandle } from '$houdini'
+import type { PageProps } from './$types'
+
+// RefetchableEntity is NOT a Node — it is refetchable via the resolve config in
+// houdini.config.ts (queryField: 'refetchableEntity'). This exercises the custom-resolve
+// refetch path end to end.
+const fragment = graphql(`
+	fragment RefetchableEntityInfo on RefetchableEntity @refetchable @arguments(size: { type: "Int", default: 50 }) {
+		avatarURL(size: $size)
+	}
+`)
+
+export default function ({ RefetchableCustomQuery }: PageProps) {
+	const handle = useFragmentHandle(RefetchableCustomQuery.refetchableEntity, fragment)
+
+	return (
+		<>
+			<div id="result">{handle.data?.avatarURL}</div>
+
+			<button id="refetch" onClick={() => handle.refetch({ size: 100 })}>
+				refetch
+			</button>
+			<button id="refetch-large" onClick={() => handle.refetch({ size: 200 })}>
+				refetch large
+			</button>
+		</>
+	)
+}

--- a/e2e/react/src/routes/refetchable-fragment-custom/+page.tsx
+++ b/e2e/react/src/routes/refetchable-fragment-custom/+page.tsx
@@ -16,6 +16,10 @@ export default function ({ RefetchableCustomQuery }: PageProps) {
 	return (
 		<>
 			<div id="result">{handle.data?.avatarURL}</div>
+			{/* variables expose only the fragment args; the synthetic id (from resolve.arguments) must not leak */}
+			<div id="vars">
+				size={handle.variables?.size};id={(handle.variables as any)?.id ?? 'none'}
+			</div>
 
 			<button id="refetch" onClick={() => handle.refetch({ size: 100 })}>
 				refetch

--- a/e2e/react/src/routes/refetchable-fragment-custom/test.ts
+++ b/e2e/react/src/routes/refetchable-fragment-custom/test.ts
@@ -9,12 +9,17 @@ test.describe('refetchable fragment (custom resolve)', () => {
 		// the fragment loads with the default size argument
 		await expectToContain(page, '?size=50', 'div[id=result]')
 
+		// variables expose the fragment's args only — the resolve-derived id must not leak
+		await expectToContain(page, 'size=50;id=none', 'div[id=vars]')
+
 		// refetching re-runs the embedded refetchableEntity(id:) query with new arguments
 		await expect_1_gql(page, 'button[id=refetch]')
 		await expectToContain(page, '?size=100', 'div[id=result]')
+		await expectToContain(page, 'size=100;id=none', 'div[id=vars]')
 
 		// a second refetch with a different size also works
 		await expect_1_gql(page, 'button[id=refetch-large]')
 		await expectToContain(page, '?size=200', 'div[id=result]')
+		await expectToContain(page, 'size=200;id=none', 'div[id=vars]')
 	})
 })

--- a/e2e/react/src/routes/refetchable-fragment-custom/test.ts
+++ b/e2e/react/src/routes/refetchable-fragment-custom/test.ts
@@ -1,0 +1,20 @@
+import { test } from '@playwright/test'
+import { routes } from '~/utils/routes.js'
+import { expect_1_gql, expectToContain, goto } from '~/utils/testsHelper.js'
+
+test.describe('refetchable fragment (custom resolve)', () => {
+	test('refetch works on a non-Node type resolved by a custom query', async ({ page }) => {
+		await goto(page, routes.refetchable_fragment_custom)
+
+		// the fragment loads with the default size argument
+		await expectToContain(page, '?size=50', 'div[id=result]')
+
+		// refetching re-runs the embedded refetchableEntity(id:) query with new arguments
+		await expect_1_gql(page, 'button[id=refetch]')
+		await expectToContain(page, '?size=100', 'div[id=result]')
+
+		// a second refetch with a different size also works
+		await expect_1_gql(page, 'button[id=refetch-large]')
+		await expectToContain(page, '?size=200', 'div[id=result]')
+	})
+})

--- a/e2e/react/src/routes/refetchable-fragment/+page.gql
+++ b/e2e/react/src/routes/refetchable-fragment/+page.gql
@@ -1,5 +1,5 @@
 query RefetchableFragmentQuery {
 	user(id: "1", snapshot: "refetchable-fragment-react") {
-		...RefetchableUserInfo @with(size: 50)
+		...RefetchableUserInfo @with(size: 50, param: true)
 	}
 }

--- a/e2e/react/src/routes/refetchable-fragment/+page.gql
+++ b/e2e/react/src/routes/refetchable-fragment/+page.gql
@@ -1,0 +1,5 @@
+query RefetchableFragmentQuery {
+	user(id: "1", snapshot: "refetchable-fragment-react") {
+		...RefetchableUserInfo @with(size: 50)
+	}
+}

--- a/e2e/react/src/routes/refetchable-fragment/+page.tsx
+++ b/e2e/react/src/routes/refetchable-fragment/+page.tsx
@@ -17,6 +17,10 @@ export default function ({ RefetchableFragmentQuery }: PageProps) {
 			<div id="result">{handle.data?.avatarURL}</div>
 			{/* testField reflects the `param` argument; we refetch only `size`, so this must survive */}
 			<div id="merge">{handle.data?.testField}</div>
+			{/* variables reflect the fragment's current args (no id key), updated after refetch */}
+			<div id="vars">
+				size={handle.variables?.size};param={String(handle.variables?.param)}
+			</div>
 
 			<button id="refetch" onClick={() => handle.refetch({ size: 100 })}>
 				refetch

--- a/e2e/react/src/routes/refetchable-fragment/+page.tsx
+++ b/e2e/react/src/routes/refetchable-fragment/+page.tsx
@@ -2,9 +2,10 @@ import { graphql, useFragmentHandle } from '$houdini'
 import type { PageProps } from './$types'
 
 const fragment = graphql(`
-	fragment RefetchableUserInfo on User @refetchable @arguments(size: { type: "Int", default: 50 }) {
+	fragment RefetchableUserInfo on User @refetchable @arguments(size: { type: "Int", default: 50 }, param: { type: "Boolean", default: false }) {
 		name
 		avatarURL(size: $size)
+		testField(someParam: $param)
 	}
 `)
 
@@ -14,6 +15,8 @@ export default function ({ RefetchableFragmentQuery }: PageProps) {
 	return (
 		<>
 			<div id="result">{handle.data?.avatarURL}</div>
+			{/* testField reflects the `param` argument; we refetch only `size`, so this must survive */}
+			<div id="merge">{handle.data?.testField}</div>
 
 			<button id="refetch" onClick={() => handle.refetch({ size: 100 })}>
 				refetch

--- a/e2e/react/src/routes/refetchable-fragment/+page.tsx
+++ b/e2e/react/src/routes/refetchable-fragment/+page.tsx
@@ -1,0 +1,26 @@
+import { graphql, useFragmentHandle } from '$houdini'
+import type { PageProps } from './$types'
+
+const fragment = graphql(`
+	fragment RefetchableUserInfo on User @refetchable @arguments(size: { type: "Int", default: 50 }) {
+		name
+		avatarURL(size: $size)
+	}
+`)
+
+export default function ({ RefetchableFragmentQuery }: PageProps) {
+	const handle = useFragmentHandle(RefetchableFragmentQuery.user, fragment)
+
+	return (
+		<>
+			<div id="result">{handle.data?.avatarURL}</div>
+
+			<button id="refetch" onClick={() => handle.refetch({ size: 100 })}>
+				refetch
+			</button>
+			<button id="refetch-large" onClick={() => handle.refetch({ size: 200 })}>
+				refetch large
+			</button>
+		</>
+	)
+}

--- a/e2e/react/src/routes/refetchable-fragment/test.ts
+++ b/e2e/react/src/routes/refetchable-fragment/test.ts
@@ -1,0 +1,22 @@
+import { test } from '@playwright/test'
+import { routes } from '~/utils/routes.js'
+import { expect_1_gql, expectToContain, goto } from '~/utils/testsHelper.js'
+
+test.describe('refetchable fragment', () => {
+	test('refetch re-runs the fragment with new arguments', async ({ page }) => {
+		await goto(page, routes.refetchable_fragment)
+
+		// the fragment loads with the default size argument
+		await expectToContain(page, '?size=50', 'div[id=result]')
+
+		// refetching with a new size hits the network and swaps in the result
+		await expect_1_gql(page, 'button[id=refetch]')
+
+		await expectToContain(page, '?size=100', 'div[id=result]')
+
+		// refetching again with a different size works and replaces the result
+		await expect_1_gql(page, 'button[id=refetch-large]')
+
+		await expectToContain(page, '?size=200', 'div[id=result]')
+	})
+})

--- a/e2e/react/src/routes/refetchable-fragment/test.ts
+++ b/e2e/react/src/routes/refetchable-fragment/test.ts
@@ -9,10 +9,16 @@ test.describe('refetchable fragment', () => {
 		// the fragment loads with the default size argument
 		await expectToContain(page, '?size=50', 'div[id=result]')
 
+		// the `param` argument (passed via @with) drives testField
+		await expectToContain(page, 'Hello world', 'div[id=merge]')
+
 		// refetching with a new size hits the network and swaps in the result
 		await expect_1_gql(page, 'button[id=refetch]')
 
 		await expectToContain(page, '?size=100', 'div[id=result]')
+
+		// refetch only changed `size`; the previously-set `param` must be preserved (merge)
+		await expectToContain(page, 'Hello world', 'div[id=merge]')
 
 		// refetching again with a different size works and replaces the result
 		await expect_1_gql(page, 'button[id=refetch-large]')

--- a/e2e/react/src/routes/refetchable-fragment/test.ts
+++ b/e2e/react/src/routes/refetchable-fragment/test.ts
@@ -12,6 +12,9 @@ test.describe('refetchable fragment', () => {
 		// the `param` argument (passed via @with) drives testField
 		await expectToContain(page, 'Hello world', 'div[id=merge]')
 
+		// the handle exposes the fragment's current args (no synthetic id key)
+		await expectToContain(page, 'size=50;param=true', 'div[id=vars]')
+
 		// refetching with a new size hits the network and swaps in the result
 		await expect_1_gql(page, 'button[id=refetch]')
 
@@ -20,9 +23,14 @@ test.describe('refetchable fragment', () => {
 		// refetch only changed `size`; the previously-set `param` must be preserved (merge)
 		await expectToContain(page, 'Hello world', 'div[id=merge]')
 
+		// variables update with the new size while the merged `param` persists
+		await expectToContain(page, 'size=100;param=true', 'div[id=vars]')
+
 		// refetching again with a different size works and replaces the result
 		await expect_1_gql(page, 'button[id=refetch-large]')
 
 		await expectToContain(page, '?size=200', 'div[id=result]')
+
+		await expectToContain(page, 'size=200;param=true', 'div[id=vars]')
 	})
 })

--- a/e2e/react/src/utils/routes.ts
+++ b/e2e/react/src/utils/routes.ts
@@ -24,6 +24,7 @@ export const routes = {
 	pagination_fragment_cursor_backwards_singlepage: '/pagination/fragment/connection-backwards-singlepage',
 	pagination_query_offset_variable: '/pagination/query/offset-variable/2',
 	refetchable_fragment: '/refetchable-fragment',
+	refetchable_fragment_custom: '/refetchable-fragment-custom',
 	optimistic_keys: '/optimistic-keys',
 	node_plugin: '/node-plugin',
 	list_id: '/list-id',

--- a/e2e/react/src/utils/routes.ts
+++ b/e2e/react/src/utils/routes.ts
@@ -23,6 +23,7 @@ export const routes = {
 	pagination_fragment_cursor_forwards_singlepage: '/pagination/fragment/connection-forwards-singlepage',
 	pagination_fragment_cursor_backwards_singlepage: '/pagination/fragment/connection-backwards-singlepage',
 	pagination_query_offset_variable: '/pagination/query/offset-variable/2',
+	refetchable_fragment: '/refetchable-fragment',
 	optimistic_keys: '/optimistic-keys',
 	node_plugin: '/node-plugin',
 	list_id: '/list-id',

--- a/packages/houdini-core/plugin/afterValidate.go
+++ b/packages/houdini-core/plugin/afterValidate.go
@@ -24,6 +24,12 @@ func (p *HoudiniCore) AfterValidate(ctx context.Context) error {
 		return err
 	}
 
+	// and the embedded queries for @refetchable fragments
+	err = lists.PrepareRefetchableDocuments(ctx, p.DB)
+	if err != nil {
+		return err
+	}
+
 	// finally, add the necessary fields to ALL documents (including newly created ones)
 	err = documents.AddDocumentFields(ctx, p.DB)
 	if err != nil {

--- a/packages/houdini-core/plugin/documents/artifacts/selection_refetchable_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_refetchable_test.go
@@ -1,0 +1,181 @@
+package artifacts_test
+
+import (
+	"testing"
+
+	"code.houdinigraphql.com/packages/houdini-core/config"
+	"code.houdinigraphql.com/packages/houdini-core/plugin"
+	"code.houdinigraphql.com/plugins/tests"
+)
+
+func TestRefetchableArtifacts(t *testing.T) {
+	tests.RunTable(t, tests.Table[config.PluginConfig, *plugin.HoudiniCore]{
+		Schema: `
+      type Query {
+        node(id: ID!): Node
+        user: User
+      }
+
+      type User implements Node {
+        id: ID!
+        firstName: String!
+      }
+
+      interface Node {
+        id: ID!
+      }
+    `,
+		PerformTest: performArtifactTest,
+		Tests: []tests.Test[config.PluginConfig]{
+			{
+				Name: "refetchable fragment generates a query artifact with a non-paginated refetch block",
+				Input: []string{
+					`
+            fragment UserInfo on User @refetchable {
+              firstName
+            }
+          `,
+				},
+				Pass: true,
+				Extra: map[string]any{
+					"UserInfo_Pagination_Query": `const artifact = {
+    "name": "UserInfo_Pagination_Query",
+    "kind": "HoudiniQuery",
+    "hash": "9575bb0b6d1a226a4c7489a1a0dc27ed4320abd5be65fc6ae56c02d86b46d185",
+
+    "refetch": {
+        "path": [],
+        "method": "offset",
+        "pageSize": 0,
+        "embedded": false,
+        "targetType": "Node",
+        "paginated": false,
+        "direction": "forward",
+        "mode": "Infinite"
+    },
+
+    "raw": ` + "`" + `fragment UserInfo on User {
+    firstName
+    __typename
+    id
+}
+
+query UserInfo_Pagination_Query($id: ID!) {
+    node(id: $id) {
+        ...UserInfo
+        __typename
+        id
+    }
+}
+` + "`" + `,
+
+    "rootType": "Query",
+    "stripVariables": [] as Array<string>,
+
+    "selection": {
+        "fields": {
+            "node": {
+                "type": "Node",
+                "keyRaw": "node(id: $id)",
+                "nullable": true,
+
+                "selection": {
+                    "fields": {
+                        "__typename": {
+                            "type": "String",
+                            "keyRaw": "__typename",
+                        },
+
+                        "id": {
+                            "type": "ID",
+                            "keyRaw": "id",
+                        },
+                    },
+                    "abstractFields": {
+                        "fields": {
+                            "User": {
+                                "__typename": {
+                                    "type": "String",
+                                    "keyRaw": "__typename",
+                                },
+                                "firstName": {
+                                    "type": "String",
+                                    "keyRaw": "firstName",
+                                    "visible": true,
+                                },
+                                "id": {
+                                    "type": "ID",
+                                    "keyRaw": "id",
+                                },
+                            },
+                        },
+
+                        "typeMap": {},
+                    },
+
+                    "fragments": {
+                        "UserInfo": {
+                            "arguments": {}
+                        },
+                    },
+                },
+
+                "abstract": true,
+                "visible": true,
+            },
+        },
+    },
+
+    "pluginData": {},
+
+    "input": {
+        "fields": {
+            "id": "ID",
+        },
+
+        "types": {},
+
+        "defaults": {},
+
+        "runtimeScalars": {},
+    },
+
+    "policy": "CacheOrNetwork",
+    "partial": false
+} as const
+
+export default artifact
+
+export type UserInfo_Pagination_Query = {
+	readonly "input": UserInfo_Pagination_Query$input;
+	readonly "result": UserInfo_Pagination_Query$result | undefined;
+};
+
+export type UserInfo_Pagination_Query$result = {
+	readonly node: {
+		readonly " $fragments": {
+			UserInfo: {};
+		};
+	} | null;
+};
+
+export type UserInfo_Pagination_Query$input = {
+	id: string;
+};
+
+export type UserInfo_Pagination_Query$unmasked = {
+	readonly node: {} & (({
+		readonly firstName: string;
+		readonly id: string;
+		readonly __typename: "User";
+	})) | null;
+};
+
+export type UserInfo_Pagination_Query$artifact = typeof artifact
+
+"HoudiniHash=9575bb0b6d1a226a4c7489a1a0dc27ed4320abd5be65fc6ae56c02d86b46d185"`,
+				},
+			},
+		},
+	})
+}

--- a/packages/houdini-core/plugin/documents/artifacts/selection_refetchable_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_refetchable_test.go
@@ -38,10 +38,10 @@ func TestRefetchableArtifacts(t *testing.T) {
 				},
 				Pass: true,
 				Extra: map[string]any{
-					"UserInfo_Pagination_Query": `const artifact = {
-    "name": "UserInfo_Pagination_Query",
+					"UserInfo_Refetch_Query": `const artifact = {
+    "name": "UserInfo_Refetch_Query",
     "kind": "HoudiniQuery",
-    "hash": "9575bb0b6d1a226a4c7489a1a0dc27ed4320abd5be65fc6ae56c02d86b46d185",
+    "hash": "835ab9f8d3c95cebdcee39010d1e0256ed73c05c84b03f9422b22da5806943a7",
 
     "refetch": {
         "path": [],
@@ -60,7 +60,7 @@ func TestRefetchableArtifacts(t *testing.T) {
     id
 }
 
-query UserInfo_Pagination_Query($id: ID!) {
+query UserInfo_Refetch_Query($id: ID!) {
     node(id: $id) {
         ...UserInfo
         __typename
@@ -146,12 +146,12 @@ query UserInfo_Pagination_Query($id: ID!) {
 
 export default artifact
 
-export type UserInfo_Pagination_Query = {
-	readonly "input": UserInfo_Pagination_Query$input;
-	readonly "result": UserInfo_Pagination_Query$result | undefined;
+export type UserInfo_Refetch_Query = {
+	readonly "input": UserInfo_Refetch_Query$input;
+	readonly "result": UserInfo_Refetch_Query$result | undefined;
 };
 
-export type UserInfo_Pagination_Query$result = {
+export type UserInfo_Refetch_Query$result = {
 	readonly node: {
 		readonly " $fragments": {
 			UserInfo: {};
@@ -159,11 +159,11 @@ export type UserInfo_Pagination_Query$result = {
 	} | null;
 };
 
-export type UserInfo_Pagination_Query$input = {
+export type UserInfo_Refetch_Query$input = {
 	id: string;
 };
 
-export type UserInfo_Pagination_Query$unmasked = {
+export type UserInfo_Refetch_Query$unmasked = {
 	readonly node: {} & (({
 		readonly firstName: string;
 		readonly id: string;
@@ -171,9 +171,9 @@ export type UserInfo_Pagination_Query$unmasked = {
 	})) | null;
 };
 
-export type UserInfo_Pagination_Query$artifact = typeof artifact
+export type UserInfo_Refetch_Query$artifact = typeof artifact
 
-"HoudiniHash=9575bb0b6d1a226a4c7489a1a0dc27ed4320abd5be65fc6ae56c02d86b46d185"`,
+"HoudiniHash=835ab9f8d3c95cebdcee39010d1e0256ed73c05c84b03f9422b22da5806943a7"`,
 				},
 			},
 		},

--- a/packages/houdini-core/plugin/documents/collected/collect.go
+++ b/packages/houdini-core/plugin/documents/collected/collect.go
@@ -230,6 +230,7 @@ func collectDoc(
 				statements.Search,
 				statements.DocumentVariables,
 				statements.DocumentDirectives,
+				statements.RefetchMeta,
 				statements.PossibleTypes,
 				statements.InputTypes,
 			} {
@@ -788,6 +789,44 @@ func collectDoc(
 				return
 			}
 
+			// attach refetch metadata for list-less refetchable documents. this drives the
+			// artifact "refetch" block the same way a discovered_lists row does for lists,
+			// but without pretending the document contains a list.
+			err = db.StepStatement(ctx, statements.RefetchMeta, func() {
+				documentName := statements.RefetchMeta.GetText("document_name")
+				doc, ok := documents[documentName]
+				if !ok {
+					return
+				}
+
+				mode := statements.RefetchMeta.GetText("mode")
+				if mode == "" {
+					mode = "Infinite"
+				}
+				method := statements.RefetchMeta.GetText("method")
+				if method == "" {
+					method = "offset"
+				}
+
+				doc.Refetch = &DocumentRefetch{
+					Path:       []string{},
+					Method:     method,
+					PageSize:   int(statements.RefetchMeta.GetInt64("page_size")),
+					Mode:       mode,
+					TargetType: statements.RefetchMeta.GetText("target_type"),
+					Embedded:   statements.RefetchMeta.GetBool("embedded"),
+					Paginated:  false,
+					Direction:  "forward",
+				}
+			})
+			if err != nil {
+				errs.Append(plugins.WrapError(err))
+				return
+			}
+			if errs.Len() > 0 {
+				return
+			}
+
 			// if we've gotten this far then we have recreated the full selection apart from
 			// the nested argument structure
 			valueIDs := []int64{}
@@ -909,6 +948,7 @@ type CollectStatements struct {
 	Search             plugins.Stmt
 	DocumentVariables  plugins.Stmt
 	DocumentDirectives plugins.Stmt
+	RefetchMeta        plugins.Stmt
 	PossibleTypes      plugins.Stmt
 	InputTypes         plugins.Stmt
 }
@@ -1203,6 +1243,25 @@ func prepareCollectStatements(conn plugins.Conn, count int) (*CollectStatements,
 		return nil, err
 	}
 
+	// refetch_meta carries the artifact "refetch" block for list-less refetchable
+	// documents (e.g. @refetchable fragments' generated queries). it's the analog of
+	// the discovered_lists row that drives the refetch block for paginated lists.
+	refetchMeta, err := conn.Prepare(fmt.Sprintf(`
+    SELECT
+      d.name AS document_name,
+      refetch_meta.target_type,
+      refetch_meta.method,
+      refetch_meta.mode,
+      refetch_meta.page_size,
+      refetch_meta.embedded
+    FROM refetch_meta
+      JOIN documents d ON d.id = refetch_meta.document
+    WHERE d.id in %s
+  `, whereIn))
+	if err != nil {
+		return nil, err
+	}
+
 	// we need a query that looks up every abstract type that's used in
 	// the set of documents. Split into UNION branches (no OR in JOIN) so
 	// SQLite can use indexes on each branch independently.
@@ -1345,6 +1404,7 @@ func prepareCollectStatements(conn plugins.Conn, count int) (*CollectStatements,
 		Search:             search,
 		DocumentVariables:  documentVariables,
 		DocumentDirectives: documentDirectives,
+		RefetchMeta:        refetchMeta,
 		PossibleTypes:      possibleTypes,
 		InputTypes:         inputTypes,
 	}, nil
@@ -1355,6 +1415,7 @@ func (s *CollectStatements) Finalize() {
 	s.Search.Finalize()
 	s.DocumentVariables.Finalize()
 	s.DocumentDirectives.Finalize()
+	s.RefetchMeta.Finalize()
 	s.PossibleTypes.Finalize()
 	s.InputTypes.Finalize()
 }

--- a/packages/houdini-core/plugin/lists/paginationDocuments.go
+++ b/packages/houdini-core/plugin/lists/paginationDocuments.go
@@ -5,9 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	
-	
-
 	"code.houdinigraphql.com/packages/houdini-core/config"
 	"code.houdinigraphql.com/plugins"
 	"code.houdinigraphql.com/plugins/graphql"
@@ -207,8 +204,14 @@ func PreparePaginationDocuments(
 		return commit(plugins.WrapError(err))
 	}
 	defer insertFragment.Finalize()
+	// resolve-key variables are inserted before the fragment's own @arguments. if a fragment
+	// @argument shares a name with a key (e.g. a custom-resolve type keyed by a field the
+	// fragment also takes as an argument), reuse the existing non-null key declaration instead
+	// of inserting a duplicate, which would violate UNIQUE(document, name). references resolve
+	// by name, so the @with argument still points at the same variable.
 	insertDocumentVariable, err := conn.Prepare(`
 		INSERT INTO document_variables (document, "name", type, type_modifiers, default_value, row, column) VALUES ($document, $name, $type, $type_modifiers, $default_value, 0, 0)
+		ON CONFLICT (document, "name") DO NOTHING
 	`)
 	if err != nil {
 		return commit(plugins.WrapError(err))

--- a/packages/houdini-core/plugin/lists/paginationDocuments_test.go
+++ b/packages/houdini-core/plugin/lists/paginationDocuments_test.go
@@ -27,7 +27,7 @@ func TestPaginationDocumentGeneration(t *testing.T) {
 
 			type Legend {
 				title: String!
-				believers(limit: Int, offset: Int): [User!]!
+				believers(title: String, limit: Int, offset: Int): [User!]!
 			}
 
 			type User implements Node {
@@ -617,6 +617,69 @@ func TestPaginationDocumentGeneration(t *testing.T) {
 				},
 			},
 			{
+				Name: "fragment @argument reuses the resolve key variable when names collide",
+				Pass: true,
+				Input: []string{
+					`
+fragment BelieverPages on Legend @arguments(title: { type: "String" }) {
+believers(title: $title, limit: 10) @paginate {
+firstName
+}
+}
+`,
+				},
+				ProjectConfig: func(config *plugins.ProjectConfig) {
+					config.TypeConfig["Legend"] = plugins.TypeConfig{
+						Keys:         []string{"title"},
+						ResolveQuery: "legend",
+					}
+				},
+				// the resolve key `title` and the fragment @argument `title` collapse to a single
+				// non-null variable on the pagination query; @with still references it by name.
+				Expected: []tests.ExpectedDocument{
+					tests.ExpectedDoc(`
+fragment BelieverPages_paginated_3ovGOt on Legend {
+title
+__typename
+believers(title: $title, limit: $limit, offset: $offset) @paginate {
+firstName
+__typename
+id
+}
+}
+`).WithVariables(
+						tests.ExpectedOperationVariable{
+							Name: "title",
+							Type: "String",
+						},
+						tests.ExpectedOperationVariable{
+							Name: "limit",
+							Type: "Int",
+							DefaultValue: &tests.ExpectedArgumentValue{
+								Kind: "Int",
+								Raw:  "10",
+							},
+						},
+						tests.ExpectedOperationVariable{
+							Name: "offset",
+							Type: "Int",
+						},
+					),
+					tests.ExpectedDoc(
+						fmt.Sprintf(`
+query %s($limit: Int = 10, $offset: Int, $title: String!) @dedupe(match: Variables) {
+legend(title: $title) {
+...BelieverPages_paginated_3ovGOt @mask_disable @with(limit: $limit, offset: $offset, title: $title)
+__typename
+title
+}
+}
+`,
+							graphql.FragmentPaginationQueryName("BelieverPages"),
+						)),
+				},
+			},
+			{
 				Name: "fragment suppress dedupe",
 				Pass: true,
 				Input: []string{
@@ -889,7 +952,7 @@ func TestPaginationDocumentGeneration_multipleInvocations(t *testing.T) {
 
 			type Legend {
 				title: String!
-				believers(limit: Int, offset: Int): [User!]!
+				believers(title: String, limit: Int, offset: Int): [User!]!
 			}
 
 			type User implements Node {

--- a/packages/houdini-core/plugin/lists/refetchableDocuments.go
+++ b/packages/houdini-core/plugin/lists/refetchableDocuments.go
@@ -150,8 +150,14 @@ func PrepareRefetchableDocuments(
 		return commit(plugins.WrapError(err))
 	}
 	defer insertArgumentValue.Finalize()
+	// the lookup key variables are inserted first (non-null, e.g. $id: ID!). if a fragment
+	// @argument happens to share a name with a key, reuse the existing declaration instead of
+	// inserting a duplicate (which would violate UNIQUE(document, name)). the key's non-null
+	// type is what the resolve field requires, so letting it win is correct; the @with
+	// reference resolves to it by name either way.
 	insertDocumentVariable, err := conn.Prepare(`
 		INSERT INTO document_variables (document, "name", type, type_modifiers, default_value, row, column) VALUES ($document, $name, $type, $type_modifiers, $default_value, 0, 0)
+		ON CONFLICT (document, "name") DO NOTHING
 	`)
 	if err != nil {
 		return commit(plugins.WrapError(err))

--- a/packages/houdini-core/plugin/lists/refetchableDocuments.go
+++ b/packages/houdini-core/plugin/lists/refetchableDocuments.go
@@ -32,11 +32,11 @@ type refetchableArg struct {
 }
 
 // PrepareRefetchableDocuments looks for every fragment tagged with @refetchable and
-// generates an embedded query (named like the pagination query) that re-fetches the
+// generates an embedded query (named <Fragment>_Refetch_Query) that re-fetches the
 // fragment by id. This is the same wrapper @paginate generates for paginated
 // fragments — node(id:) { ...Fragment @with(...) } — but without any list/pagination
-// semantics. The generated query gets a discovered_lists row (with no list name and
-// no paginate marker) so the artifact picks up a "refetch" block with paginated: false.
+// semantics. The generated query gets a refetch_meta row so the artifact picks up a
+// "refetch" block with paginated: false.
 func PrepareRefetchableDocuments(
 	ctx context.Context,
 	db plugins.DatabasePool[config.PluginConfig],
@@ -84,7 +84,7 @@ func PrepareRefetchableDocuments(
 			LEFT JOIN type_fields tf
 				ON tf.parent = documents.type_condition
 				AND tf.name = je.value
-			LEFT JOIN documents existing_operations ON existing_operations.name = documents.name || $pagination_suffix
+			LEFT JOIN documents existing_operations ON existing_operations.name = documents.name || $refetch_suffix
 		WHERE (raw_documents.current_task = $task_id OR $task_id IS NULL)
 			AND documents.kind = 'fragment'
 			AND existing_operations.id IS NULL
@@ -97,7 +97,7 @@ func PrepareRefetchableDocuments(
 	defer query.Finalize()
 	err = db.BindStatement(query, map[string]any{
 		"refetchable_directive": graphql.RefetchableDirective,
-		"pagination_suffix":     graphql.PaginationQuerySuffix,
+		"refetch_suffix":        graphql.RefetchQuerySuffix,
 	})
 	if err != nil {
 		return commit(plugins.WrapError(err))
@@ -290,7 +290,7 @@ func generateRefetchableQuery(
 ) error {
 	// create the query that embeds the fragment
 	err := db.ExecStatement(stmts.insertDocument, map[string]any{
-		"name":         graphql.FragmentPaginationQueryName(frag.Name),
+		"name":         graphql.FragmentRefetchQueryName(frag.Name),
 		"raw_document": frag.RawDocument,
 	})
 	if err != nil {

--- a/packages/houdini-core/plugin/lists/refetchableDocuments.go
+++ b/packages/houdini-core/plugin/lists/refetchableDocuments.go
@@ -180,16 +180,16 @@ func PrepareRefetchableDocuments(
 		return commit(plugins.WrapError(err))
 	}
 	defer copyArgumentValue.Finalize()
-	insertDiscoveredLists, err := conn.Prepare(`
-		INSERT INTO discovered_lists
-			(name, node_type, connection_type, document, connection, list_field, paginate, node, page_size, mode, embedded, target_type, supports_forward, supports_backward)
+	insertRefetchMeta, err := conn.Prepare(`
+		INSERT INTO refetch_meta
+			(document, selection, target_type)
 		VALUES
-			($name, $node_type, $connection_type, $document, false, $list_field, NULL, $node, 0, 'Infinite', false, $target_type, false, false)
+			($document, $selection, $target_type)
 	`)
 	if err != nil {
 		return commit(plugins.WrapError(err))
 	}
-	defer insertDiscoveredLists.Finalize()
+	defer insertRefetchMeta.Finalize()
 
 	// collect the matching fragments first so we don't generate while iterating.
 	fragments := []refetchableFragment{}
@@ -251,7 +251,7 @@ func PrepareRefetchableDocuments(
 			insertSelectionDirective:         insertSelectionDirective,
 			insertSelectionDirectiveArgument: insertSelectionDirectiveArgument,
 			copyArgumentValue:                copyArgumentValue,
-			insertDiscoveredLists:            insertDiscoveredLists,
+			insertRefetchMeta:                insertRefetchMeta,
 		}, frag, args)
 		if err != nil {
 			errs.Append(plugins.WrapError(err))
@@ -276,7 +276,7 @@ type statementsForRefetch struct {
 	insertSelectionDirective         plugins.Stmt
 	insertSelectionDirectiveArgument plugins.Stmt
 	copyArgumentValue                plugins.Stmt
-	insertDiscoveredLists            plugins.Stmt
+	insertRefetchMeta                plugins.Stmt
 }
 
 func generateRefetchableQuery(
@@ -450,17 +450,14 @@ func generateRefetchableQuery(
 		targetType = frag.TypeCondition
 	}
 
-	// record a discovered_lists row for the generated query so the artifact emits a
-	// "refetch" block (paginated: false). an empty name keeps it out of the list
-	// machinery — it carries refetch metadata only.
-	err = db.ExecStatement(stmts.insertDiscoveredLists, map[string]any{
-		"name":            "",
-		"node_type":       frag.TypeCondition,
-		"connection_type": frag.TypeCondition,
-		"document":        queryDocumentID,
-		"list_field":      resolveSelectionID,
-		"node":            resolveSelectionID,
-		"target_type":     targetType,
+	// record a refetch_meta row for the generated query so the artifact emits a
+	// "refetch" block (paginated: false). this is the list-less analog of a
+	// discovered_lists row — it carries refetch metadata only, keyed by the
+	// node(id:)/resolve selection the block attaches to.
+	err = db.ExecStatement(stmts.insertRefetchMeta, map[string]any{
+		"document":    queryDocumentID,
+		"selection":   resolveSelectionID,
+		"target_type": targetType,
 	})
 	if err != nil {
 		return err

--- a/packages/houdini-core/plugin/lists/refetchableDocuments.go
+++ b/packages/houdini-core/plugin/lists/refetchableDocuments.go
@@ -1,0 +1,470 @@
+package lists
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"code.houdinigraphql.com/packages/houdini-core/config"
+	"code.houdinigraphql.com/plugins"
+	"code.houdinigraphql.com/plugins/graphql"
+)
+
+// refetchableFragment captures everything we need to generate the embedded query
+// for a fragment tagged with @refetchable.
+type refetchableFragment struct {
+	ID            int64
+	Name          string
+	RawDocument   int
+	TypeCondition string
+	ResolveQuery  string
+	Keys          []fieldArgumentSpec
+}
+
+// refetchableArg is an @arguments declaration on the fragment. These need to be
+// forwarded to the generated query (as document variables) and passed back into
+// the fragment via @with so they can be supplied at refetch time.
+type refetchableArg struct {
+	Name          string
+	Type          string
+	TypeModifiers string
+	DefaultValue  int64 // argument_values id, 0 if there is no default
+}
+
+// PrepareRefetchableDocuments looks for every fragment tagged with @refetchable and
+// generates an embedded query (named like the pagination query) that re-fetches the
+// fragment by id. This is the same wrapper @paginate generates for paginated
+// fragments — node(id:) { ...Fragment @with(...) } — but without any list/pagination
+// semantics. The generated query gets a discovered_lists row (with no list name and
+// no paginate marker) so the artifact picks up a "refetch" block with paginated: false.
+func PrepareRefetchableDocuments(
+	ctx context.Context,
+	db plugins.DatabasePool[config.PluginConfig],
+) error {
+	projectConfig, err := db.ProjectConfig(ctx)
+	if err != nil {
+		return plugins.WrapError(err)
+	}
+
+	conn, err := db.Take(ctx)
+	if err != nil {
+		return plugins.WrapError(err)
+	}
+	defer db.Put(conn)
+
+	close := db.Transaction(conn)
+	commit := func(err error) error {
+		close(&err)
+		return err
+	}
+
+	// find every fragment marked @refetchable that hasn't already been processed,
+	// along with the query used to resolve its type by id (node by default) and the
+	// key fields (with their types) needed to look it up.
+	query, err := conn.Prepare(`
+		SELECT
+			documents.id,
+			documents.name,
+			documents.raw_document,
+			documents.type_condition,
+			COALESCE(type_configs.resolve_query, 'node') as resolve_query,
+			CASE
+				WHEN COUNT(tf.type) = 0 THEN NULL
+				ELSE json_group_array(
+					DISTINCT json_object('name', je.value, 'kind', tf.type)
+				)
+			END as resolve_keys
+		FROM documents
+			JOIN raw_documents on documents.raw_document = raw_documents.id
+			JOIN document_directives on document_directives.document = documents.id
+				AND document_directives.directive = $refetchable_directive
+			LEFT JOIN type_configs on documents.type_condition = type_configs."name"
+			JOIN config
+			CROSS JOIN json_each(COALESCE(type_configs.keys, config.default_keys)) AS je
+			LEFT JOIN type_fields tf
+				ON tf.parent = documents.type_condition
+				AND tf.name = je.value
+			LEFT JOIN documents existing_operations ON existing_operations.name = documents.name || $pagination_suffix
+		WHERE (raw_documents.current_task = $task_id OR $task_id IS NULL)
+			AND documents.kind = 'fragment'
+			AND existing_operations.id IS NULL
+			AND (documents.processed = false OR documents.processed IS NULL)
+		GROUP BY documents.id
+	`)
+	if err != nil {
+		return commit(plugins.WrapError(err))
+	}
+	defer query.Finalize()
+	err = db.BindStatement(query, map[string]any{
+		"refetchable_directive": graphql.RefetchableDirective,
+		"pagination_suffix":     graphql.PaginationQuerySuffix,
+	})
+	if err != nil {
+		return commit(plugins.WrapError(err))
+	}
+
+	// the @arguments declared on a fragment are stored as document_variables.
+	getArguments, err := conn.Prepare(`
+		SELECT "name", "type", type_modifiers, default_value
+		FROM document_variables
+		WHERE document = $document
+	`)
+	if err != nil {
+		return commit(plugins.WrapError(err))
+	}
+	defer getArguments.Finalize()
+
+	// statements for building the generated query (mirrors paginationDocuments.go)
+	insertDocument, err := conn.Prepare(`
+		INSERT INTO documents (name, kind, raw_document, internal, visible) VALUES ($name, 'query', $raw_document, false, false)
+	`)
+	if err != nil {
+		return commit(plugins.WrapError(err))
+	}
+	defer insertDocument.Finalize()
+	insertSelection, err := conn.Prepare(`
+		INSERT INTO selections (field_name, kind, alias, type, fragment_args) VALUES ($field_name, $kind, $field_name, $type, $fragment_args)
+	`)
+	if err != nil {
+		return commit(plugins.WrapError(err))
+	}
+	defer insertSelection.Finalize()
+	insertSelectionRef, err := conn.Prepare(`
+		INSERT INTO selection_refs (document, child_id, parent_id, row, column, path_index, internal) VALUES ($document, $child_id, $parent_id, 0, 0, 0, $internal)
+	`)
+	if err != nil {
+		return commit(plugins.WrapError(err))
+	}
+	defer insertSelectionRef.Finalize()
+	insertSelectionArgument, err := conn.Prepare(`
+		INSERT INTO selection_arguments (selection_id, "name", "value", row, column, field_argument, document) VALUES ($selection_id, $name, $value, 0, 0, $field_argument, $document)
+	`)
+	if err != nil {
+		return commit(plugins.WrapError(err))
+	}
+	defer insertSelectionArgument.Finalize()
+	insertArgumentValue, err := conn.Prepare(`
+		INSERT INTO argument_values (kind, raw, expected_type, document, row, column) VALUES ($kind, $raw, $expected_type, $document, 0, 0)
+	`)
+	if err != nil {
+		return commit(plugins.WrapError(err))
+	}
+	defer insertArgumentValue.Finalize()
+	insertDocumentVariable, err := conn.Prepare(`
+		INSERT INTO document_variables (document, "name", type, type_modifiers, default_value, row, column) VALUES ($document, $name, $type, $type_modifiers, $default_value, 0, 0)
+	`)
+	if err != nil {
+		return commit(plugins.WrapError(err))
+	}
+	defer insertDocumentVariable.Finalize()
+	insertSelectionDirective, err := conn.Prepare(`
+		INSERT INTO selection_directives (selection_id, directive, row, column) VALUES ($selection, $directive, 0, 0)
+	`)
+	if err != nil {
+		return commit(plugins.WrapError(err))
+	}
+	defer insertSelectionDirective.Finalize()
+	insertSelectionDirectiveArgument, err := conn.Prepare(`
+		INSERT INTO selection_directive_arguments (parent, name, value, document) VALUES ($parent, $name, $value, $document)
+	`)
+	if err != nil {
+		return commit(plugins.WrapError(err))
+	}
+	defer insertSelectionDirectiveArgument.Finalize()
+	copyArgumentValue, err := conn.Prepare(`
+		INSERT INTO argument_values (kind, raw, row, column, expected_type, document)
+		SELECT kind, raw, row, column, expected_type, $document
+		FROM argument_values where id = $id
+	`)
+	if err != nil {
+		return commit(plugins.WrapError(err))
+	}
+	defer copyArgumentValue.Finalize()
+	insertDiscoveredLists, err := conn.Prepare(`
+		INSERT INTO discovered_lists
+			(name, node_type, connection_type, document, connection, list_field, paginate, node, page_size, mode, embedded, target_type, supports_forward, supports_backward)
+		VALUES
+			($name, $node_type, $connection_type, $document, false, $list_field, NULL, $node, 0, 'Infinite', false, $target_type, false, false)
+	`)
+	if err != nil {
+		return commit(plugins.WrapError(err))
+	}
+	defer insertDiscoveredLists.Finalize()
+
+	// collect the matching fragments first so we don't generate while iterating.
+	fragments := []refetchableFragment{}
+	errs := &plugins.ErrorList{}
+	err = db.StepStatement(ctx, query, func() {
+		frag := refetchableFragment{
+			ID:            query.ColumnInt64(0),
+			Name:          query.ColumnText(1),
+			RawDocument:   query.ColumnInt(2),
+			TypeCondition: query.ColumnText(3),
+			ResolveQuery:  query.ColumnText(4),
+		}
+
+		if !query.IsNull("resolve_keys") {
+			if err := json.Unmarshal([]byte(query.GetText("resolve_keys")), &frag.Keys); err != nil {
+				errs.Append(plugins.WrapError(fmt.Errorf("failed to unmarshal refetchable keys: %v", err)))
+				return
+			}
+		}
+
+		fragments = append(fragments, frag)
+	})
+	if err != nil {
+		return commit(plugins.WrapError(err))
+	}
+	if errs.Len() > 0 {
+		return commit(errs)
+	}
+
+	for _, frag := range fragments {
+		// gather the fragment's @arguments (stored as document variables)
+		args := []refetchableArg{}
+		err = db.BindStatement(getArguments, map[string]any{"document": frag.ID})
+		if err != nil {
+			return commit(plugins.WrapError(err))
+		}
+		err = db.StepStatement(ctx, getArguments, func() {
+			arg := refetchableArg{
+				Name:          getArguments.ColumnText(0),
+				Type:          getArguments.ColumnText(1),
+				TypeModifiers: getArguments.ColumnText(2),
+			}
+			if !getArguments.IsNull("default_value") {
+				arg.DefaultValue = getArguments.ColumnInt64(3)
+			}
+			args = append(args, arg)
+		})
+		if err != nil {
+			return commit(plugins.WrapError(err))
+		}
+
+		err = generateRefetchableQuery(ctx, db, conn, projectConfig, statementsForRefetch{
+			insertDocument:                   insertDocument,
+			insertSelection:                  insertSelection,
+			insertSelectionRef:               insertSelectionRef,
+			insertSelectionArgument:          insertSelectionArgument,
+			insertArgumentValue:              insertArgumentValue,
+			insertDocumentVariable:           insertDocumentVariable,
+			insertSelectionDirective:         insertSelectionDirective,
+			insertSelectionDirectiveArgument: insertSelectionDirectiveArgument,
+			copyArgumentValue:                copyArgumentValue,
+			insertDiscoveredLists:            insertDiscoveredLists,
+		}, frag, args)
+		if err != nil {
+			errs.Append(plugins.WrapError(err))
+			continue
+		}
+	}
+
+	if errs.Len() > 0 {
+		return commit(errs)
+	}
+
+	return commit(nil)
+}
+
+type statementsForRefetch struct {
+	insertDocument                   plugins.Stmt
+	insertSelection                  plugins.Stmt
+	insertSelectionRef               plugins.Stmt
+	insertSelectionArgument          plugins.Stmt
+	insertArgumentValue              plugins.Stmt
+	insertDocumentVariable           plugins.Stmt
+	insertSelectionDirective         plugins.Stmt
+	insertSelectionDirectiveArgument plugins.Stmt
+	copyArgumentValue                plugins.Stmt
+	insertDiscoveredLists            plugins.Stmt
+}
+
+func generateRefetchableQuery(
+	ctx context.Context,
+	db plugins.DatabasePool[config.PluginConfig],
+	conn plugins.Conn,
+	projectConfig plugins.ProjectConfig,
+	stmts statementsForRefetch,
+	frag refetchableFragment,
+	args []refetchableArg,
+) error {
+	// create the query that embeds the fragment
+	err := db.ExecStatement(stmts.insertDocument, map[string]any{
+		"name":         graphql.FragmentPaginationQueryName(frag.Name),
+		"raw_document": frag.RawDocument,
+	})
+	if err != nil {
+		return err
+	}
+	queryDocumentID := conn.LastInsertRowID()
+
+	// the resolve field that looks the entity up by id (node by default)
+	err = db.ExecStatement(stmts.insertSelection, map[string]any{
+		"field_name":    frag.ResolveQuery,
+		"kind":          "field",
+		"type":          fmt.Sprintf("Query.%s", frag.ResolveQuery),
+		"fragment_args": nil,
+	})
+	if err != nil {
+		return err
+	}
+	resolveSelectionID := conn.LastInsertRowID()
+
+	err = db.ExecStatement(stmts.insertSelectionRef, map[string]any{
+		"document": queryDocumentID,
+		"child_id": resolveSelectionID,
+		"internal": false,
+	})
+	if err != nil {
+		return err
+	}
+
+	// spread the original fragment underneath the resolve field
+	err = db.ExecStatement(stmts.insertSelection, map[string]any{
+		"field_name":    frag.Name,
+		"kind":          "fragment",
+		"type":          "",
+		"fragment_args": nil,
+	})
+	if err != nil {
+		return err
+	}
+	fragmentSpreadID := conn.LastInsertRowID()
+
+	err = db.ExecStatement(stmts.insertSelectionRef, map[string]any{
+		"document":  queryDocumentID,
+		"child_id":  fragmentSpreadID,
+		"parent_id": resolveSelectionID,
+		"internal":  true,
+	})
+	if err != nil {
+		return err
+	}
+
+	// node() returns an interface and external fragment spreads are masked by
+	// default; expose the fragment's fields through the wrapper.
+	err = db.ExecStatement(stmts.insertSelectionDirective, map[string]any{
+		"selection": fragmentSpreadID,
+		"directive": graphql.DisableMaskDirective,
+	})
+	if err != nil {
+		return err
+	}
+
+	// the resolve field's key arguments (id) become query variables
+	for _, key := range frag.Keys {
+		err = db.ExecStatement(stmts.insertArgumentValue, map[string]any{
+			"kind":          "Variable",
+			"raw":           key.Name,
+			"expected_type": key.Kind,
+			"document":      queryDocumentID,
+		})
+		if err != nil {
+			return err
+		}
+		err = db.ExecStatement(stmts.insertSelectionArgument, map[string]any{
+			"selection_id":   resolveSelectionID,
+			"name":           key.Name,
+			"value":          conn.LastInsertRowID(),
+			"field_argument": fmt.Sprintf("Query.%s.%s", frag.ResolveQuery, key.Name),
+			"document":       queryDocumentID,
+		})
+		if err != nil {
+			return err
+		}
+		err = db.ExecStatement(stmts.insertDocumentVariable, map[string]any{
+			"document":       queryDocumentID,
+			"name":           key.Name,
+			"type":           key.Kind,
+			"type_modifiers": "!",
+			"default_value":  nil,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	// forward the fragment's @arguments via @with so they can be supplied at refetch time
+	if len(args) > 0 {
+		err = db.ExecStatement(stmts.insertSelectionDirective, map[string]any{
+			"selection": fragmentSpreadID,
+			"directive": graphql.WithDirective,
+		})
+		if err != nil {
+			return err
+		}
+		withDirectiveID := conn.LastInsertRowID()
+
+		for _, arg := range args {
+			// the @with argument references a query variable of the same name
+			err = db.ExecStatement(stmts.insertArgumentValue, map[string]any{
+				"kind":          "Variable",
+				"raw":           arg.Name,
+				"expected_type": arg.Type,
+				"document":      queryDocumentID,
+			})
+			if err != nil {
+				return err
+			}
+			err = db.ExecStatement(stmts.insertSelectionDirectiveArgument, map[string]any{
+				"parent":   withDirectiveID,
+				"name":     arg.Name,
+				"value":    conn.LastInsertRowID(),
+				"document": queryDocumentID,
+			})
+			if err != nil {
+				return err
+			}
+
+			// copy the @arguments default (if any) onto the query variable
+			var defaultValue any
+			if arg.DefaultValue != 0 {
+				err = db.ExecStatement(stmts.copyArgumentValue, map[string]any{
+					"id":       arg.DefaultValue,
+					"document": queryDocumentID,
+				})
+				if err != nil {
+					return err
+				}
+				defaultValue = conn.LastInsertRowID()
+			}
+
+			err = db.ExecStatement(stmts.insertDocumentVariable, map[string]any{
+				"document":       queryDocumentID,
+				"name":           arg.Name,
+				"type":           arg.Type,
+				"type_modifiers": arg.TypeModifiers,
+				"default_value":  defaultValue,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// the target type used to resolve the entity: "Node" via node(id:) by default,
+	// or the fragment's type when it has a custom resolve query configured.
+	targetType := "Node"
+	if typeConfig, exists := projectConfig.TypeConfig[frag.TypeCondition]; exists &&
+		typeConfig.ResolveQuery != "" {
+		targetType = frag.TypeCondition
+	}
+
+	// record a discovered_lists row for the generated query so the artifact emits a
+	// "refetch" block (paginated: false). an empty name keeps it out of the list
+	// machinery — it carries refetch metadata only.
+	err = db.ExecStatement(stmts.insertDiscoveredLists, map[string]any{
+		"name":            "",
+		"node_type":       frag.TypeCondition,
+		"connection_type": frag.TypeCondition,
+		"document":        queryDocumentID,
+		"list_field":      resolveSelectionID,
+		"node":            resolveSelectionID,
+		"target_type":     targetType,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/packages/houdini-core/plugin/lists/refetchableDocuments_test.go
+++ b/packages/houdini-core/plugin/lists/refetchableDocuments_test.go
@@ -29,6 +29,7 @@ func TestRefetchableDocumentGeneration(t *testing.T) {
 			type Legend {
 				title: String!
 				name: String!
+				nickname(title: String): String
 			}
 
 			interface Node {
@@ -130,6 +131,45 @@ func TestRefetchableDocumentGeneration(t *testing.T) {
 							}
 						`,
 							graphql.FragmentRefetchQueryName("LegendInfo"),
+						)).WithVariables(
+						tests.ExpectedOperationVariable{
+							Name:          "title",
+							Type:          "String",
+							TypeModifiers: "!",
+						},
+					),
+				},
+			},
+			{
+				Name: "reuses the key variable when a fragment @argument shares its name",
+				Pass: true,
+				Input: []string{
+					`
+						fragment LegendCollision on Legend @refetchable @arguments(title: { type: "String" }) {
+							nickname(title: $title)
+						}
+					`,
+				},
+				ProjectConfig: func(config *plugins.ProjectConfig) {
+					config.TypeConfig["Legend"] = plugins.TypeConfig{
+						Keys:         []string{"title"},
+						ResolveQuery: "legend",
+					}
+				},
+				// the resolve key `title` and the fragment @argument `title` collapse to a
+				// single non-null variable; the @with reference points at that same variable.
+				Expected: []tests.ExpectedDocument{
+					tests.ExpectedDoc(
+						fmt.Sprintf(`
+							query %s($title: String!) {
+								legend(title: $title) {
+									...LegendCollision_OqqDb @mask_disable @with(title: $title)
+									__typename
+									title
+								}
+							}
+						`,
+							graphql.FragmentRefetchQueryName("LegendCollision"),
 						)).WithVariables(
 						tests.ExpectedOperationVariable{
 							Name:          "title",

--- a/packages/houdini-core/plugin/lists/refetchableDocuments_test.go
+++ b/packages/houdini-core/plugin/lists/refetchableDocuments_test.go
@@ -1,0 +1,144 @@
+package lists_test
+
+import (
+	"fmt"
+	"testing"
+
+	"code.houdinigraphql.com/packages/houdini-core/config"
+	core "code.houdinigraphql.com/packages/houdini-core/plugin"
+	"code.houdinigraphql.com/plugins"
+	"code.houdinigraphql.com/plugins/graphql"
+	"code.houdinigraphql.com/plugins/tests"
+)
+
+func TestRefetchableDocumentGeneration(t *testing.T) {
+	tests.RunTable(t, tests.Table[config.PluginConfig, *core.HoudiniCore]{
+		Schema: `
+			type Query {
+				node(id: ID!): Node
+				user: User
+				legend(title: String!): Legend
+			}
+
+			type User implements Node {
+				id: ID!
+				firstName: String!
+				field(filter: String): String
+			}
+
+			type Legend {
+				title: String!
+				name: String!
+			}
+
+			interface Node {
+				id: ID!
+			}
+		`,
+		Tests: []tests.Test[config.PluginConfig]{
+			{
+				Name: "embeds a refetchable fragment in a query keyed by id",
+				Pass: true,
+				Input: []string{
+					`
+						fragment UserInfo on User @refetchable {
+							firstName
+						}
+					`,
+				},
+				Expected: []tests.ExpectedDocument{
+					tests.ExpectedDoc(
+						fmt.Sprintf(`
+							query %s($id: ID!) {
+								node(id: $id) {
+									...UserInfo @mask_disable
+									__typename
+									id
+								}
+							}
+						`,
+							graphql.FragmentPaginationQueryName("UserInfo"),
+						)).WithVariables(
+						tests.ExpectedOperationVariable{
+							Name:          "id",
+							Type:          "ID",
+							TypeModifiers: "!",
+						},
+					),
+				},
+			},
+			{
+				Name: "forwards @arguments through @with on the embedded query",
+				Pass: true,
+				Input: []string{
+					`
+						fragment UserInfo on User @refetchable @arguments(filter: { type: "String" }) {
+							field(filter: $filter)
+						}
+					`,
+				},
+				Expected: []tests.ExpectedDocument{
+					tests.ExpectedDoc(
+						fmt.Sprintf(`
+							query %s($filter: String, $id: ID!) {
+								node(id: $id) {
+									...UserInfo_3Wbh3 @mask_disable @with(filter: $filter)
+									__typename
+									id
+								}
+							}
+						`,
+							graphql.FragmentPaginationQueryName("UserInfo"),
+						)).WithVariables(
+						tests.ExpectedOperationVariable{
+							Name: "filter",
+							Type: "String",
+						},
+						tests.ExpectedOperationVariable{
+							Name:          "id",
+							Type:          "ID",
+							TypeModifiers: "!",
+						},
+					),
+				},
+			},
+			{
+				Name: "embeds via a custom resolve query keyed by the type's keys",
+				Pass: true,
+				Input: []string{
+					`
+						fragment LegendInfo on Legend @refetchable {
+							name
+						}
+					`,
+				},
+				ProjectConfig: func(config *plugins.ProjectConfig) {
+					config.TypeConfig["Legend"] = plugins.TypeConfig{
+						Keys:         []string{"title"},
+						ResolveQuery: "legend",
+					}
+				},
+				Expected: []tests.ExpectedDocument{
+					tests.ExpectedDoc(
+						fmt.Sprintf(`
+							query %s($title: String!) {
+								legend(title: $title) {
+									...LegendInfo @mask_disable
+									__typename
+									title
+								}
+							}
+						`,
+							graphql.FragmentPaginationQueryName("LegendInfo"),
+						)).WithVariables(
+						tests.ExpectedOperationVariable{
+							Name:          "title",
+							Type:          "String",
+							TypeModifiers: "!",
+						},
+					),
+				},
+			},
+		},
+	})
+}

--- a/packages/houdini-core/plugin/lists/refetchableDocuments_test.go
+++ b/packages/houdini-core/plugin/lists/refetchableDocuments_test.go
@@ -57,7 +57,7 @@ func TestRefetchableDocumentGeneration(t *testing.T) {
 								}
 							}
 						`,
-							graphql.FragmentPaginationQueryName("UserInfo"),
+							graphql.FragmentRefetchQueryName("UserInfo"),
 						)).WithVariables(
 						tests.ExpectedOperationVariable{
 							Name:          "id",
@@ -88,7 +88,7 @@ func TestRefetchableDocumentGeneration(t *testing.T) {
 								}
 							}
 						`,
-							graphql.FragmentPaginationQueryName("UserInfo"),
+							graphql.FragmentRefetchQueryName("UserInfo"),
 						)).WithVariables(
 						tests.ExpectedOperationVariable{
 							Name: "filter",
@@ -129,7 +129,7 @@ func TestRefetchableDocumentGeneration(t *testing.T) {
 								}
 							}
 						`,
-							graphql.FragmentPaginationQueryName("LegendInfo"),
+							graphql.FragmentRefetchQueryName("LegendInfo"),
 						)).WithVariables(
 						tests.ExpectedOperationVariable{
 							Name:          "title",

--- a/packages/houdini-core/plugin/lists/validate.go
+++ b/packages/houdini-core/plugin/lists/validate.go
@@ -267,6 +267,72 @@ func ValidatePaginateTypeCondition(
 	}
 }
 
+// ValidateRefetchableTypeCondition makes sure that every fragment tagged with
+// @refetchable lives on a type that can be looked up on its own — it either
+// implements Node or has a type_configs entry with a custom resolve_query.
+// Without that, the embedded refetch query we generate (node(id:) { ...Frag })
+// would be invalid, so we surface a clear error instead.
+func ValidateRefetchableTypeCondition(
+	ctx context.Context,
+	db plugins.DatabasePool[config.PluginConfig],
+	errs *plugins.ErrorList,
+) {
+	// @refetchable is a document-level directive, so we look it up via
+	// document_directives (unlike @paginate which lives on a selection). The
+	// Node / resolve_query checks are the same as ValidatePaginateTypeCondition:
+	// the type must implement Node or have a custom resolve_query so the generated
+	// query can look it up by id.
+	//
+	// Unlike @paginate we do NOT exclude operation types — a fragment on Query is
+	// rejected here because queries are already refetchable on their own, so
+	// @refetchable is redundant (and we can't look one up by id).
+	query := `
+		SELECT DISTINCT
+			d.name AS documentName,
+			d.type_condition,
+			rd.filepath,
+			rd.offset_line,
+			rd.offset_column,
+			dd.row as line,
+			dd.column
+		FROM documents d
+			JOIN raw_documents rd ON rd.id = d.raw_document
+			JOIN document_directives dd ON dd.document = d.id
+			LEFT JOIN possible_types pt ON pt.type = 'Node' AND d.type_condition = pt.member
+			LEFT JOIN type_configs tc ON tc.resolve_query IS NOT NULL AND d.type_condition = tc.name
+		WHERE d.kind = 'fragment'
+			AND dd.directive = $refetchable_directive
+			AND pt.member IS NULL
+			AND tc.name IS NULL
+			AND (rd.current_task = $task_id OR $task_id IS NULL)
+	`
+	bindings := map[string]any{
+		"refetchable_directive": graphql.RefetchableDirective,
+	}
+	err := db.StepQuery(ctx, query, bindings, func(stmt plugins.Row) {
+		docName := stmt.ColumnText(0)
+		typeCondition := stmt.ColumnText(1)
+		filepath := stmt.ColumnText(2)
+		line := int(stmt.ColumnInt(3)) + int(stmt.ColumnInt(5))
+		column := int(stmt.ColumnInt(4)) + int(stmt.ColumnInt(6))
+		errs.Append(&plugins.Error{
+			Message: fmt.Sprintf(
+				"Document %q uses @%s but its type condition %q is invalid. It must either implement Node or have a type_configs entry with a valid resolve_query",
+				docName,
+				graphql.RefetchableDirective,
+				typeCondition,
+			),
+			Kind: plugins.ErrorKindValidation,
+			Locations: []*plugins.ErrorLocation{
+				{Filepath: filepath, Line: line, Column: column},
+			},
+		})
+	})
+	if err != nil {
+		errs.Append(plugins.WrapError(err))
+	}
+}
+
 func ValidateSinglePaginateDirective(
 	ctx context.Context,
 	db plugins.DatabasePool[config.PluginConfig],

--- a/packages/houdini-core/plugin/lists/validate.go
+++ b/packages/houdini-core/plugin/lists/validate.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"sync"
 
-	
-
 	"code.houdinigraphql.com/packages/houdini-core/config"
 	"code.houdinigraphql.com/plugins"
 	"code.houdinigraphql.com/plugins/graphql"
@@ -321,6 +319,63 @@ func ValidateRefetchableTypeCondition(
 				docName,
 				graphql.RefetchableDirective,
 				typeCondition,
+			),
+			Kind: plugins.ErrorKindValidation,
+			Locations: []*plugins.ErrorLocation{
+				{Filepath: filepath, Line: line, Column: column},
+			},
+		})
+	})
+	if err != nil {
+		errs.Append(plugins.WrapError(err))
+	}
+}
+
+// ValidateRefetchablePaginateConflict rejects documents that carry both @refetchable
+// (a document-level directive) and @paginate (a selection-level directive). A paginated
+// fragment is already independently refetchable via its generated _Pagination_Query, so
+// @refetchable is redundant — and both want to own the embedded refetch query, so allowing
+// the combination would silently drop one. We surface a clear error instead.
+func ValidateRefetchablePaginateConflict(
+	ctx context.Context,
+	db plugins.DatabasePool[config.PluginConfig],
+	errs *plugins.ErrorList,
+) {
+	// find documents that have a @refetchable document directive AND a @paginate selection
+	// directive. we report at the @refetchable location since that's the redundant one.
+	query := `
+		SELECT DISTINCT
+			d.name AS documentName,
+			rd.filepath,
+			rd.offset_line,
+			rd.offset_column,
+			dd.row as line,
+			dd.column
+		FROM documents d
+			JOIN raw_documents rd ON rd.id = d.raw_document
+			JOIN document_directives dd ON dd.document = d.id
+				AND dd.directive = $refetchable_directive
+			JOIN selection_refs sr ON sr.document = d.id
+			JOIN selection_directives sd ON sd.selection_id = sr.child_id
+				AND sd.directive = $paginate_directive
+		WHERE (rd.current_task = $task_id OR $task_id IS NULL)
+	`
+	bindings := map[string]any{
+		"refetchable_directive": graphql.RefetchableDirective,
+		"paginate_directive":    graphql.PaginationDirective,
+	}
+	err := db.StepQuery(ctx, query, bindings, func(stmt plugins.Row) {
+		docName := stmt.ColumnText(0)
+		filepath := stmt.ColumnText(1)
+		line := int(stmt.ColumnInt(2)) + int(stmt.ColumnInt(4))
+		column := int(stmt.ColumnInt(3)) + int(stmt.ColumnInt(5))
+		errs.Append(&plugins.Error{
+			Message: fmt.Sprintf(
+				"Document %q cannot use both @%s and @%s. A paginated fragment is already refetchable on its own, so @%s is redundant",
+				docName,
+				graphql.RefetchableDirective,
+				graphql.PaginationDirective,
+				graphql.RefetchableDirective,
 			),
 			Kind: plugins.ErrorKindValidation,
 			Locations: []*plugins.ErrorLocation{

--- a/packages/houdini-core/plugin/schema/generateDefinitions_test.go
+++ b/packages/houdini-core/plugin/schema/generateDefinitions_test.go
@@ -126,6 +126,9 @@ directive @required on FIELD
 """@refetch marks a record in a mutation response so the cache refetches every document that depends on it"""
 directive @refetch on FIELD
 
+"""@refetchable marks a fragment so it can be refetched on its own with new argument values"""
+directive @refetchable on FRAGMENT_DEFINITION
+
 """@componentField is used to mark a field as a component field"""
 directive @componentField(field: String, prop: String) on FIELD_DEFINITION | FRAGMENT_DEFINITION | INLINE_FRAGMENT
 

--- a/packages/houdini-core/plugin/schema/write.go
+++ b/packages/houdini-core/plugin/schema/write.go
@@ -1052,6 +1052,23 @@ then the request will never be deduplicated.`,
 		return err
 	}
 
+	// @refetchable on FRAGMENT_DEFINITION
+	err = db.ExecStatement(statements.InsertInternalDirective, map[string]any{
+		"name":        graphql.RefetchableDirective,
+		"description": "@refetchable marks a fragment so it can be refetched on its own with new argument values",
+		"visible":     true,
+	})
+	if err != nil {
+		return err
+	}
+	err = db.ExecStatement(statements.InsertDirectiveLocation, map[string]any{
+		"directive": graphql.RefetchableDirective,
+		"location":  "FRAGMENT_DEFINITION",
+	})
+	if err != nil {
+		return err
+	}
+
 	// @componentField(prop: String, field: String) on FRAGMENT_DEFINITION | INLINE_FRAGMENT | FIELD_DEFINITION
 	err = db.ExecStatement(statements.InsertInternalDirective, map[string]any{
 		"name":        graphql.ComponentFieldDirective,

--- a/packages/houdini-core/plugin/validate.go
+++ b/packages/houdini-core/plugin/validate.go
@@ -53,6 +53,7 @@ func (p *HoudiniCore) Validate(ctx context.Context) error {
 		lists.ValidateConflictingPrependAppend,
 		lists.ValidateIncludeListID,
 		lists.ValidatePaginateTypeCondition,
+		lists.ValidateRefetchableTypeCondition,
 		lists.ValidateSinglePaginateDirective,
 		lists.ValidateParentID,
 		fragmentArguments.ValidateFragmentArgumentValues,

--- a/packages/houdini-core/plugin/validate.go
+++ b/packages/houdini-core/plugin/validate.go
@@ -54,6 +54,7 @@ func (p *HoudiniCore) Validate(ctx context.Context) error {
 		lists.ValidateIncludeListID,
 		lists.ValidatePaginateTypeCondition,
 		lists.ValidateRefetchableTypeCondition,
+		lists.ValidateRefetchablePaginateConflict,
 		lists.ValidateSinglePaginateDirective,
 		lists.ValidateParentID,
 		fragmentArguments.ValidateFragmentArgumentValues,

--- a/packages/houdini-core/plugin/validate_test.go
+++ b/packages/houdini-core/plugin/validate_test.go
@@ -2036,6 +2036,39 @@ func TestValidate_Houdini(t *testing.T) {
 				},
 			},
 			{
+				Name: "@refetchable on a Node type (happy path)",
+				Pass: true,
+				Input: []string{
+					`
+					fragment RefetchableOnNode on User @refetchable {
+						firstName
+					}
+				`,
+				},
+			},
+			{
+				Name: "@refetchable on a type that is not a Node and has no resolve query",
+				Pass: false,
+				Input: []string{
+					`
+					fragment RefetchableOnGhost on Ghost @refetchable {
+						name
+					}
+				`,
+				},
+			},
+			{
+				Name: "@refetchable on Query is not allowed (queries are refetchable by default)",
+				Pass: false,
+				Input: []string{
+					`
+					fragment RefetchableOnQuery on Query @refetchable {
+						rootScalar
+					}
+				`,
+				},
+			},
+			{
 				Name: "limit pagination requires first",
 				Pass: false,
 				Input: []string{

--- a/packages/houdini-core/plugin/validate_test.go
+++ b/packages/houdini-core/plugin/validate_test.go
@@ -2085,6 +2085,23 @@ func TestValidate_Houdini(t *testing.T) {
 				},
 			},
 			{
+				Name: "@refetchable and @paginate on the same document is not allowed",
+				Pass: false,
+				Input: []string{
+					`
+					fragment RefetchableAndPaginated on User @refetchable {
+						friendsConnection(first: 10) @paginate {
+							edges {
+								node {
+									id
+								}
+							}
+						}
+					}
+				`,
+				},
+			},
+			{
 				Name: "limit pagination requires first",
 				Pass: false,
 				Input: []string{

--- a/packages/houdini-core/plugin/validate_test.go
+++ b/packages/houdini-core/plugin/validate_test.go
@@ -20,6 +20,10 @@ func TestValidate_Houdini(t *testing.T) {
 				"Ghost": {
 					Keys: []string{"aka", "name"},
 				},
+				"Cat": {
+					Keys:         []string{"name"},
+					ResolveQuery: "cat",
+				},
 			},
 			RuntimeScalars: map[string]string{
 				"ViewerIDFromSession": "ID",
@@ -77,6 +81,7 @@ func TestValidate_Houdini(t *testing.T) {
 				entitiesByCursor(first: Int, after: String, last: Int, before: String): EntityConnection!
 				node(id: ID!): Node
 				ghost: Ghost!
+				cat(name: String!): Cat
 			}
 
 			input UserFilter {
@@ -2042,6 +2047,17 @@ func TestValidate_Houdini(t *testing.T) {
 					`
 					fragment RefetchableOnNode on User @refetchable {
 						firstName
+					}
+				`,
+				},
+			},
+			{
+				Name: "@refetchable on a non-Node type that has a resolve query (happy path)",
+				Pass: true,
+				Input: []string{
+					`
+					fragment RefetchableOnCat on Cat @refetchable {
+						name
 					}
 				`,
 				},

--- a/packages/houdini-react/package/vite/transform.ts
+++ b/packages/houdini-react/package/vite/transform.ts
@@ -55,9 +55,12 @@ export async function transform_file(
 
 			const properties = [AST.objectProperty(AST.stringLiteral('artifact'), artifactRef)]
 
-			if (is_paginated(parsedDocument)) {
+			// both @paginate and @refetchable fragments embed the document in a
+			// separate query that useFragmentHandle uses to refetch.
+			if (is_paginated(parsedDocument) || is_refetchable(parsedDocument)) {
 				if (artifact.kind !== ArtifactKind.Query) {
-					// fragment/subscription pagination: the refetch artifact is a separate query
+					// fragment/subscription pagination (and @refetchable): the refetch
+					// artifact is a separate query
 					const refetchName = artifact.name + '_Pagination_Query'
 					const { id: refetchRef } = artifact_import({
 						page,
@@ -120,4 +123,16 @@ function is_paginated(doc: graphql.DocumentNode): boolean {
 		},
 	})
 	return paginated
+}
+
+function is_refetchable(doc: graphql.DocumentNode): boolean {
+	let refetchable = false
+	graphql.visit(doc, {
+		Directive(node) {
+			if (node.name.value === 'refetchable') {
+				refetchable = true
+			}
+		},
+	})
+	return refetchable
 }

--- a/packages/houdini-react/package/vite/transform.ts
+++ b/packages/houdini-react/package/vite/transform.ts
@@ -60,8 +60,11 @@ export async function transform_file(
 			if (is_paginated(parsedDocument) || is_refetchable(parsedDocument)) {
 				if (artifact.kind !== ArtifactKind.Query) {
 					// fragment/subscription pagination (and @refetchable): the refetch
-					// artifact is a separate query
-					const refetchName = artifact.name + '_Pagination_Query'
+					// artifact is a separate query. @paginate embeds a _Pagination_Query;
+					// @refetchable embeds a _Refetch_Query.
+					const refetchName =
+						artifact.name +
+						(is_paginated(parsedDocument) ? '_Pagination_Query' : '_Refetch_Query')
 					const { id: refetchRef } = artifact_import({
 						page,
 						script,

--- a/packages/houdini-react/plugin/runtime.go
+++ b/packages/houdini-react/plugin/runtime.go
@@ -630,7 +630,7 @@ func (p *HoudiniReact) UpdateHookFiles(ctx context.Context) ([]string, error) {
 	// during Validate) and @refetchable fragments (detected via the directive). We
 	// don't look for a pre-existing _Pagination_Query document because GenerateRuntime
 	// runs concurrently with GenerateDocuments and it may not exist yet.
-	paginatedFragments := map[string]string{}
+	refetchableFragments := map[string]string{}
 	err = p.DB.StepQuery(ctx, `
 		SELECT DISTINCT d.name, 0 AS refetchable
 		FROM documents d
@@ -650,9 +650,9 @@ func (p *HoudiniReact) UpdateHookFiles(ctx context.Context) ([]string, error) {
 		// @paginate fragments embed a <name>_Pagination_Query; @refetchable fragments
 		// embed a <name>_Refetch_Query. both are wired up as the refetchArtifact.
 		if q.ColumnInt(1) == 1 {
-			paginatedFragments[name] = graphql.FragmentRefetchQueryName(name)
+			refetchableFragments[name] = graphql.FragmentRefetchQueryName(name)
 		} else {
-			paginatedFragments[name] = graphql.FragmentPaginationQueryName(name)
+			refetchableFragments[name] = graphql.FragmentPaginationQueryName(name)
 		}
 	})
 	if err != nil {
@@ -691,13 +691,13 @@ func (p *HoudiniReact) UpdateHookFiles(ctx context.Context) ([]string, error) {
 			top.WriteString("\n")
 		}
 		for _, name := range names {
-			top.WriteString(spec.imports(name, paginatedFragments[name], pluralFragments[name]))
+			top.WriteString(spec.imports(name, refetchableFragments[name], pluralFragments[name]))
 		}
 		top.WriteString("\n")
 
 		var before strings.Builder
 		for _, name := range names {
-			before.WriteString(spec.overloads(name, paginatedFragments[name], pluralFragments[name]))
+			before.WriteString(spec.overloads(name, refetchableFragments[name], pluralFragments[name]))
 		}
 		if spec.passthrough != "" {
 			before.WriteString(spec.passthrough + "\n")

--- a/packages/houdini-react/plugin/runtime.go
+++ b/packages/houdini-react/plugin/runtime.go
@@ -623,10 +623,12 @@ func (p *HoudiniReact) UpdateHookFiles(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	// Build the set of visible fragments that are paginated. We detect pagination
-	// via discovered_lists (populated during Validate) rather than looking for
-	// a pre-existing _Pagination_Query document, because GenerateRuntime runs
-	// concurrently with GenerateDocuments and the document may not exist yet.
+	// Build the set of visible fragments that get an embedded refetch query, so
+	// useFragmentHandle is wired up with the generated query as its refetchArtifact.
+	// This covers both @paginate fragments (detected via discovered_lists, populated
+	// during Validate) and @refetchable fragments (detected via the directive). We
+	// don't look for a pre-existing _Pagination_Query document because GenerateRuntime
+	// runs concurrently with GenerateDocuments and it may not exist yet.
 	paginatedFragments := map[string]string{}
 	err = p.DB.StepQuery(ctx, `
 		SELECT DISTINCT d.name
@@ -634,6 +636,14 @@ func (p *HoudiniReact) UpdateHookFiles(ctx context.Context) ([]string, error) {
 		JOIN discovered_lists dl ON dl.document = d.id
 		WHERE d.visible = 1 AND d.kind = 'fragment'
 		  AND dl.paginate IS NOT NULL
+
+		UNION
+
+		SELECT DISTINCT d.name
+		FROM documents d
+		JOIN document_directives dd ON dd.document = d.id
+		WHERE d.visible = 1 AND d.kind = 'fragment'
+		  AND dd.directive = 'refetchable'
 	`, nil, func(q plugins.Row) {
 		name := q.ColumnText(0)
 		paginatedFragments[name] = name + "_Pagination_Query"

--- a/packages/houdini-react/plugin/runtime.go
+++ b/packages/houdini-react/plugin/runtime.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/afero"
 
 	plugins "code.houdinigraphql.com/plugins"
+	"code.houdinigraphql.com/plugins/graphql"
 )
 
 // TransformRuntime patches static runtime files as they are copied into the plugin directory.
@@ -631,7 +632,7 @@ func (p *HoudiniReact) UpdateHookFiles(ctx context.Context) ([]string, error) {
 	// runs concurrently with GenerateDocuments and it may not exist yet.
 	paginatedFragments := map[string]string{}
 	err = p.DB.StepQuery(ctx, `
-		SELECT DISTINCT d.name
+		SELECT DISTINCT d.name, 0 AS refetchable
 		FROM documents d
 		JOIN discovered_lists dl ON dl.document = d.id
 		WHERE d.visible = 1 AND d.kind = 'fragment'
@@ -639,14 +640,20 @@ func (p *HoudiniReact) UpdateHookFiles(ctx context.Context) ([]string, error) {
 
 		UNION
 
-		SELECT DISTINCT d.name
+		SELECT DISTINCT d.name, 1 AS refetchable
 		FROM documents d
 		JOIN document_directives dd ON dd.document = d.id
 		WHERE d.visible = 1 AND d.kind = 'fragment'
 		  AND dd.directive = 'refetchable'
 	`, nil, func(q plugins.Row) {
 		name := q.ColumnText(0)
-		paginatedFragments[name] = name + "_Pagination_Query"
+		// @paginate fragments embed a <name>_Pagination_Query; @refetchable fragments
+		// embed a <name>_Refetch_Query. both are wired up as the refetchArtifact.
+		if q.ColumnInt(1) == 1 {
+			paginatedFragments[name] = graphql.FragmentRefetchQueryName(name)
+		} else {
+			paginatedFragments[name] = graphql.FragmentPaginationQueryName(name)
+		}
 	})
 	if err != nil {
 		return nil, err

--- a/packages/houdini-react/runtime/hooks/useDocumentHandle.ts
+++ b/packages/houdini-react/runtime/hooks/useDocumentHandle.ts
@@ -234,5 +234,10 @@ type RefetchHandlers<_Artifact extends QueryArtifact, _Data extends GraphQLObjec
 					loadNext: OffsetHandlers<_Data, _Input>['loadNextPage']
 					loadNextPending: boolean
 				}
-			: // the artifact does not support a known pagination method, don't add anything
-				{}
+			: // a @refetchable fragment: embedded query keyed by id, re-run with new args
+				_Artifact extends { refetch: { paginated: false } }
+				? {
+						refetch: (variables?: Partial<_Input>) => Promise<_Data>
+					}
+				: // the artifact does not support a known pagination method, don't add anything
+					{}

--- a/packages/houdini-react/runtime/hooks/useFragmentHandle.ts
+++ b/packages/houdini-react/runtime/hooks/useFragmentHandle.ts
@@ -113,8 +113,8 @@ export function useFragmentHandle<
 		isSinglePage && paginationEntityData !== null
 			? paginationEntityData
 			: isRefetchable && refetchEntityData !== null
-			? refetchEntityData
-			: fragmentData
+				? refetchEntityData
+				: fragmentData
 
 	const wrapLoad = <_Result>(
 		setLoading: (val: boolean) => void,

--- a/packages/houdini-react/runtime/hooks/useFragmentHandle.ts
+++ b/packages/houdini-react/runtime/hooks/useFragmentHandle.ts
@@ -1,4 +1,10 @@
-import { extractPageInfo, cursorHandlers, offsetHandlers } from 'houdini/runtime'
+import {
+	extractPageInfo,
+	cursorHandlers,
+	offsetHandlers,
+	getCurrentConfig,
+	entityRefetchVariables,
+} from 'houdini/runtime'
 import type {
 	GraphQLObject,
 	FragmentArtifact,
@@ -71,8 +77,44 @@ export function useFragmentHandle<
 		return (paginationData as any)[rootField] ?? null
 	}, [paginationData, refetchArtifact])
 
+	// @refetchable fragments embed the fragment in a query keyed by id (paginated: false).
+	// We observe that query so refetch() can swap in fresh data computed with new argument
+	// values, just like SinglePage pagination swaps in the latest page.
+	const isRefetchable = !!refetchArtifact?.refetch && !refetchArtifact.refetch.paginated
+
+	const refetchObserver = React.useMemo(() => {
+		if (!isRefetchable || !refetchArtifact) return null
+		return client.observe<_Data, _Input>({ artifact: refetchArtifact })
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [refetchArtifact?.name, isRefetchable])
+
+	const subscribeToRefetch = React.useCallback(
+		(fn: () => void) => refetchObserver?.subscribe(() => fn()) ?? (() => {}),
+		[refetchObserver]
+	)
+	const getRefetchSnapshot = React.useCallback(
+		() => refetchObserver?.state.data ?? null,
+		[refetchObserver]
+	)
+	const refetchData = React.useSyncExternalStore(
+		subscribeToRefetch,
+		getRefetchSnapshot,
+		getRefetchSnapshot
+	)
+
+	const refetchEntityData = React.useMemo<_Data | null>(() => {
+		if (!refetchData || !refetchArtifact?.selection?.fields) return null
+		const rootField = Object.keys(refetchArtifact.selection.fields)[0]
+		if (!rootField) return null
+		return (refetchData as any)[rootField] ?? null
+	}, [refetchData, refetchArtifact])
+
 	const displayData =
-		isSinglePage && paginationEntityData !== null ? paginationEntityData : fragmentData
+		isSinglePage && paginationEntityData !== null
+			? paginationEntityData
+			: isRefetchable && refetchEntityData !== null
+			? refetchEntityData
+			: fragmentData
 
 	const wrapLoad = <_Result>(
 		setLoading: (val: boolean) => void,
@@ -170,9 +212,38 @@ export function useFragmentHandle<
 		return null
 	}, [refetchArtifact, paginationObserver, displayData, session, forwardPending, backwardPending])
 
+	// re-run the embedded query with new argument values. the entity's id is derived from
+	// the fragment data (the parent reference), which always carries the visible id. we must
+	// NOT derive it from displayData: after a refetch that becomes the embedded query result,
+	// which masks the entity's id out of its selection, so reading it back would yield
+	// `id: undefined` and clobber the real id on a second refetch.
+	const refetch = React.useMemo(() => {
+		if (!isRefetchable || !refetchObserver || !refetchArtifact) return undefined
+		return (newVariables?: _Input) => {
+			const idVariables = entityRefetchVariables(
+				getCurrentConfig(),
+				refetchArtifact.refetch?.targetType,
+				fragmentData as Record<string, any> | null
+			)
+			return refetchObserver.send({
+				variables: {
+					...(refetchObserver.state.variables ?? variables),
+					...idVariables,
+					...newVariables,
+				} as _Input,
+				// suppress loading-state placeholder data during the transition so the
+				// currently displayed value stays put until the fresh result arrives
+				stuff: { silenceLoading: true },
+				cacheParams: { disableSubscriptions: true, disablePartial: true },
+				session,
+			})
+		}
+	}, [isRefetchable, refetchObserver, refetchArtifact, fragmentData, variables, session])
+
 	return {
 		...handle,
 		variables,
 		data: displayData,
+		refetch,
 	}
 }

--- a/packages/houdini-react/runtime/hooks/useFragmentHandle.ts
+++ b/packages/houdini-react/runtime/hooks/useFragmentHandle.ts
@@ -212,6 +212,11 @@ export function useFragmentHandle<
 		return null
 	}, [refetchArtifact, paginationObserver, displayData, session, forwardPending, backwardPending])
 
+	// the fragment's current argument values: the initial args overlaid with everything that
+	// has been passed to refetch() so far. we track these explicitly rather than reading them
+	// back off the embedded query, whose variables also carry the synthetic id-lookup keys.
+	const [refetchArgs, setRefetchArgs] = React.useState<Partial<_Input>>({})
+
 	// re-run the embedded query with new argument values. the entity's id is derived from
 	// the fragment data (the parent reference), which always carries the visible id. we must
 	// NOT derive it from displayData: after a refetch that becomes the embedded query result,
@@ -220,6 +225,7 @@ export function useFragmentHandle<
 	const refetch = React.useMemo(() => {
 		if (!isRefetchable || !refetchObserver || !refetchArtifact) return undefined
 		return (newVariables?: _Input) => {
+			setRefetchArgs((prev) => ({ ...prev, ...newVariables }))
 			const idVariables = entityRefetchVariables(
 				getCurrentConfig(),
 				refetchArtifact.refetch?.targetType,
@@ -240,9 +246,13 @@ export function useFragmentHandle<
 		}
 	}, [isRefetchable, refetchObserver, refetchArtifact, fragmentData, variables, session])
 
+	const displayVariables = isRefetchable
+		? ({ ...(variables as Record<string, any>), ...refetchArgs } as _Input)
+		: variables
+
 	return {
 		...handle,
-		variables,
+		variables: displayVariables,
 		data: displayData,
 		refetch,
 	}

--- a/packages/houdini-svelte/plugin/config.go
+++ b/packages/houdini-svelte/plugin/config.go
@@ -81,6 +81,10 @@ func (p *HoudiniSvelte) DefaultConfig(
 		pluginConfig.CustomStores.FragmentCursor = "$houdini/plugins/houdini-svelte/runtime/stores/pagination/fragment.js#FragmentStoreCursor"
 	}
 
+	if pluginConfig.CustomStores.FragmentRefetchable == "" {
+		pluginConfig.CustomStores.FragmentRefetchable = "$houdini/plugins/houdini-svelte/runtime/stores/refetchable.js#FragmentStoreRefetchable"
+	}
+
 	return pluginConfig, nil
 }
 

--- a/packages/houdini-svelte/plugin/config/config.go
+++ b/packages/houdini-svelte/plugin/config/config.go
@@ -29,12 +29,12 @@ type PluginConfig struct {
 }
 
 type PluginConfigStorePaths struct {
-	Query          string `json:"query"`
-	Mutation       string `json:"mutation"`
-	Fragment       string `json:"fragment"`
-	Subscription   string `json:"subscription"`
-	QueryCursor    string `json:"queryCursor"`
-	QueryOffset    string `json:"queryOffset"`
+	Query               string `json:"query"`
+	Mutation            string `json:"mutation"`
+	Fragment            string `json:"fragment"`
+	Subscription        string `json:"subscription"`
+	QueryCursor         string `json:"queryCursor"`
+	QueryOffset         string `json:"queryOffset"`
 	FragmentCursor      string `json:"fragmentCursor"`
 	FragmentOffset      string `json:"fragmentOffset"`
 	FragmentRefetchable string `json:"fragmentRefetchable"`

--- a/packages/houdini-svelte/plugin/config/config.go
+++ b/packages/houdini-svelte/plugin/config/config.go
@@ -16,9 +16,10 @@ const (
 type StorePaginationType = string
 
 const (
-	StorePaginationTypeNone   = ""
-	StorePaginationTypeCursor = "cursor"
-	StorePaginationTypeOffset = "offset"
+	StorePaginationTypeNone        = ""
+	StorePaginationTypeCursor      = "cursor"
+	StorePaginationTypeOffset      = "offset"
+	StorePaginationTypeRefetchable = "refetchable"
 )
 
 type PluginConfig struct {
@@ -34,8 +35,9 @@ type PluginConfigStorePaths struct {
 	Subscription   string `json:"subscription"`
 	QueryCursor    string `json:"queryCursor"`
 	QueryOffset    string `json:"queryOffset"`
-	FragmentCursor string `json:"fragmentCursor"`
-	FragmentOffset string `json:"fragmentOffset"`
+	FragmentCursor      string `json:"fragmentCursor"`
+	FragmentOffset      string `json:"fragmentOffset"`
+	FragmentRefetchable string `json:"fragmentRefetchable"`
 }
 
 type Import struct {
@@ -62,6 +64,8 @@ func (c PluginConfig) StoreBaseClassImport(
 			importString = c.CustomStores.FragmentCursor
 		case StorePaginationTypeOffset:
 			importString = c.CustomStores.FragmentOffset
+		case StorePaginationTypeRefetchable:
+			importString = c.CustomStores.FragmentRefetchable
 		}
 	case "query":
 		switch paginated {

--- a/packages/houdini-svelte/plugin/generate/stores.go
+++ b/packages/houdini-svelte/plugin/generate/stores.go
@@ -356,10 +356,16 @@ func generateFragmentStore(
 	extraFields := ""
 	if refetchMethod != config.StorePaginationTypeNone {
 		variablesRequired = true
+		// @refetchable fragments embed a <name>_Refetch_Query; paginated fragments a
+		// <name>_Pagination_Query. both are passed to the store as paginationArtifact.
+		embeddedQueryName := graphql.FragmentPaginationQueryName(name)
+		if refetchMethod == config.StorePaginationTypeRefetchable {
+			embeddedQueryName = graphql.FragmentRefetchQueryName(name)
+		}
 		extraImport = fmt.Sprintf(
 			`
 import _PaginationArtifact from '$houdini/artifacts/%s.js'`,
-			graphql.FragmentPaginationQueryName(name),
+			embeddedQueryName,
 		)
 		extraFields = fmt.Sprintf(`
             variables: %t,

--- a/packages/houdini-svelte/plugin/generate/stores.go
+++ b/packages/houdini-svelte/plugin/generate/stores.go
@@ -51,6 +51,7 @@ func GenerateStores(
 			CASE
 				WHEN COUNT(dl_cursor.document) > 0 THEN 'cursor'
 				WHEN COUNT(dl_offset.document) > 0 THEN 'offset'
+				WHEN COUNT(dd_refetchable.document) > 0 THEN 'refetchable'
 				ELSE ''
 			END as refetch_method
 		FROM documents d
@@ -66,6 +67,10 @@ func GenerateStores(
 		LEFT JOIN discovered_lists dl_offset ON (
 			dl_offset.document = d.id
 			AND dl_offset.connection = 0 AND dl_offset.paginate is not null
+		)
+		LEFT JOIN document_directives dd_refetchable ON (
+			dd_refetchable.document = d.id
+			AND dd_refetchable.directive = 'refetchable'
 		)
 		GROUP BY d.id, d.name, d.kind
 		HAVING d.visible = 1

--- a/packages/houdini-svelte/plugin/generate/stores.go
+++ b/packages/houdini-svelte/plugin/generate/stores.go
@@ -356,20 +356,25 @@ func generateFragmentStore(
 	extraFields := ""
 	if refetchMethod != config.StorePaginationTypeNone {
 		variablesRequired = true
-		// @refetchable fragments embed a <name>_Refetch_Query; paginated fragments a
-		// <name>_Pagination_Query. both are passed to the store as paginationArtifact.
+		// @refetchable fragments embed a <name>_Refetch_Query passed as refetchArtifact;
+		// paginated fragments a <name>_Pagination_Query passed as paginationArtifact.
 		embeddedQueryName := graphql.FragmentPaginationQueryName(name)
+		artifactBinding := "_PaginationArtifact"
+		artifactField := "paginationArtifact"
 		if refetchMethod == config.StorePaginationTypeRefetchable {
 			embeddedQueryName = graphql.FragmentRefetchQueryName(name)
+			artifactBinding = "_RefetchArtifact"
+			artifactField = "refetchArtifact"
 		}
 		extraImport = fmt.Sprintf(
 			`
-import _PaginationArtifact from '$houdini/artifacts/%s.js'`,
+import %s from '$houdini/artifacts/%s.js'`,
+			artifactBinding,
 			embeddedQueryName,
 		)
 		extraFields = fmt.Sprintf(`
             variables: %t,
-            paginationArtifact: _PaginationArtifact,`, variablesRequired)
+            %s: %s,`, variablesRequired, artifactField, artifactBinding)
 	}
 
 	storeContent := fmt.Sprintf(`import { %s } from '%s'

--- a/packages/houdini-svelte/plugin/generate/stores_test.go
+++ b/packages/houdini-svelte/plugin/generate/stores_test.go
@@ -218,7 +218,7 @@ export * from './client'
 						import { FragmentStoreRefetchable } from '$houdini/plugins/houdini-svelte/runtime/stores/refetchable.js'
 						import artifact from '$houdini/artifacts/RefetchableUser.js'
 						import type { RefetchableUser, RefetchableUser$data, RefetchableUser$input } from '$houdini/artifacts/RefetchableUser.js'
-						import _PaginationArtifact from '$houdini/artifacts/RefetchableUser_Pagination_Query.js'
+						import _PaginationArtifact from '$houdini/artifacts/RefetchableUser_Refetch_Query.js'
 
 						export type { RefetchableUser }
 

--- a/packages/houdini-svelte/plugin/generate/stores_test.go
+++ b/packages/houdini-svelte/plugin/generate/stores_test.go
@@ -22,15 +22,15 @@ func TestGenerateStores(t *testing.T) {
 			IncludeRuntime: "runtime",
 			Config: config.PluginConfig{
 				CustomStores: config.PluginConfigStorePaths{
-					Query:          "$houdini/plugins/houdini-svelte/runtime/stores/query.js#QueryStore",
-					QueryOffset:    "$houdini/plugins/houdini-svelte/runtime/stores/query.js#QueryStoreOffset",
-					QueryCursor:    "$houdini/plugins/houdini-svelte/runtime/stores/query.js#QueryStoreCursor",
+					Query:               "$houdini/plugins/houdini-svelte/runtime/stores/query.js#QueryStore",
+					QueryOffset:         "$houdini/plugins/houdini-svelte/runtime/stores/query.js#QueryStoreOffset",
+					QueryCursor:         "$houdini/plugins/houdini-svelte/runtime/stores/query.js#QueryStoreCursor",
 					Fragment:            "$houdini/plugins/houdini-svelte/runtime/stores/fragment.js#FragmentStore",
 					FragmentOffset:      "$houdini/plugins/houdini-svelte/runtime/stores/fragment.js#FragmentStoreOffset",
 					FragmentCursor:      "$houdini/plugins/houdini-svelte/runtime/stores/fragment.js#FragmentStoreCursor",
 					FragmentRefetchable: "$houdini/plugins/houdini-svelte/runtime/stores/refetchable.js#FragmentStoreRefetchable",
-					Mutation:       "$houdini/plugins/houdini-svelte/runtime/stores/mutation.js#MutationStore",
-					Subscription:   "$houdini/plugins/houdini-svelte/runtime/stores/subscription.js#SubscriptionStore",
+					Mutation:            "$houdini/plugins/houdini-svelte/runtime/stores/mutation.js#MutationStore",
+					Subscription:        "$houdini/plugins/houdini-svelte/runtime/stores/subscription.js#SubscriptionStore",
 				},
 			},
 		},
@@ -218,7 +218,7 @@ export * from './client'
 						import { FragmentStoreRefetchable } from '$houdini/plugins/houdini-svelte/runtime/stores/refetchable.js'
 						import artifact from '$houdini/artifacts/RefetchableUser.js'
 						import type { RefetchableUser, RefetchableUser$data, RefetchableUser$input } from '$houdini/artifacts/RefetchableUser.js'
-						import _PaginationArtifact from '$houdini/artifacts/RefetchableUser_Refetch_Query.js'
+						import _RefetchArtifact from '$houdini/artifacts/RefetchableUser_Refetch_Query.js'
 
 						export type { RefetchableUser }
 
@@ -228,7 +228,7 @@ export * from './client'
 						            artifact,
 						            storeName: "RefetchableUserStore",
 						            variables: true,
-						            paginationArtifact: _PaginationArtifact,
+						            refetchArtifact: _RefetchArtifact,
 						        })
 						    }
 						}

--- a/packages/houdini-svelte/plugin/generate/stores_test.go
+++ b/packages/houdini-svelte/plugin/generate/stores_test.go
@@ -25,9 +25,10 @@ func TestGenerateStores(t *testing.T) {
 					Query:          "$houdini/plugins/houdini-svelte/runtime/stores/query.js#QueryStore",
 					QueryOffset:    "$houdini/plugins/houdini-svelte/runtime/stores/query.js#QueryStoreOffset",
 					QueryCursor:    "$houdini/plugins/houdini-svelte/runtime/stores/query.js#QueryStoreCursor",
-					Fragment:       "$houdini/plugins/houdini-svelte/runtime/stores/fragment.js#FragmentStore",
-					FragmentOffset: "$houdini/plugins/houdini-svelte/runtime/stores/fragment.js#FragmentStoreOffset",
-					FragmentCursor: "$houdini/plugins/houdini-svelte/runtime/stores/fragment.js#FragmentStoreCursor",
+					Fragment:            "$houdini/plugins/houdini-svelte/runtime/stores/fragment.js#FragmentStore",
+					FragmentOffset:      "$houdini/plugins/houdini-svelte/runtime/stores/fragment.js#FragmentStoreOffset",
+					FragmentCursor:      "$houdini/plugins/houdini-svelte/runtime/stores/fragment.js#FragmentStoreCursor",
+					FragmentRefetchable: "$houdini/plugins/houdini-svelte/runtime/stores/refetchable.js#FragmentStoreRefetchable",
 					Mutation:       "$houdini/plugins/houdini-svelte/runtime/stores/mutation.js#MutationStore",
 					Subscription:   "$houdini/plugins/houdini-svelte/runtime/stores/subscription.js#SubscriptionStore",
 				},
@@ -41,6 +42,7 @@ func TestGenerateStores(t *testing.T) {
 				usersByForwardsCursor(first: Int, after: String): UserConnection!
 				usersByBackwardsCursor(last: Int, before: String): UserConnection!
 				users: [User!]!
+				node(id: ID!): Node
 			}
 
 			type Mutation {
@@ -198,6 +200,35 @@ export * from './client'
 						        super({
 						            artifact,
 						            storeName: "TestFragmentStore",
+						        })
+						    }
+						}
+
+					`),
+				},
+			},
+			{
+				Name: "refetchable fragment store",
+				Pass: true,
+				Input: []string{
+					`fragment RefetchableUser on User @refetchable { name }`,
+				},
+				Extra: map[string]any{
+					"RefetchableUser": tests.Dedent(`
+						import { FragmentStoreRefetchable } from '$houdini/plugins/houdini-svelte/runtime/stores/refetchable.js'
+						import artifact from '$houdini/artifacts/RefetchableUser.js'
+						import type { RefetchableUser, RefetchableUser$data, RefetchableUser$input } from '$houdini/artifacts/RefetchableUser.js'
+						import _PaginationArtifact from '$houdini/artifacts/RefetchableUser_Pagination_Query.js'
+
+						export type { RefetchableUser }
+
+						export class RefetchableUserStore extends FragmentStoreRefetchable<RefetchableUser$data, { RefetchableUser: any }, RefetchableUser$input> {
+						    constructor() {
+						        super({
+						            artifact,
+						            storeName: "RefetchableUserStore",
+						            variables: true,
+						            paginationArtifact: _PaginationArtifact,
 						        })
 						    }
 						}

--- a/packages/houdini-svelte/runtime/fragments.ts
+++ b/packages/houdini-svelte/runtime/fragments.ts
@@ -6,6 +6,7 @@ import type {
 	BasePaginatedFragmentStore,
 	FragmentStorePaginated,
 } from './stores/pagination/fragment.js'
+import type { FragmentStoreRefetchable } from './stores/refetchable.js'
 
 // Accepts both FragmentStore (non-paginated) and paginated variants (FragmentStoreCursor /
 // FragmentStoreOffset). The paginated classes extend BasePaginatedFragmentStore, not
@@ -100,4 +101,29 @@ export function paginatedFragment<_Data extends GraphQLObject>(
 	// @ts-expect-error: the query store will only include the methods when it needs to
 	// and the userland type checking happens as part of the query type generation
 	return fragment(initialValue, store)
+}
+
+// refetchableFragment is just like fragment but the fragment is marked with @refetchable.
+// it returns a store whose value is `{ data, variables }` plus a `refetch` method that
+// re-runs the fragment with new argument values.
+export function refetchableFragment<_Data extends GraphQLObject, _Fragment extends Fragment<_Data>>(
+	initialValue: _Fragment | null | undefined,
+	document: FragmentStoreRefetchable<_Data, {}, any>
+): ReturnType<FragmentStoreRefetchable<_Data, {}, any>['get']>
+
+export function refetchableFragment<_Data extends GraphQLObject>(
+	initialValue: Fragment<_Data> | null | undefined,
+	store: FragmentStoreRefetchable<_Data, {}, any>
+): ReturnType<FragmentStoreRefetchable<_Data, {}, any>['get']> {
+	// make sure we got a fragment document
+	if (store.kind !== 'HoudiniFragment') {
+		throw new Error(`refetchableFragment() must be passed a fragment document: ${store.kind}`)
+	}
+	// if we don't have a refetchable fragment there is a problem
+	if (!('refetchable' in store)) {
+		throw new Error('refetchableFragment() must be passed a fragment with @refetchable')
+	}
+
+	// @ts-expect-error: ref is Fragment<_Data> but store.get() expects _Data | { [fragmentKey]: _ReferenceType }
+	return store.get(initialValue)
 }

--- a/packages/houdini-svelte/runtime/stores/refetchable.ts
+++ b/packages/houdini-svelte/runtime/stores/refetchable.ts
@@ -20,7 +20,7 @@ type RefetchableFragmentStoreConfig<_Data extends GraphQLObject, _Input> = Store
 	_Data,
 	_Input,
 	FragmentArtifact
-> & { paginationArtifact: QueryArtifact }
+> & { refetchArtifact: QueryArtifact }
 
 // the value handed back to components subscribing to a refetchable fragment store
 export type RefetchableFragmentResult<_Data extends GraphQLObject, _Input> = {
@@ -53,7 +53,7 @@ export class FragmentStoreRefetchable<
 	constructor(config: RefetchableFragmentStoreConfig<_Data, _Input>) {
 		this.artifact = config.artifact
 		this.name = config.storeName
-		this.refetchArtifact = config.paginationArtifact
+		this.refetchArtifact = config.refetchArtifact
 	}
 
 	get(initialValue: _Data | { [fragmentKey]: _ReferenceType } | null) {

--- a/packages/houdini-svelte/runtime/stores/refetchable.ts
+++ b/packages/houdini-svelte/runtime/stores/refetchable.ts
@@ -8,7 +8,7 @@ import type {
 	QueryArtifact,
 } from 'houdini/runtime'
 import { CompiledFragmentKind, fragmentKey } from 'houdini/runtime'
-import { derived, get } from 'svelte/store'
+import { derived, get, writable } from 'svelte/store'
 import type { Readable, Subscriber } from 'svelte/store'
 
 import { getClient, initClient } from '../client.js'
@@ -91,6 +91,11 @@ export class FragmentStoreRefetchable<
 			return wrapped ? (wrapped as _Data) : null
 		}
 
+		// the fragment's current argument values: the initial args overlaid with everything that
+		// has been passed to refetch() so far. we track these explicitly rather than reading them
+		// back off the embedded query, whose variables also carry the synthetic id-lookup keys.
+		const fragmentArgs = writable<Partial<_Input>>({})
+
 		// re-run the embedded query with new argument values. the entity's id is derived
 		// from the parent fragment reference, which always carries the (visible) id. we must
 		// NOT derive it from the embedded query result: the fragment masks the entity's id
@@ -98,6 +103,7 @@ export class FragmentStoreRefetchable<
 		// the real id on a second refetch.
 		const refetch = async (variables?: Partial<_Input>) => {
 			await initClient()
+			fragmentArgs.update((prev) => ({ ...prev, ...variables }))
 			const state =
 				store.initialValue ??
 				(get({ subscribe: store.subscribe }) as _Data | null) ??
@@ -127,19 +133,22 @@ export class FragmentStoreRefetchable<
 			run: Subscriber<RefetchableFragmentResult<_Data, _Input>>,
 			invalidate?: (value?: RefetchableFragmentResult<_Data, _Input>) => void
 		): (() => void) => {
-			const combined = derived([parent, refetchStore], ([$parent, $refetch]) => {
-				let data = $parent as _Data | null
-				if (rootField) {
-					const wrapped = ($refetch.data as any)?.[rootField]
-					if (wrapped) {
-						data = wrapped as _Data
+			const combined = derived(
+				[parent, refetchStore, fragmentArgs],
+				([$parent, $refetch, $args]) => {
+					let data = $parent as _Data | null
+					if (rootField) {
+						const wrapped = ($refetch.data as any)?.[rootField]
+						if (wrapped) {
+							data = wrapped as _Data
+						}
+					}
+					return {
+						data,
+						variables: { ...(store.variables ?? {}), ...$args } as _Input,
 					}
 				}
-				return {
-					data,
-					variables: ($refetch.variables ?? store.variables) as _Input,
-				}
-			})
+			)
 			return combined.subscribe(run, invalidate)
 		}
 

--- a/packages/houdini-svelte/runtime/stores/refetchable.ts
+++ b/packages/houdini-svelte/runtime/stores/refetchable.ts
@@ -1,0 +1,152 @@
+import { getCurrentConfig } from '$houdini/runtime/config'
+import type { DocumentStore } from '$houdini/runtime/client'
+import { entityRefetchVariables } from 'houdini/runtime'
+import type {
+	FragmentArtifact,
+	GraphQLObject,
+	GraphQLVariables,
+	QueryArtifact,
+} from 'houdini/runtime'
+import { CompiledFragmentKind, fragmentKey } from 'houdini/runtime'
+import { derived, get } from 'svelte/store'
+import type { Readable, Subscriber } from 'svelte/store'
+
+import { getClient, initClient } from '../client.js'
+import { getSession } from '../session.js'
+import { FragmentStore } from './fragment.js'
+import type { StoreConfig } from './query.js'
+
+type RefetchableFragmentStoreConfig<_Data extends GraphQLObject, _Input> = StoreConfig<
+	_Data,
+	_Input,
+	FragmentArtifact
+> & { paginationArtifact: QueryArtifact }
+
+// the value handed back to components subscribing to a refetchable fragment store
+export type RefetchableFragmentResult<_Data extends GraphQLObject, _Input> = {
+	data: _Data | null
+	variables: _Input
+}
+
+// Keyed by "<refetchQueryName>:<entityID>" so reactive re-invocations of get() (e.g. when
+// the parent query re-emits after a refetch writes to the cache) reuse the same observer
+// instead of starting over with no variables/data. Mirrors _singlePageStateCache in
+// stores/pagination/fragment.ts.
+const _refetchStateCache = new Map<string, { refetchStore: DocumentStore<any, any> }>()
+
+// FragmentStoreRefetchable backs the refetchableFragment() helper. The fragment is
+// embedded in a query keyed by id (the same wrapper @paginate uses, minus the list
+// semantics); refetch() re-runs that query with new argument values and swaps the
+// fresh result in for the masked fragment data.
+export class FragmentStoreRefetchable<
+	_Data extends GraphQLObject,
+	_ReferenceType extends {},
+	_Input extends GraphQLVariables,
+> {
+	kind = CompiledFragmentKind
+	artifact: FragmentArtifact
+	name: string
+	// a flag the refetchableFragment() helper looks for to validate the store
+	refetchable = true
+	protected refetchArtifact: QueryArtifact
+
+	constructor(config: RefetchableFragmentStoreConfig<_Data, _Input>) {
+		this.artifact = config.artifact
+		this.name = config.storeName
+		this.refetchArtifact = config.paginationArtifact
+	}
+
+	get(initialValue: _Data | { [fragmentKey]: _ReferenceType } | null) {
+		const base = new FragmentStore<_Data, {}, _Input>({
+			artifact: this.artifact,
+			storeName: this.name,
+		})
+		const store = base.get(initialValue)
+
+		// observe the embedded query so refetch() can swap in fresh data. reuse a cached
+		// observer (keyed by the fragment's parent id) across reactive re-invocations of
+		// get() so a second refetch keeps the entity id and prior variables.
+		const parentID = (initialValue as any)?.[fragmentKey]?.values?.[this.artifact.name]?.parent
+		const stateKey = parentID ? `${this.refetchArtifact.name}:${parentID}` : null
+		const cached = stateKey ? _refetchStateCache.get(stateKey) : null
+
+		let refetchStore: DocumentStore<_Data, _Input>
+		if (cached) {
+			refetchStore = cached.refetchStore
+		} else {
+			refetchStore = getClient().observe<_Data, _Input>({
+				artifact: this.refetchArtifact,
+				initialValue: store.initialValue,
+			})
+			if (stateKey) {
+				_refetchStateCache.set(stateKey, { refetchStore })
+			}
+		}
+
+		// the embedded query wraps the entity in a root field (e.g. "node")
+		const rootField = Object.keys(this.refetchArtifact.selection.fields ?? {})[0]
+		const refetchEntity = (): _Data | null => {
+			if (!rootField) return null
+			const wrapped = (get(refetchStore).data as any)?.[rootField]
+			return wrapped ? (wrapped as _Data) : null
+		}
+
+		// re-run the embedded query with new argument values. the entity's id is derived
+		// from the parent fragment reference, which always carries the (visible) id. we must
+		// NOT derive it from the embedded query result: the fragment masks the entity's id
+		// out of that selection, so reading it back would yield `id: undefined` and clobber
+		// the real id on a second refetch.
+		const refetch = async (variables?: Partial<_Input>) => {
+			await initClient()
+			const state =
+				store.initialValue ??
+				(get({ subscribe: store.subscribe }) as _Data | null) ??
+				refetchEntity()
+			const idVariables = entityRefetchVariables(
+				getCurrentConfig(),
+				this.refetchArtifact.refetch?.targetType,
+				state as Record<string, any> | null
+			)
+			const sentVars = {
+				...(get(refetchStore).variables ?? store.variables),
+				...idVariables,
+				...variables,
+			} as _Input
+			return await refetchStore.send({
+				session: await getSession(),
+				variables: sentVars,
+				// suppress loading-state placeholder data during the transition so the
+				// currently displayed value stays put until the fresh result arrives
+				stuff: { silenceLoading: true },
+				cacheParams: { disableSubscriptions: true, disablePartial: true },
+			})
+		}
+
+		const parent: Readable<_Data | null> = { subscribe: store.subscribe }
+		const subscribe = (
+			run: Subscriber<RefetchableFragmentResult<_Data, _Input>>,
+			invalidate?: (value?: RefetchableFragmentResult<_Data, _Input>) => void
+		): (() => void) => {
+			const combined = derived([parent, refetchStore], ([$parent, $refetch]) => {
+				let data = $parent as _Data | null
+				if (rootField) {
+					const wrapped = ($refetch.data as any)?.[rootField]
+					if (wrapped) {
+						data = wrapped as _Data
+					}
+				}
+				return {
+					data,
+					variables: ($refetch.variables ?? store.variables) as _Input,
+				}
+			})
+			return combined.subscribe(run, invalidate)
+		}
+
+		return {
+			kind: CompiledFragmentKind,
+			subscribe,
+			refetch,
+		}
+	}
+}

--- a/packages/houdini/src/lib/database.ts
+++ b/packages/houdini/src/lib/database.ts
@@ -393,9 +393,6 @@ CREATE TABLE IF NOT EXISTS refetch_meta (
     mode TEXT NOT NULL DEFAULT 'Infinite',
     page_size INTEGER NOT NULL DEFAULT 0,
     embedded BOOLEAN NOT NULL DEFAULT false,
-    supports_forward BOOLEAN NOT NULL DEFAULT false,
-    supports_backward BOOLEAN NOT NULL DEFAULT false,
-    cursor_type TEXT,
 
     FOREIGN KEY (document) REFERENCES documents(id) ON DELETE CASCADE,
     FOREIGN KEY (selection) REFERENCES selections(id) ON DELETE CASCADE

--- a/packages/houdini/src/lib/database.ts
+++ b/packages/houdini/src/lib/database.ts
@@ -380,6 +380,27 @@ CREATE TABLE IF NOT EXISTS discovered_lists (
     FOREIGN KEY (document) REFERENCES documents(id) ON DELETE CASCADE
 );
 
+-- refetch_meta carries the "refetch" artifact-block metadata for documents that are
+-- refetchable but are NOT lists (e.g. @refetchable fragments). Lists keep their refetch
+-- metadata on discovered_lists since it is intrinsic to pagination; this table is for the
+-- list-less case so we don't have to fake a discovered_lists row.
+CREATE TABLE IF NOT EXISTS refetch_meta (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    document INTEGER NOT NULL,
+    selection INTEGER NOT NULL,
+    target_type TEXT NOT NULL,
+    method TEXT NOT NULL DEFAULT 'offset',
+    mode TEXT NOT NULL DEFAULT 'Infinite',
+    page_size INTEGER NOT NULL DEFAULT 0,
+    embedded BOOLEAN NOT NULL DEFAULT false,
+    supports_forward BOOLEAN NOT NULL DEFAULT false,
+    supports_backward BOOLEAN NOT NULL DEFAULT false,
+    cursor_type TEXT,
+
+    FOREIGN KEY (document) REFERENCES documents(id) ON DELETE CASCADE,
+    FOREIGN KEY (selection) REFERENCES selections(id) ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS document_dependencies (
   document INTEGER NOT NULL,
   depends_on TEXT NOT NULL,
@@ -400,6 +421,10 @@ CREATE INDEX IF NOT EXISTS idx_discovered_lists_document ON discovered_lists(doc
 CREATE INDEX IF NOT EXISTS idx_discovered_lists_node ON discovered_lists(node);
 CREATE INDEX IF NOT EXISTS idx_discovered_lists_list_field ON discovered_lists(list_field);
 -- note: no index on discovered_lists(connection) — boolean column, ~2 distinct values
+
+-- refetch_meta
+CREATE INDEX IF NOT EXISTS idx_refetch_meta_selection ON refetch_meta(selection);
+CREATE INDEX IF NOT EXISTS idx_refetch_meta_document ON refetch_meta(document);
 
 -- types
 CREATE INDEX IF NOT EXISTS idx_types_kind_operation ON types(kind, operation);

--- a/packages/houdini/src/runtime/config.test.ts
+++ b/packages/houdini/src/runtime/config.test.ts
@@ -10,11 +10,10 @@ describe('entityRefetchVariables', () => {
 	})
 
 	test('falls back to the config default keys for an arbitrary type', () => {
-		const vars = entityRefetchVariables(
-			{ defaultKeys: ['uuid'] } as ConfigFile,
-			'User',
-			{ uuid: 'abc', name: 'Alec' }
-		)
+		const vars = entityRefetchVariables({ defaultKeys: ['uuid'] } as ConfigFile, 'User', {
+			uuid: 'abc',
+			name: 'Alec',
+		})
 		expect(vars).toEqual({ uuid: 'abc' })
 	})
 

--- a/packages/houdini/src/runtime/config.test.ts
+++ b/packages/houdini/src/runtime/config.test.ts
@@ -1,0 +1,56 @@
+import { test, expect, describe } from 'vitest'
+
+import type { ConfigFile } from '../lib/types'
+import { entityRefetchVariables } from './config.js'
+
+describe('entityRefetchVariables', () => {
+	test('Node uses the default id key', () => {
+		const vars = entityRefetchVariables({} as ConfigFile, 'Node', { id: '42', name: 'Alec' })
+		expect(vars).toEqual({ id: '42' })
+	})
+
+	test('falls back to the config default keys for an arbitrary type', () => {
+		const vars = entityRefetchVariables(
+			{ defaultKeys: ['uuid'] } as ConfigFile,
+			'User',
+			{ uuid: 'abc', name: 'Alec' }
+		)
+		expect(vars).toEqual({ uuid: 'abc' })
+	})
+
+	test('supports composite keys', () => {
+		const config = {
+			types: { Book: { keys: ['isbn', 'edition'] } },
+		} as unknown as ConfigFile
+		const vars = entityRefetchVariables(config, 'Book', {
+			isbn: '123',
+			edition: 2,
+			title: 'GraphQL',
+		})
+		expect(vars).toEqual({ isbn: '123', edition: 2 })
+	})
+
+	test('uses a custom resolve.arguments function when configured', () => {
+		const config = {
+			types: {
+				City: {
+					resolve: {
+						queryField: 'city',
+						arguments: (city: any) => ({ name: city.name }),
+					},
+				},
+			},
+		} as unknown as ConfigFile
+		const vars = entityRefetchVariables(config, 'City', { name: 'Paris', population: 2 })
+		expect(vars).toEqual({ name: 'Paris' })
+	})
+
+	test('returns nothing for the Query type (no entity to look up)', () => {
+		expect(entityRefetchVariables({} as ConfigFile, 'Query', { foo: 1 })).toEqual({})
+	})
+
+	test('returns nothing when there is no state', () => {
+		expect(entityRefetchVariables({} as ConfigFile, 'Node', null)).toEqual({})
+		expect(entityRefetchVariables({} as ConfigFile, undefined, { id: '1' })).toEqual({})
+	})
+})

--- a/packages/houdini/src/runtime/config.ts
+++ b/packages/houdini/src/runtime/config.ts
@@ -32,6 +32,27 @@ export function keyFieldsForType(configFile: ConfigFile, type: string) {
 	return withDefault.types?.[type]?.keys || withDefault.defaultKeys!
 }
 
+// entityRefetchVariables derives the variables needed to look an entity up by id
+// (e.g. { id: "..." } for a Node) from the entity's data. It powers both fragment
+// pagination and @refetchable fragments, which embed the fragment in a query keyed
+// by the entity. Mirrors the logic in Svelte's queryVariables().
+export function entityRefetchVariables(
+	configFile: ConfigFile,
+	targetType: string | undefined | null,
+	state: Record<string, any> | null | undefined
+): Record<string, any> {
+	if (!targetType || targetType === 'Query' || !state) {
+		return {}
+	}
+	const config = defaultConfigValues(configFile)
+	const typeConfig = config.types?.[targetType]
+	if (typeConfig?.resolve?.arguments) {
+		return (typeConfig.resolve.arguments(state) as Record<string, any>) ?? {}
+	}
+	const keys = keyFieldsForType(config, targetType)
+	return Object.fromEntries(keys.map((key) => [key, state[key]]))
+}
+
 export function computeID(configFile: ConfigFile, type: string, data: any): string {
 	const fields = keyFieldsForType(configFile, type)
 	let id = ''

--- a/packages/houdini/src/runtime/index.ts
+++ b/packages/houdini/src/runtime/index.ts
@@ -5,6 +5,7 @@ export * from './types.js'
 export {
 	computeID,
 	keyFieldsForType,
+	entityRefetchVariables,
 	setMockConfig,
 	getMockConfig,
 	getCurrentConfig,

--- a/plugins/graphql/conventions.go
+++ b/plugins/graphql/conventions.go
@@ -54,6 +54,8 @@ const RefetchDirective = "refetch"
 
 const PluralDirective = "plural"
 
+const RefetchableDirective = "refetchable"
+
 const ListOperationSuffixInsert = "_insert"
 
 const ListOperationSuffixRemove = "_remove"

--- a/plugins/graphql/conventions.go
+++ b/plugins/graphql/conventions.go
@@ -81,3 +81,9 @@ func FragmentPaginationQueryName(fragmentName string) string {
 }
 
 const PaginationQuerySuffix = "_Pagination_Query"
+
+func FragmentRefetchQueryName(fragmentName string) string {
+	return fragmentName + RefetchQuerySuffix
+}
+
+const RefetchQuerySuffix = "_Refetch_Query"

--- a/plugins/tests/schema.sql
+++ b/plugins/tests/schema.sql
@@ -383,9 +383,6 @@ CREATE TABLE IF NOT EXISTS refetch_meta (
     mode TEXT NOT NULL DEFAULT 'Infinite',
     page_size INTEGER NOT NULL DEFAULT 0,
     embedded BOOLEAN NOT NULL DEFAULT false,
-    supports_forward BOOLEAN NOT NULL DEFAULT false,
-    supports_backward BOOLEAN NOT NULL DEFAULT false,
-    cursor_type TEXT,
 
     FOREIGN KEY (document) REFERENCES documents(id) ON DELETE CASCADE,
     FOREIGN KEY (selection) REFERENCES selections(id) ON DELETE CASCADE

--- a/plugins/tests/schema.sql
+++ b/plugins/tests/schema.sql
@@ -370,6 +370,27 @@ CREATE TABLE IF NOT EXISTS discovered_lists (
     FOREIGN KEY (document) REFERENCES documents(id) ON DELETE CASCADE
 );
 
+-- refetch_meta carries the "refetch" artifact-block metadata for documents that are
+-- refetchable but are NOT lists (e.g. @refetchable fragments). Lists keep their refetch
+-- metadata on discovered_lists since it is intrinsic to pagination; this table is for the
+-- list-less case so we don't have to fake a discovered_lists row.
+CREATE TABLE IF NOT EXISTS refetch_meta (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    document INTEGER NOT NULL,
+    selection INTEGER NOT NULL,
+    target_type TEXT NOT NULL,
+    method TEXT NOT NULL DEFAULT 'offset',
+    mode TEXT NOT NULL DEFAULT 'Infinite',
+    page_size INTEGER NOT NULL DEFAULT 0,
+    embedded BOOLEAN NOT NULL DEFAULT false,
+    supports_forward BOOLEAN NOT NULL DEFAULT false,
+    supports_backward BOOLEAN NOT NULL DEFAULT false,
+    cursor_type TEXT,
+
+    FOREIGN KEY (document) REFERENCES documents(id) ON DELETE CASCADE,
+    FOREIGN KEY (selection) REFERENCES selections(id) ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS document_dependencies (
   document INTEGER NOT NULL,
   depends_on TEXT NOT NULL,
@@ -390,6 +411,10 @@ CREATE INDEX IF NOT EXISTS idx_discovered_lists_document ON discovered_lists(doc
 CREATE INDEX IF NOT EXISTS idx_discovered_lists_node ON discovered_lists(node);
 CREATE INDEX IF NOT EXISTS idx_discovered_lists_list_field ON discovered_lists(list_field);
 -- note: no index on discovered_lists(connection) — boolean column, ~2 distinct values
+
+-- refetch_meta
+CREATE INDEX IF NOT EXISTS idx_refetch_meta_selection ON refetch_meta(selection);
+CREATE INDEX IF NOT EXISTS idx_refetch_meta_document ON refetch_meta(document);
 
 -- types
 CREATE INDEX IF NOT EXISTS idx_types_kind_operation ON types(kind, operation);


### PR DESCRIPTION
This PR adds a `@refetchable` directive that marks a fragment as refetchable on its own with new argument values.

```
  fragment UserInfo on User @refetchable @arguments(filter: { type: "String" }) {
    friends(filter: $filter) { name }
  }
```

- React uses the same  `useFragmentHandle(user, fragment)` that pagination support uses
- Svelte introduces a new  `refetchableFragment(user, fragment)` wrapper that returns a store whose value is { data, variables } plus refetch.


closes #129
