### PR TITLE
Use `import type` for enum imports in generated inputs.ts

### DIFF
--- a/.changeset/inputs-import-type.md
+++ b/.changeset/inputs-import-type.md
@@ -1,0 +1,6 @@
+---
+'houdini-core': patch
+'houdini': patch
+---
+
+Generate the enum imports in `inputs.ts` with `import type` so projects using TypeScript's `verbatimModuleSyntax` no longer fail to compile.

--- a/packages/houdini-core/plugin/schema/inputTypes.go
+++ b/packages/houdini-core/plugin/schema/inputTypes.go
@@ -122,8 +122,10 @@ func generateInputTypeDefinitions(
 		}
 		sort.Strings(enumNames)
 
-		// generate import statement
-		finalContent.WriteString("import { ")
+		// generate import statement - the enum option types are only ever
+		// referenced in type positions, so use `import type` to stay compatible
+		// with TypeScript's verbatimModuleSyntax
+		finalContent.WriteString("import type { ")
 		for i, enumName := range enumNames {
 			if i > 0 {
 				finalContent.WriteString(", ")

--- a/packages/houdini-core/plugin/schema/inputTypes_test.go
+++ b/packages/houdini-core/plugin/schema/inputTypes_test.go
@@ -70,7 +70,7 @@ func TestInputTypeDefinitions(t *testing.T) {
 			targetPath := filepath.Join(config.DefinitionsDirectory(), "inputs.ts")
 
 			expected := tests.Dedent(`
-				import { MyEnum$options, Priority$options, Status$options } from './enums.js';
+				import type { MyEnum$options, Priority$options, Status$options } from './enums.js';
 
 				type ValueOf<T> = T[keyof T];
 


### PR DESCRIPTION
The generated `.houdini/graphql/inputs.ts` imports enum option types with a plain value import, even though they're only ever referenced in type positions within the generated type aliases. Projects using TypeScript's `verbatimModuleSyntax: true` (the default for new SvelteKit projects) fail to compile with **TS1484**, which requires a type-only import for these symbols.


Fixes #1711