### PR TITLE
Fix "could not find Router context" HMR failure by stabilizing context reference

### DIFF
--- a/.changeset/router-context-hmr.md
+++ b/.changeset/router-context-hmr.md
@@ -1,0 +1,5 @@
+---
+'houdini-react': patch
+---
+
+Fix a "Could not find router context" crash that could occur during development when editing a route file triggered an HMR update.

--- a/packages/houdini-react/runtime/contexts.test.ts
+++ b/packages/houdini-react/runtime/contexts.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'vitest'
+
+import * as contexts from './contexts.js'
+
+const runtimeDir = fileURLToPath(new URL('.', import.meta.url))
+
+function runtimeSourceFiles(dir: string): string[] {
+	return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+		const full = join(dir, entry.name)
+		if (entry.isDirectory()) {
+			return entry.name === 'node_modules' ? [] : runtimeSourceFiles(full)
+		}
+		return /\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name) ? [full] : []
+	})
+}
+
+describe('runtime React contexts', () => {
+	// A React context is a module-level singleton: provider and consumer must share the
+	// object returned by createContext(). When a context is created inside a module that also
+	// exports components/hooks, Vite re-evaluates that module on an HMR update and mints a new
+	// context object, splitting an already-mounted provider from a freshly-bound consumer
+	// ("Could not find router context"). Every context therefore lives in contexts.ts, a
+	// dependency-only leaf module that the HMR graph never re-evaluates. This test fails if a
+	// createContext() call is reintroduced anywhere else in the runtime.
+	test('createContext is only called in the contexts leaf module', () => {
+		const offenders = runtimeSourceFiles(runtimeDir).filter(
+			(file) =>
+				!file.endsWith(`${join('runtime', 'contexts.ts')}`) &&
+				readFileSync(file, 'utf-8').includes('createContext')
+		)
+		expect(offenders).toEqual([])
+	})
+
+	test('the leaf exports every runtime context', () => {
+		for (const name of [
+			'RouterContextObject',
+			'LocationContext',
+			'Is404Context',
+			'PageContext',
+			'StatusContext',
+			'FormStatusContext',
+		] as const) {
+			expect(contexts[name]).toHaveProperty('Provider')
+		}
+	})
+})

--- a/packages/houdini-react/runtime/contexts.ts
+++ b/packages/houdini-react/runtime/contexts.ts
@@ -1,0 +1,54 @@
+import { createContext } from 'react'
+
+import type { Goto } from './routes.js'
+import type { RouterContext } from './routing/Router.js'
+
+// All of the runtime's React contexts are defined in this module on purpose.
+//
+// A React context is a module-level singleton: provider and consumer must hold
+// the *same* object returned by createContext(). When a context is created
+// inside a module that also exports components/hooks (like Router.tsx), Vite's
+// dev server re-evaluates that module on an HMR update (for example when codegen
+// rewrites a neighboring generated unit, or when react-refresh falls back to a
+// full module re-run). Each re-evaluation mints a brand-new context object, and
+// if a consumer rebinds to the new one while the still-mounted provider holds
+// the old one, useContext() reads a context the provider never populated and
+// throws "Could not find router context".
+//
+// This module imports only `react` at runtime (everything else is `import type`,
+// erased at build time), so it is a pure leaf in the dependency graph. Route
+// edits never re-evaluate it, so these context objects keep a stable identity
+// across granular HMR updates. We deliberately avoid a globalThis registry to
+// pin identity: multiple independent Router contexts can legitimately coexist in
+// one process (for example across Astro islands), and a global singleton would
+// wrongly collapse them into one.
+
+export const RouterContextObject = createContext<RouterContext | null>(null)
+
+export const LocationContext = createContext<{
+	pathname: string
+	params: Record<string, any>
+	// the parsed query string of the current url (declared search params coerced to
+	// their scalar type, other keys raw; repeated keys are arrays).
+	search: Record<string, any>
+	// a function to imperatively navigate to a url
+	goto: Goto
+}>({
+	pathname: '',
+	params: {},
+	search: {},
+	goto: () => {},
+})
+
+export const Is404Context = createContext(false)
+
+export const PageContext = createContext<{ params: Record<string, any> }>({ params: {} })
+
+// Mutable ref passed from the server renderer so that a synchronous RoutingError
+// or redirect() can propagate the correct HTTP status/location before streaming.
+export const StatusContext = createContext<{ status: number; location?: string } | null>(null)
+
+// FormStatusContext carries the nearest <Form>'s pending state to useMutationFormStatus(),
+// the no-prop-drilling ergonomic of React's useFormStatus (which only tracks function-action
+// submissions, so it can't see our forms).
+export const FormStatusContext = createContext<{ pending: boolean }>({ pending: false })

--- a/packages/houdini-react/runtime/hooks/useMutationForm.tsx
+++ b/packages/houdini-react/runtime/hooks/useMutationForm.tsx
@@ -3,6 +3,7 @@ import type { MutationArtifact, GraphQLObject, GraphQLVariables } from 'houdini/
 import { coerceFormData, interpolateRedirect } from 'houdini/runtime'
 import React from 'react'
 
+import { FormStatusContext } from '../contexts.js'
 import { useSession, useRoute, useFormResult, useFormToken } from '../routing/Router.js'
 import { useDocumentStore } from './useDocumentStore.js'
 
@@ -40,10 +41,9 @@ export type MutationForm<_Result = any> = {
 	pending: boolean
 }
 
-// FormStatusContext carries the nearest <Form>'s pending state to useMutationFormStatus(),
-// the no-prop-drilling ergonomic of React's useFormStatus (which only tracks function-action
-// submissions, so it can't see our forms).
-const FormStatusContext = React.createContext<{ pending: boolean }>({ pending: false })
+// FormStatusContext (defined in ../contexts.js) carries the nearest <Form>'s pending state
+// to useMutationFormStatus(), the no-prop-drilling ergonomic of React's useFormStatus (which
+// only tracks function-action submissions, so it can't see our forms).
 
 /** useMutationFormStatus reads the pending state of the nearest <Form> from a child. */
 export function useMutationFormStatus(): { pending: boolean } {

--- a/packages/houdini-react/runtime/routing/Router.tsx
+++ b/packages/houdini-react/runtime/routing/Router.tsx
@@ -13,6 +13,12 @@ import type { RouterManifest, RouterPageManifest } from 'houdini/router/types'
 import React from 'react'
 import { useContext, useEffect } from 'react'
 
+import {
+	RouterContextObject as Context,
+	LocationContext,
+	Is404Context,
+	PageContext,
+} from '../contexts.js'
 import { buildHref, scalarUnmarshalers, unmarshalScalars } from '../resolve-href.js'
 import type { Goto } from '../routes.js'
 import { type DocumentHandle, useDocumentHandle } from '../hooks/useDocumentHandle.js'
@@ -611,7 +617,7 @@ export function RouterContextProvider({
 	)
 }
 
-type RouterContext = {
+export type RouterContext = {
 	client: HoudiniClient
 	cache: Cache
 
@@ -661,8 +667,6 @@ export type FormResult = Record<string, { data: any; errors: any }>
 export type PendingCache = SuspenseCache<
 	Promise<void> & { resolve: () => void; reject: (message: string) => void }
 >
-
-const Context = React.createContext<RouterContext | null>(null)
 
 export const useRouterContext = () => {
 	const ctx = React.useContext(Context)
@@ -739,21 +743,6 @@ export function useSession(): [
 
 	return [ctx.session, updateSession]
 }
-
-const LocationContext = React.createContext<{
-	pathname: string
-	params: Record<string, any>
-	// the parsed query string of the current url (declared search params coerced to
-	// their scalar type, other keys raw; repeated keys are arrays).
-	search: Record<string, any>
-	// a function to imperatively navigate to a url
-	goto: Goto
-}>({
-	pathname: '',
-	params: {},
-	search: {},
-	goto: () => {},
-})
 
 export function useQueryResult<_Data extends GraphQLObject, _Input extends GraphQLVariables>(
 	name: string
@@ -1018,7 +1007,8 @@ class NotFoundLayoutBoundary extends React.Component<
 	}
 }
 
-export const Is404Context = React.createContext(false)
+// re-exported (defined in ../contexts.js) so existing `routing` barrel consumers keep working
+export { Is404Context }
 
 export function NotFoundGate({ children }: { children: React.ReactNode }) {
 	const is404 = React.useContext(Is404Context)
@@ -1027,8 +1017,6 @@ export function NotFoundGate({ children }: { children: React.ReactNode }) {
 	}
 	return <>{children}</>
 }
-
-const PageContext = React.createContext<{ params: Record<string, any> }>({ params: {} })
 
 export function PageContextProvider({
 	keys,

--- a/packages/houdini-react/runtime/routing/errors.tsx
+++ b/packages/houdini-react/runtime/routing/errors.tsx
@@ -1,6 +1,8 @@
 import type { GraphQLError } from 'houdini/runtime'
 import React from 'react'
 
+import { StatusContext } from '../contexts.js'
+
 export class GraphQLErrors extends Error {
 	graphqlErrors: GraphQLError[]
 
@@ -73,9 +75,9 @@ export function redirect(status: 300 | 301 | 302 | 303 | 307 | 308, location: st
 	throw new RedirectError(status, location)
 }
 
-// Mutable ref passed from the server renderer so that a synchronous RoutingError
-// or redirect() can propagate the correct HTTP status/location before streaming.
-export const StatusContext = React.createContext<{ status: number; location?: string } | null>(null)
+// StatusContext is defined in ../contexts.js (a dependency-only leaf module) so its
+// identity survives Vite HMR re-evaluation; re-exported here to keep the existing surface.
+export { StatusContext }
 
 type HoudiniErrorBoundaryProps = {
 	errorView: React.ComponentType<{


### PR DESCRIPTION
The Router context module was not stable across HMR fast-refreshes. This PR fixes it by moving the context definition to its own module. I verified the fix by adding a counter at the module level, confirming that Router.tsx was re-evaluated mulltiple times and then confirmed that the new module was only resolved a single time while saving a file