### PR TITLE
Fix @loading query error hanging

### DIFF
--- a/.changeset/loading-error-boundary.md
+++ b/.changeset/loading-error-boundary.md
@@ -1,0 +1,5 @@
+---
+'houdini-react': patch
+---
+
+Fix a query with `@loading` that errors during SSR hanging on its loading state instead of reaching the nearest `+error.tsx` boundary.

--- a/e2e/_api/graphql.mjs
+++ b/e2e/_api/graphql.mjs
@@ -543,7 +543,7 @@ export const resolvers = {
 			}
 
 			if (!user) {
-				throw new Error('User not found', { code: 404 })
+				throw new GraphQLError('User not found', { code: 404 })
 			}
 			return user
 		},

--- a/e2e/react/src/routes/loading-error-link/+page.tsx
+++ b/e2e/react/src/routes/loading-error-link/+page.tsx
@@ -1,0 +1,11 @@
+import { Link } from '$houdini'
+
+// A query-less page whose only job is to link into the erroring @loading route so the e2e
+// suite can exercise a client-side navigation into it (not just the initial SSR load).
+export default function () {
+	return (
+		<Link id="to-loading-error" to="/loading-error">
+			go to loading-error
+		</Link>
+	)
+}

--- a/e2e/react/src/routes/loading-error/+error.tsx
+++ b/e2e/react/src/routes/loading-error/+error.tsx
@@ -1,0 +1,5 @@
+import type { ErrorProps } from './$types'
+
+export default function LoadingErrorError({ errors }: ErrorProps) {
+	return <div id="error-message">{errors[0]?.message}</div>
+}

--- a/e2e/react/src/routes/loading-error/+page.gql
+++ b/e2e/react/src/routes/loading-error/+page.gql
@@ -1,0 +1,5 @@
+query LoadingErrorQuery @loading {
+	user(id: "999", snapshot: "loading-error", delay: 100) {
+		name
+	}
+}

--- a/e2e/react/src/routes/loading-error/+page.tsx
+++ b/e2e/react/src/routes/loading-error/+page.tsx
@@ -1,0 +1,12 @@
+import { isPending } from '$houdini'
+
+import type { PageProps } from './$types'
+
+// A page whose query is marked @loading streams its loading frame inside a Suspense boundary
+// before the query resolves. When the query errors (user id 999 doesn't exist, so the resolver
+// throws) the page must reach the +error.tsx boundary instead of hanging on the loading frame.
+export default function ({ LoadingErrorQuery }: PageProps) {
+	const user = LoadingErrorQuery.user
+
+	return <div id="name">{isPending(user.name) ? 'loading' : user.name}</div>
+}

--- a/e2e/react/src/routes/loading-error/test.ts
+++ b/e2e/react/src/routes/loading-error/test.ts
@@ -1,0 +1,26 @@
+import { test } from '@playwright/test'
+import { routes } from '~/utils/routes'
+import { expect_to_be, goto } from '~/utils/testsHelper.js'
+
+test.describe('@loading query that errors', () => {
+	// A query marked @loading streams its loading frame before the query resolves, so an error
+	// from the API has to be carried to the client; otherwise the page hangs on the loading
+	// state instead of reaching +error.tsx. We cover both entry points into the route.
+
+	// the initial SSR load: the shell flushes with the loading frame, then the API errors and
+	// the error must stream down so the client surfaces it on the boundary after hydration.
+	test('SSR: an erroring @loading query reaches the error boundary', async ({ page }) => {
+		await goto(page, routes.loading_error)
+		await expect_to_be(page, 'User not found', '#error-message')
+	})
+
+	// a client-side navigation into the route: the query is sent from the browser and its error
+	// must unblock the @loading suspense and throw to the boundary.
+	test('client-side nav: an erroring @loading query reaches the error boundary', async ({
+		page,
+	}) => {
+		await goto(page, routes.loading_error_link)
+		await page.click('#to-loading-error')
+		await expect_to_be(page, 'User not found', '#error-message')
+	})
+})

--- a/e2e/react/src/utils/routes.ts
+++ b/e2e/react/src/utils/routes.ts
@@ -25,6 +25,8 @@ export const routes = {
 	pagination_query_offset_variable: '/pagination/query/offset-variable/2',
 	loading_paginated_fragment: '/loading-paginated-fragment',
 	loading_interactive: '/loading-interactive',
+	loading_error: '/loading-error',
+	loading_error_link: '/loading-error-link',
 	refetchable_fragment: '/refetchable-fragment',
 	refetchable_fragment_custom: '/refetchable-fragment-custom',
 	optimistic_keys: '/optimistic-keys',

--- a/packages/houdini-react/runtime/hydration.tsx
+++ b/packages/houdini-react/runtime/hydration.tsx
@@ -26,6 +26,7 @@ declare global {
 		__houdini__auth_url__?: string | null
 		__houdini__pending_artifacts__?: Record<string, QueryArtifact>
 		__houdini__pending_data__?: Record<string, any>
+		__houdini__pending_errors__?: Record<string, any>
 		__houdini__pending_variables__?: Record<string, GraphQLVariables>
 		__houdini__pending_cache__?: any[]
 		__houdini__nav_caches__?: RouterCache
@@ -126,6 +127,26 @@ export function hydrate_page(
 			initialData[artifactName] = observer
 		}
 	}
+
+	// an @loading query that errored streams its errors here (its data is null, so it has no
+	// pending_data entry above). build a store that already carries the errors so the page's
+	// useQueryResult throws to the error boundary instead of hanging on the loading frame.
+	for (const [artifactName, errors] of Object.entries(window.__houdini__pending_errors__ ?? {})) {
+		const artifact = window.__houdini__pending_artifacts__?.[artifactName]
+		if (!artifact) {
+			continue
+		}
+		initialArtifacts[artifactName] = artifact
+		const variables = window.__houdini__pending_variables__?.[artifactName]
+		const observer = window.__houdini__client__!.observe({
+			artifact,
+			cache: window.__houdini__cache__,
+			initialVariables: variables,
+		})
+		observer.update((state) => ({ ...state, fetching: false, errors }))
+		initialData[artifactName] = observer
+	}
+	window.__houdini__pending_errors__ = {}
 
 	if (!window.__houdini__nav_caches__) {
 		window.__houdini__nav_caches__ = router_cache({

--- a/packages/houdini-react/runtime/routing/Router.tsx
+++ b/packages/houdini-react/runtime/routing/Router.tsx
@@ -1,4 +1,4 @@
-import type { GraphQLObject, GraphQLVariables } from 'houdini/runtime'
+import type { GraphQLError, GraphQLObject, GraphQLVariables } from 'houdini/runtime'
 import type { QueryArtifact } from 'houdini/runtime'
 import type { Cache } from 'houdini/runtime/cache'
 import type { DocumentStore, HoudiniClient } from 'houdini/runtime/client'
@@ -19,6 +19,7 @@ import {
 	Is404Context,
 	PageContext,
 } from '../contexts.js'
+import { escapeScriptTag } from '../escape.js'
 import { buildHref, scalarUnmarshalers, unmarshalScalars } from '../resolve-href.js'
 import type { Goto } from '../routes.js'
 import { type DocumentHandle, useDocumentHandle } from '../hooks/useDocumentHandle.js'
@@ -291,6 +292,64 @@ function usePageData({
 			? data_cache.get(artifact.name)!
 			: client.observe({ artifact, cache })
 
+		// surface a query error to the client. an @loading query streams its result while the
+		// document is still open, so on the initial SSR load the client is parked on the loading
+		// frame waiting for this query's pending signal to resolve. unlike the success path the
+		// store carries no data we can hydrate from the cache (errors aren't cache data), so we
+		// stream the errors directly and rebuild an erroring store on the client. without this the
+		// pending signal never resolves and the page hangs on the loading state instead of reaching
+		// the nearest error boundary.
+		function stream_error(errors: GraphQLError[]) {
+			injectToStream?.(`
+				<script>
+				{
+					const artifactName = ${escapeScriptTag(JSON.stringify(artifact.name))}
+					const errors = ${escapeScriptTag(JSON.stringify(errors))}
+					const variables = ${escapeScriptTag(JSON.stringify(observer.state.variables))}
+					const artifact = ${escapeScriptTag(JSON.stringify(artifact))}
+
+					// build a document store that already carries the errors so useQueryResult
+					// throws to the nearest boundary the moment it reads the store
+					const __houdini__error_store__ = (knownArtifact) => {
+						const store = window.__houdini__client__.observe({
+							artifact: knownArtifact ?? artifact,
+							cache: window.__houdini__cache__,
+							initialVariables: variables,
+						})
+						store.update((state) => ({ ...state, fetching: false, errors }))
+						return store
+					}
+
+					// if the client has already hydrated (a client-side navigation to an @loading
+					// route) push the error store straight into the live caches and release the signal
+					if (window.__houdini__nav_caches__) {
+						const caches = window.__houdini__nav_caches__
+						caches.data_cache.set(
+							artifactName,
+							__houdini__error_store__(caches.artifact_cache.get(artifactName))
+						)
+						if (caches.ssr_signals.has(artifactName)) {
+							caches.ssr_signals.get(artifactName).resolve()
+							caches.ssr_signals.delete(artifactName)
+						}
+					} else {
+						// otherwise the page module hasn't run yet (the common @loading case): stash the
+						// error so hydrate_page can build the error store when it sets up the caches
+						const pendingArtifacts = (window.__houdini__pending_artifacts__ =
+							window.__houdini__pending_artifacts__ || {})
+						pendingArtifacts[artifactName] = artifact
+						const pendingVariables = (window.__houdini__pending_variables__ =
+							window.__houdini__pending_variables__ || {})
+						pendingVariables[artifactName] = variables
+						const pendingErrors = (window.__houdini__pending_errors__ =
+							window.__houdini__pending_errors__ || {})
+						pendingErrors[artifactName] = errors
+					}
+				}
+				</script>
+			`)
+		}
+
 		// store the observer immediately so useQueryResult can access it
 		// during SSR rendering before the fetch resolves
 		let resolve: () => void = () => {}
@@ -307,9 +366,12 @@ function usePageData({
 				.then(async () => {
 					data_cache.set(id, observer)
 
-					// if there is an error, signal completion (the error is visible via
-					// useQueryResult reading observer.state.errors) and clean up
+					// if there is an error, stream it to the client (so an @loading query
+					// reaches the error boundary instead of hanging on the loading state) and
+					// clean up. on the client data_cache.set above is enough for useQueryResult
+					// to read the errors and throw; the stream is what carries them across SSR.
 					if (observer.state.errors && observer.state.errors.length > 0) {
+						stream_error(observer.state.errors)
 						ssr_signals.delete(id)
 						resolve()
 						return
@@ -428,7 +490,14 @@ function usePageData({
 					if (err?.name === 'AbortError') {
 						return
 					}
-					reject(err)
+					// a thrown error (e.g. a throwOnError plugin) never lands in observer.state, so
+					// seed it as a synthetic GraphQL error on the store and stream it to the client,
+					// otherwise an @loading query that rejects hangs on the loading state
+					const errors = [{ message: err?.message ?? String(err) }]
+					observer.update((state) => ({ ...state, fetching: false, errors }))
+					data_cache.set(id, observer)
+					stream_error(errors)
+					resolve()
 				})
 		})
 


### PR DESCRIPTION
This PR fixes an issue with @loading queries that was causing errors too hang instead of bubbling up to the error boundary. Now, the error state is streamed to the client and then bubbles up to a `+error` page if its defined