### PR TITLE
Fix a batch of generated-type bugs: selection merging, scalar registration, per-document read/write

### DIFF
--- a/.changeset/gentle-planets-shine.md
+++ b/.changeset/gentle-planets-shine.md
@@ -1,0 +1,6 @@
+---
+'houdini-core': patch
+'houdini': patch
+---
+
+Fix generated `$result` types including pipeline-added key fields (e.g. `id`) in interface/union arms the document never selected; fields selected on the abstract type itself still appear in every arm.

--- a/.changeset/khaki-donuts-shout.md
+++ b/.changeset/khaki-donuts-shout.md
@@ -1,0 +1,6 @@
+---
+'houdini-core': patch
+'houdini': patch
+---
+
+Fix custom scalars mapped to non-default TypeScript types (e.g. `URL`, `bigint`) failing the `GraphQLObject` constraint on stores; the generated runtime now registers the project's scalar types with `houdini/runtime`.

--- a/.changeset/olive-poems-repeat.md
+++ b/.changeset/olive-poems-repeat.md
@@ -1,0 +1,7 @@
+---
+'houdini-core': patch
+'houdini': patch
+'houdini-svelte': patch
+---
+
+Fix `cache.read`/`cache.write` and record-level `read`/`write` resolving their types to a union of every document; documents are now matched by their artifact so `data` and `variables` are typed per document.

--- a/.changeset/plenty-crabs-smile.md
+++ b/.changeset/plenty-crabs-smile.md
@@ -1,0 +1,6 @@
+---
+'houdini-core': patch
+'houdini': patch
+---
+
+Fix generated types dropping fields when multiple `@mask_disable` fragments select the same field with different sub-selections; the sub-selections are now merged instead of keeping only the first occurrence.

--- a/.changeset/plenty-crabs-smile.md
+++ b/.changeset/plenty-crabs-smile.md
@@ -3,4 +3,4 @@
 'houdini': patch
 ---
 
-Fix generated types dropping fields when multiple `@mask_disable` fragments select the same field with different sub-selections; the sub-selections are now merged instead of keeping only the first occurrence.
+Fix generated types dropping fields when multiple `@mask_disable` fragments select the same field with different sub-selections; the sub-selections are now merged instead of keeping only the first occurrence. Diamond-shaped `@mask_disable` spreads also no longer produce duplicate keys in the ` $fragments` marker.

--- a/.changeset/shiny-games-hide.md
+++ b/.changeset/shiny-games-hide.md
@@ -1,0 +1,6 @@
+---
+'houdini-core': patch
+'houdini': patch
+---
+
+Fix generated types dropping selections made directly on an interface field when the selection also contains inline fragments; fields like `nodes { id }` and fragment spreads on the interface now appear on the object intersected with the discriminated union.

--- a/.changeset/tough-berries-tell.md
+++ b/.changeset/tough-berries-tell.md
@@ -1,0 +1,6 @@
+---
+'houdini-core': patch
+'houdini': patch
+---
+
+Fix generated types keeping fields optional when a fragment is spread with `@include`/`@skip` in one place and unconditionally in another; the unconditional spread now makes the fields required.

--- a/e2e/react/src/cache-types.types.ts
+++ b/e2e/react/src/cache-types.types.ts
@@ -1,0 +1,107 @@
+// Compile-time type assertions for the imperative cache: the generated CacheTypeDef
+// (in $houdini/runtime/generated) and the cache.get / cache.list / markStale surface.
+// Verified by `tsc --noEmit` — not a Playwright test.
+
+import { cache } from '$houdini'
+import type { MyEnum$options } from '$houdini/graphql/enums'
+import type { CacheTypeDef } from '$houdini/runtime/generated'
+import type { Record as CacheRecord } from '$houdini/runtime/public/record'
+import type { GraphQLObject } from 'houdini/runtime'
+
+export {}
+
+// strict type equality: only resolves to true when A and B are identical
+type Equals<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+	? true
+	: false
+
+type UserFields = CacheTypeDef['types']['User']['fields']
+
+// ── field types come from the schema + scalar config ─────────────────────────
+
+// plain scalars keep their wire type
+const _name: Equals<UserFields['name']['type'], string> = true
+// custom scalars resolve to their configured TypeScript type (DateTime → Date)
+const _birthDate: Equals<UserFields['birthDate']['type'], Date | null> = true
+// enums resolve to the generated $options union
+const _enum: Equals<UserFields['enumValue']['type'], MyEnum$options | null> = true
+// relations resolve to Record proxies of the target type
+const _friends: Equals<UserFields['friendsList']['type'], CacheRecord<CacheTypeDef, 'User'>[]> =
+	true
+
+// field arguments keep their schema types; nullable args are optional
+const _avatarArgs: Equals<UserFields['avatarURL']['args'], { size?: number | null | undefined }> =
+	true
+// required args stay required
+const _testFieldArgs: Equals<UserFields['testField']['args'], { someParam: boolean }> = true
+// fields without arguments are marked never
+const _noArgs: Equals<UserFields['name']['args'], never> = true
+
+// ── the project scalar union is registered with the runtime (issue #1728) ────
+
+// the generated def carries the exact project union
+const _scalars: Equals<CacheTypeDef['scalars'], number | boolean | string | Date | File> = true
+
+// configured scalar outputs satisfy the GraphQLObject constraint every store
+// enforces. File is not in the runtime's fallback union, so this only compiles
+// because the generated runtime augments CacheTypeDef['scalars']
+const _augmentedScalars: { when: Date; upload: File } extends GraphQLObject ? true : false = true
+
+// a type no scalar maps to is still rejected — the union stays project-accurate
+const _unconfiguredScalar: { url: URL } extends GraphQLObject ? true : false = false
+
+// ── cache.get: only schema types, identified by their key fields ─────────────
+
+const user = cache.get('User', { id: '1' })
+const _record: CacheRecord<CacheTypeDef, 'User'> = user
+
+// @ts-expect-error -- NotAType is not a type in the schema
+cache.get('NotAType', { id: '1' })
+
+// @ts-expect-error -- User records are identified by id
+cache.get('User', {})
+
+// ── markStale validates fields and their arguments ────────────────────────────
+
+user.markStale('name')
+user.markStale('testField', { when: { someParam: true } })
+
+// @ts-expect-error -- notAField is not a field of User
+user.markStale('notAField')
+
+user.markStale('testField', {
+	// @ts-expect-error -- someParam is a Boolean
+	when: { someParam: 'yes' },
+})
+
+// cache-level markStale is validated the same way
+cache.markStale('User', { field: 'birthDate' })
+// @ts-expect-error -- notAField is not a field of User
+cache.markStale('User', { field: 'notAField' })
+
+// ── lists: names and filters come from @list directives ──────────────────────
+
+const users = cache.list('PluralUsers')
+// filters keep their schema types, including custom scalars (bornAfter: DateTime)
+users.when({ must: { limit: 2, bornAfter: new Date() } })
+users.append(user)
+
+// @ts-expect-error -- Not_A_List was never declared with @list
+cache.list('Not_A_List')
+
+users.when({
+	must: {
+		// @ts-expect-error -- the limit filter is an Int
+		limit: 'two',
+	},
+})
+
+users.when({
+	must: {
+		// @ts-expect-error -- publishDate is not a filter on PluralUsers
+		publishDate: new Date(),
+	},
+})
+
+// @ts-expect-error -- append takes Record proxies, not raw ids
+users.append('User:1')

--- a/e2e/react/src/cache-types.types.ts
+++ b/e2e/react/src/cache-types.types.ts
@@ -3,10 +3,20 @@
 // Verified by `tsc --noEmit` — not a Playwright test.
 
 import { cache } from '$houdini'
+import type { GuardRow$artifact, GuardRow$data } from '$houdini/artifacts/GuardRow'
+import type { HelloWorld$artifact, HelloWorld$result } from '$houdini/artifacts/HelloWorld'
+import type {
+	RefetchableUserInfo$artifact,
+	RefetchableUserInfo$data,
+} from '$houdini/artifacts/RefetchableUserInfo'
+import type {
+	RouteParamsUserInfo$artifact,
+	RouteParamsUserInfo$result,
+} from '$houdini/artifacts/RouteParamsUserInfo'
 import type { MyEnum$options } from '$houdini/graphql/enums'
 import type { CacheTypeDef } from '$houdini/runtime/generated'
 import type { Record as CacheRecord } from '$houdini/runtime/public/record'
-import type { GraphQLObject } from 'houdini/runtime'
+import type { GraphQLObject, QueryArtifact } from 'houdini/runtime'
 
 export {}
 
@@ -105,3 +115,68 @@ users.when({
 
 // @ts-expect-error -- append takes Record proxies, not raw ids
 users.append('User:1')
+
+// ── cache.read / cache.write are typed per document, matched by artifact ─────
+
+declare const helloWorld: { artifact: HelloWorld$artifact }
+declare const userInfoQuery: { artifact: RouteParamsUserInfo$artifact }
+
+// read resolves the document's own result type, not a union of every query
+const helloData = cache.read({ query: helloWorld }).data
+const _helloData: Equals<typeof helloData, HelloWorld$result | null> = true
+
+const userData = cache.read({ query: userInfoQuery, variables: { id: '1' } }).data
+const _userData: Equals<typeof userData, RouteParamsUserInfo$result | null> = true
+
+// write validates data and variables against the matched document
+cache.write({ query: userInfoQuery, data: { user: { name: 'x' } }, variables: { id: '1' } })
+
+cache.write({
+	query: userInfoQuery,
+	// @ts-expect-error -- name is a String
+	data: { user: { name: 2 } },
+	variables: { id: '1' },
+})
+
+cache.write({
+	query: userInfoQuery,
+	data: { user: { name: 'x' } },
+	// @ts-expect-error -- id is an ID
+	variables: { id: false },
+})
+
+// a document the runtime doesn't know about fails closed with the error
+// sentinel instead of silently matching another document
+declare const unknownQuery: { artifact: QueryArtifact }
+const unknownData = cache.read({ query: unknownQuery }).data
+const _unknownData: Equals<
+	typeof unknownData,
+	| 'Encountered unknown query.Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
+	| null
+> = true
+
+// ── record.read / record.write match fragments the same way ──────────────────
+
+declare const guardRow: { artifact: GuardRow$artifact }
+declare const refetchableUserInfo: { artifact: RefetchableUserInfo$artifact }
+
+const guardData = user.read({ fragment: guardRow }).data
+const _guardData: Equals<typeof guardData, GuardRow$data | null> = true
+
+user.write({ fragment: guardRow, data: { id: '1', name: 'x' } })
+
+user.write({
+	fragment: guardRow,
+	// @ts-expect-error -- GuardRow selects id and name
+	data: { id: '1' },
+})
+
+// fragment variables resolve per fragment too
+const refetchableData = user.read({ fragment: refetchableUserInfo, variables: { size: 2 } }).data
+const _refetchableData: Equals<typeof refetchableData, RefetchableUserInfo$data | null> = true
+
+user.read({
+	fragment: refetchableUserInfo,
+	// @ts-expect-error -- size is an Int
+	variables: { size: 'big' },
+})

--- a/packages/houdini-core/plugin/documents/artifacts/selection_conditional_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_conditional_test.go
@@ -301,7 +301,9 @@ export type TestQuery$input = {
 };
 
 export type TestQuery$unmasked = {
-	readonly node: {} & (({
+	readonly node: {
+		readonly id: string;
+	} & (({
 		readonly firstName: string;
 		readonly id: string;
 		readonly __typename: "User";

--- a/packages/houdini-core/plugin/documents/artifacts/selection_lists_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_lists_test.go
@@ -1385,7 +1385,15 @@ export type AnimalQuery$result = {
 export type AnimalQuery$input = null | undefined;
 
 export type AnimalQuery$unmasked = {
-	readonly animals: {} & (({
+	readonly animals: {
+		readonly pageInfo: {
+			readonly __typename: "PageInfo";
+			readonly endCursor: string | null;
+			readonly hasNextPage: boolean;
+			readonly hasPreviousPage: boolean;
+			readonly startCursor: string | null;
+		};
+	} & (({
 		readonly edges: ({
 			readonly __typename: "MonkeyEdge";
 			readonly node: {

--- a/packages/houdini-core/plugin/documents/artifacts/selection_lists_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_lists_test.go
@@ -1769,11 +1769,9 @@ export type Entities = {
 export type Entities$result = {
 	readonly entities: ({} & (({
 		readonly name: string;
-		readonly id: string;
 		readonly __typename: "Cat";
 	}) | ({
 		readonly name: string;
-		readonly id: string;
 		readonly __typename: "User";
 	})))[];
 };

--- a/packages/houdini-core/plugin/documents/artifacts/selection_loading_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_loading_test.go
@@ -547,7 +547,11 @@ export type Query = {
 };
 
 export type Query$result = {
-	readonly catOwners: ({} & (({
+	readonly catOwners: ({
+		readonly cats: ({
+			readonly id: string;
+		})[];
+	} & (({
 		readonly firstName: string;
 		readonly __typename: "User";
 	}) | ({
@@ -568,7 +572,12 @@ export type Query$result = {
 export type Query$input = null | undefined;
 
 export type Query$unmasked = {
-	readonly catOwners: ({} & (({
+	readonly catOwners: ({
+		readonly cats: ({
+			readonly __typename: "Cat";
+			readonly id: string;
+		})[];
+	} & (({
 		readonly cats: ({
 			readonly __typename: "Cat";
 			readonly id: string;

--- a/packages/houdini-core/plugin/documents/artifacts/selection_loading_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_loading_test.go
@@ -549,7 +549,6 @@ export type Query = {
 export type Query$result = {
 	readonly catOwners: ({} & (({
 		readonly firstName: string;
-		readonly id: string;
 		readonly __typename: "User";
 	}) | ({
 		readonly " $fragments"?: {};
@@ -739,11 +738,9 @@ export type Query = {
 export type Query$result = {
 	readonly entities: ({} & (({
 		readonly name: string;
-		readonly id: string;
 		readonly __typename: "Cat";
 	}) | ({
 		readonly firstName: string;
-		readonly id: string;
 		readonly __typename: "User";
 	}) | ({
 		readonly " $fragments"?: {};
@@ -1089,11 +1086,9 @@ export type Query = {
 export type Query$result = {
 	readonly entities: ({} & (({
 		readonly name: string;
-		readonly id: string;
 		readonly __typename: "Cat";
 	}) | ({
 		readonly firstName: string;
-		readonly id: string;
 		readonly __typename: "User";
 	}) | ({
 		readonly " $fragments"?: {};
@@ -1275,11 +1270,9 @@ export type Query = {
 export type Query$result = {
 	readonly entities: ({} & (({
 		readonly name: string;
-		readonly id: string;
 		readonly __typename: "Cat";
 	}) | ({
 		readonly firstName: string;
-		readonly id: string;
 		readonly __typename: "User";
 	}) | ({
 		readonly " $fragments"?: {};
@@ -1288,11 +1281,9 @@ export type Query$result = {
 } | {
 	readonly entities: ({} & (({
 		readonly name: LoadingType;
-		readonly id: LoadingType;
 		readonly __typename: "Cat";
 	}) | ({
 		readonly firstName: LoadingType;
-		readonly id: LoadingType;
 		readonly __typename: "User";
 	}) | ({
 		readonly " $fragments"?: {};
@@ -1533,11 +1524,9 @@ export type Query = {
 export type Query$result = {
 	readonly entities: ({} & (({
 		readonly name: string;
-		readonly id: string;
 		readonly __typename: "Cat";
 	}) | ({
 		readonly firstName: string;
-		readonly id: string;
 		readonly __typename: "User";
 	}) | ({
 		readonly " $fragments"?: {};
@@ -1545,7 +1534,6 @@ export type Query$result = {
 	})))[];
 	readonly b: ({} & (({
 		readonly firstName: string;
-		readonly id: string;
 		readonly __typename: "User";
 	}) | ({
 		readonly " $fragments"?: {};
@@ -1554,11 +1542,9 @@ export type Query$result = {
 } | {
 	readonly entities: ({} & (({
 		readonly name: LoadingType;
-		readonly id: LoadingType;
 		readonly __typename: "Cat";
 	}) | ({
 		readonly firstName: LoadingType;
-		readonly id: LoadingType;
 		readonly __typename: "User";
 	}) | ({
 		readonly " $fragments"?: {};

--- a/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
@@ -3543,7 +3543,6 @@ export type RefetchInline$result = {
 			readonly bestFriend: {
 				readonly id: string;
 			} | null;
-			readonly id: string;
 			readonly __typename: "User";
 		})) | null;
 	};
@@ -3557,7 +3556,6 @@ export type RefetchInline$optimistic = {
 			readonly bestFriend: {
 				readonly id: string;
 			} | null;
-			readonly id: string;
 			readonly __typename: "User";
 		})) | null;
 	};

--- a/packages/houdini-core/plugin/documents/artifacts/selection_pagination_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_pagination_test.go
@@ -1751,7 +1751,6 @@ export type TestQuery$result = {
 		readonly edges: ({
 			readonly node: {} & (({
 				readonly firstName: string;
-				readonly id: string;
 				readonly __typename: "User";
 			}) | ({
 				readonly " $fragments"?: {};

--- a/packages/houdini-core/plugin/documents/artifacts/selection_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_test.go
@@ -907,7 +907,6 @@ export type TestQuery = {
 export type TestQuery$result = {
 	readonly friends: ({} & (({
 		readonly firstName: string;
-		readonly id: string;
 		readonly __typename: "User";
 	}) | ({
 		readonly " $fragments"?: {};
@@ -1089,7 +1088,6 @@ export type Friends$result = {
 		readonly __typename: "Cat";
 	}) | ({
 		readonly name: string;
-		readonly id: string;
 		readonly __typename: "User";
 	}) | ({
 		readonly " $fragments"?: {};

--- a/packages/houdini-core/plugin/documents/artifacts/selection_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_test.go
@@ -907,6 +907,9 @@ export type TestQuery = {
 export type TestQuery$result = {
 	readonly friends: ({} & (({
 		readonly firstName: string;
+		readonly " $fragments": {
+			A: {};
+		};
 		readonly __typename: "User";
 	}) | ({
 		readonly " $fragments"?: {};
@@ -1924,8 +1927,12 @@ export type NestedQuery = {
 };
 
 export type NestedQuery$result = {
-	readonly node: {} & (({
+	readonly node: {
 		readonly id: string;
+		readonly " $fragments": {
+			NodeDetails: {};
+		};
+	} & (({
 		readonly " $fragments": {
 			UserThings: {};
 		};
@@ -1939,7 +1946,9 @@ export type NestedQuery$result = {
 export type NestedQuery$input = null | undefined;
 
 export type NestedQuery$unmasked = {
-	readonly node: {} & (({
+	readonly node: {
+		readonly id: string;
+	} & (({
 		readonly id: string;
 		readonly name: string;
 		readonly __typename: "User";
@@ -2098,7 +2107,9 @@ export type TestQuery$result = {
 export type TestQuery$input = null | undefined;
 
 export type TestQuery$unmasked = {
-	readonly node: {} & (({
+	readonly node: {
+		readonly id: string;
+	} & (({
 		readonly id: string;
 		readonly __typename: "User";
 	}) | ({
@@ -2245,7 +2256,9 @@ export type TestQuery$result = {
 export type TestQuery$input = null | undefined;
 
 export type TestQuery$unmasked = {
-	readonly node: {} & (({
+	readonly node: {
+		readonly id: string;
+	} & (({
 		readonly field: string | null;
 		readonly id: string;
 		readonly __typename: "User";

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
@@ -1582,7 +1582,7 @@ func convertLeafType(
 	case "SCALAR":
 		typeStr = convertScalarType(kind, typeName, ctx.ProjectConfig, false)
 		if scalarCfg, ok := ctx.ProjectConfig.Scalars[typeName]; ok && scalarCfg.Module != "" {
-			ctx.ScalarImports[scalarImportStatement(scalarCfg)] = true
+			ctx.ScalarImports[ScalarImportStatement(scalarCfg)] = true
 		}
 	}
 
@@ -1595,11 +1595,11 @@ func convertLeafType(
 	return ApplyTypeModifiers(typeStr, modifiers, false)
 }
 
-// scalarImportStatement builds the TypeScript import statement for a custom scalar.
+// ScalarImportStatement builds the TypeScript import statement for a custom scalar.
 // The identifier is the root part of the type name (before any "."), so
 // { type: "Temporal.Instant", module: "temporal-polyfill" } → import type { Temporal } from 'temporal-polyfill'
 // { type: "MyDate", module: "./my-date", default: true }    → import type MyDate from './my-date'
-func scalarImportStatement(cfg plugins.ScalarConfig) string {
+func ScalarImportStatement(cfg plugins.ScalarConfig) string {
 	identifier := cfg.Type
 	if dot := strings.Index(identifier, "."); dot != -1 {
 		identifier = identifier[:dot]

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
@@ -130,9 +130,12 @@ func expandMaskedSpreads(
 					// a duplicate occurrence still contributes its sub-selection:
 					// two unmasked fragments can select the same field with
 					// different children and the type has to describe the union of
-					// both. the kept node is shared with the collected documents
-					// so it's cloned the first time it grows
-					if len(sel.Children) > 0 {
+					// both. an explicit occurrence also makes a field the pipeline
+					// auto-added (internal, hidden from the type) part of the type.
+					// the kept node is shared with the collected documents so it's
+					// cloned the first time it changes
+					makesVisible := kept.Internal && !sel.Internal
+					if len(sel.Children) > 0 || makesVisible {
 						if !mergedFields[name] {
 							clone := kept.Clone(false)
 							clone.Children = slices.Clone(kept.Children)
@@ -146,6 +149,9 @@ func expandMaskedSpreads(
 							kept = clone
 						}
 						kept.Children = append(kept.Children, sel.Children...)
+						if makesVisible {
+							kept.Internal = false
+						}
 					}
 					// an occurrence that is always present wins over a conditional one
 					if !conditional {

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
@@ -861,6 +861,21 @@ func generateInterfaceUnionTypeWithLoading(
 	// Process all inline fragments, including nested ones
 	processInlineFragments(selection.Children)
 
+	// fields selected on the abstract field itself (e.g. `nodes { id }`) reach the
+	// arms only as the pipeline-distributed internal copies, so they stay visible.
+	// any other internal field (auto-added keys) is hidden from the generated type,
+	// matching the top-level selection generator
+	explicitAbstractFields := map[string]bool{}
+	for _, child := range selection.Children {
+		if child.Kind == "field" && !child.Internal {
+			name := child.FieldName
+			if child.Alias != nil {
+				name = *child.Alias
+			}
+			explicitAbstractFields[name] = true
+		}
+	}
+
 	// Filter concrete types to only include those that are possible for this field
 	// This ensures we only generate union members for types that can actually appear
 	var filteredTypes []string
@@ -894,6 +909,18 @@ func generateInterfaceUnionTypeWithLoading(
 		}
 		fragmentChildren, optionalFields := expandMaskedSpreads(ctx, collectedDocs, allChildren, typeName)
 		for _, fragmentChild := range fragmentChildren {
+			// internal (pipeline-added) fields are hidden from the generated type
+			// unless they distribute an explicit abstract-level selection into the
+			// arm; $unmasked includes every server-visible field
+			if fragmentChild.Internal && !unmasked {
+				name := fragmentChild.FieldName
+				if fragmentChild.Alias != nil {
+					name = *fragmentChild.Alias
+				}
+				if !explicitAbstractFields[name] {
+					continue
+				}
+			}
 			// Skip __typename fields from fragments - we'll add the discriminated version
 			if fragmentChild.Kind == "field" && fragmentChild.FieldName != "__typename" {
 				var fieldType string

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
@@ -68,6 +68,9 @@ func expandMaskedSpreads(
 	result := make([]*collected.Selection, 0, len(selections))
 	optionalFields := map[*collected.Selection]bool{}
 	seenFields := map[string]*collected.Selection{}
+	fieldIndex := map[string]int{}
+	mergedFields := map[string]bool{}
+	seenSpreads := map[string]bool{}
 	seenFragments := map[string]bool{}
 
 	// satisfied returns true when every object of parentType matches the condition
@@ -81,8 +84,13 @@ func expandMaskedSpreads(
 		for _, sel := range sels {
 			switch sel.Kind {
 			case "fragment":
-				// always keep the spread for the " $fragments" marker
-				result = append(result, sel)
+				// keep the spread for the " $fragments" marker, once per fragment
+				// (merged duplicate fields can carry the same spread through
+				// several paths and the marker object can't repeat a key)
+				if !seenSpreads[sel.FieldName] {
+					seenSpreads[sel.FieldName] = true
+					result = append(result, sel)
+				}
 
 				if !spreadDisablesMasking(ctx.ProjectConfig, sel) {
 					continue
@@ -119,6 +127,26 @@ func expandMaskedSpreads(
 					name = *sel.Alias
 				}
 				if kept, ok := seenFields[name]; ok {
+					// a duplicate occurrence still contributes its sub-selection:
+					// two unmasked fragments can select the same field with
+					// different children and the type has to describe the union of
+					// both. the kept node is shared with the collected documents
+					// so it's cloned the first time it grows
+					if len(sel.Children) > 0 {
+						if !mergedFields[name] {
+							clone := kept.Clone(false)
+							clone.Children = slices.Clone(kept.Children)
+							if optionalFields[kept] {
+								delete(optionalFields, kept)
+								optionalFields[clone] = true
+							}
+							result[fieldIndex[name]] = clone
+							seenFields[name] = clone
+							mergedFields[name] = true
+							kept = clone
+						}
+						kept.Children = append(kept.Children, sel.Children...)
+					}
 					// an occurrence that is always present wins over a conditional one
 					if !conditional {
 						delete(optionalFields, kept)
@@ -126,6 +154,7 @@ func expandMaskedSpreads(
 					continue
 				}
 				seenFields[name] = sel
+				fieldIndex[name] = len(result)
 				if conditional {
 					optionalFields[sel] = true
 				}
@@ -848,109 +877,105 @@ func generateInterfaceUnionTypeWithLoading(
 	for _, typeName := range filteredTypes {
 		// Build the type literal for this possible type
 		var fields []string
-		fieldSet := make(map[string]bool) // Track fields to avoid duplicates
 
-		// Process all fragments that apply to this type
+		// expand every fragment that applies to this type in a single pass so a
+		// field selected by more than one fragment keeps the union of its
+		// sub-selections instead of only the first occurrence (duplicates are
+		// merged inside expandMaskedSpreads)
+		allChildren := []*collected.Selection{}
 		for _, fragment := range fragmentsByType[typeName] {
-			// inline the fields of any fragment spread that disables masking
-			fragmentChildren, optionalFields := expandMaskedSpreads(ctx, collectedDocs, fragment.Children, typeName)
-			// Include fields from this inline fragment
-			for _, fragmentChild := range fragmentChildren {
-				if fragmentChild.Kind == "field" && fragmentChild.FieldName != "__typename" {
-					// Skip __typename fields from fragments - we'll add the discriminated version
-					// Also skip if we've already added this field
-					if fieldSet[fragmentChild.FieldName] {
-						continue
-					}
-					fieldSet[fragmentChild.FieldName] = true
+			allChildren = append(allChildren, fragment.Children...)
+		}
+		fragmentChildren, optionalFields := expandMaskedSpreads(ctx, collectedDocs, allChildren, typeName)
+		for _, fragmentChild := range fragmentChildren {
+			// Skip __typename fields from fragments - we'll add the discriminated version
+			if fragmentChild.Kind == "field" && fragmentChild.FieldName != "__typename" {
+				var fieldType string
 
-					var fieldType string
-
-					if isLoadingState {
-						// In loading state, all fields become LoadingType
-						fieldType = "LoadingType"
-					} else {
-						// Check if this field has children (nested object type)
-						if len(fragmentChild.Children) > 0 {
-							// Check if this field has inline fragments (interface/union type)
-							hasInlineFragments := false
-							for _, child := range fragmentChild.Children {
-								if child.Kind == "inline_fragment" {
-									hasInlineFragments = true
-									break
-								}
+				if isLoadingState {
+					// In loading state, all fields become LoadingType
+					fieldType = "LoadingType"
+				} else {
+					// Check if this field has children (nested object type)
+					if len(fragmentChild.Children) > 0 {
+						// Check if this field has inline fragments (interface/union type)
+						hasInlineFragments := false
+						for _, child := range fragmentChild.Children {
+							if child.Kind == "inline_fragment" {
+								hasInlineFragments = true
+								break
 							}
+						}
 
-							if hasInlineFragments {
-								// Interface/Union type - generate union with discriminators
-								unionType := generateInterfaceUnionType(
+						if hasInlineFragments {
+							// Interface/Union type - generate union with discriminators
+							unionType := generateInterfaceUnionType(
+								ctx,
+								fragmentChild,
+								readonly,
+								collectedDocs,
+								unmasked,
+								indentLevel+1,
+							)
+
+							// Apply type modifiers (lists, nullability) to the union type
+							modifiers := ""
+							if fragmentChild.TypeModifiers != nil {
+								modifiers = *fragmentChild.TypeModifiers
+							}
+							fieldType = ApplyTypeModifiers(
+								unionType,
+								modifiers,
+								false,
+							) // Output type
+						} else {
+							// Regular nested object type
+							childType, childErr := generateSelectionType(ctx, fragmentChild.Children, readonly, indentLevel+1, fragmentChild.FieldType, collectedDocs, unmasked)
+							if childErr != nil {
+								// Fallback to simple type conversion on error
+								fieldType = convertLeafType(
 									ctx,
-									fragmentChild,
-									readonly,
+									fragmentChild.FieldType,
+									fragmentChild.TypeModifiers,
 									collectedDocs,
-									unmasked,
-									indentLevel+1,
 								)
-
-								// Apply type modifiers (lists, nullability) to the union type
+							} else {
+								// Apply type modifiers (lists, nullability) using the proper function
 								modifiers := ""
 								if fragmentChild.TypeModifiers != nil {
 									modifiers = *fragmentChild.TypeModifiers
 								}
-								fieldType = ApplyTypeModifiers(
-									unionType,
-									modifiers,
-									false,
-								) // Output type
-							} else {
-								// Regular nested object type
-								childType, childErr := generateSelectionType(ctx, fragmentChild.Children, readonly, indentLevel+1, fragmentChild.FieldType, collectedDocs, unmasked)
-								if childErr != nil {
-									// Fallback to simple type conversion on error
-									fieldType = convertLeafType(
-										ctx,
-										fragmentChild.FieldType,
-										fragmentChild.TypeModifiers,
-										collectedDocs,
-									)
-								} else {
-									// Apply type modifiers (lists, nullability) using the proper function
-									modifiers := ""
-									if fragmentChild.TypeModifiers != nil {
-										modifiers = *fragmentChild.TypeModifiers
-									}
-									fieldType = ApplyTypeModifiers(childType, modifiers, false) // Output type
-								}
+								fieldType = ApplyTypeModifiers(childType, modifiers, false) // Output type
 							}
-						} else {
-							fieldType = convertLeafType(
-								ctx,
-								fragmentChild.FieldType,
-								fragmentChild.TypeModifiers,
-								collectedDocs,
-							)
 						}
+					} else {
+						fieldType = convertLeafType(
+							ctx,
+							fragmentChild.FieldType,
+							fragmentChild.TypeModifiers,
+							collectedDocs,
+						)
 					}
-
-					// fields inlined through a conditionally included spread might be
-					// missing from the response so they are typed as optional
-					optional := ""
-					if optionalFields[fragmentChild] {
-						optional = "?"
-					}
-
-					fields = append(
-						fields,
-						fmt.Sprintf(
-							"%s%s%s%s: %s;",
-							fieldIndent,
-							readonlyPrefix,
-							fragmentChild.FieldName,
-							optional,
-							fieldType,
-						),
-					)
 				}
+
+				// fields inlined through a conditionally included spread might be
+				// missing from the response so they are typed as optional
+				optional := ""
+				if optionalFields[fragmentChild] {
+					optional = "?"
+				}
+
+				fields = append(
+					fields,
+					fmt.Sprintf(
+						"%s%s%s%s: %s;",
+						fieldIndent,
+						readonlyPrefix,
+						fragmentChild.FieldName,
+						optional,
+						fieldType,
+					),
+				)
 			}
 		}
 

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
@@ -96,18 +96,26 @@ func expandMaskedSpreads(
 					continue
 				}
 				// guard against revisiting a fragment (the spec forbids cycles but
-				// we don't want a malformed document to hang the generator)
-				if seenFragments[sel.FieldName] {
+				// we don't want a malformed document to hang the generator). the one
+				// revisit allowed is an unconditional spread of a fragment that was
+				// only expanded under @include/@skip: re-walking routes its fields
+				// through the duplicate branch below, which clears their optionality.
+				// conditionality is inherited down the walk, so a nested self-spread
+				// can never upgrade the walk it's part of and each fragment expands
+				// at most twice
+				spreadConditional := conditional || spreadIsConditional(sel)
+				if expandedUnconditionally, expanded := seenFragments[sel.FieldName]; expanded &&
+					(expandedUnconditionally || spreadConditional) {
 					continue
 				}
-				seenFragments[sel.FieldName] = true
+				seenFragments[sel.FieldName] = !spreadConditional
 
 				definition, ok := collectedDocs.Selections[sel.FieldName]
 				if !ok || !satisfied(definition.TypeCondition) {
 					continue
 				}
 
-				walk(definition.Selections, true, conditional || spreadIsConditional(sel))
+				walk(definition.Selections, true, spreadConditional)
 
 			case "inline_fragment":
 				// inline fragments pulled out of an expanded definition can't be

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
@@ -869,18 +869,47 @@ func generateInterfaceUnionTypeWithLoading(
 	// Process all inline fragments, including nested ones
 	processInlineFragments(selection.Children)
 
-	// fields selected on the abstract field itself (e.g. `nodes { id }`) reach the
-	// arms only as the pipeline-distributed internal copies, so they stay visible.
-	// any other internal field (auto-added keys) is hidden from the generated type,
-	// matching the top-level selection generator
-	explicitAbstractFields := map[string]bool{}
-	for _, child := range selection.Children {
-		if child.Kind == "field" && !child.Internal {
-			name := child.FieldName
-			if child.Alias != nil {
-				name = *child.Alias
+	// selections made on the abstract field itself (fields like `nodes { id }`,
+	// fragment spreads on the field's own type) apply to every possible type, so
+	// they become the object intersected with the arm union. internal
+	// (pipeline-added) fields stay hidden here just like at the top level, and
+	// __typename is left to the arms' discriminated literals. a spread whose type
+	// condition is narrower than the field type only applies to some objects, so
+	// its marker is routed to the matching arms instead of the shared object.
+	// the loading variant keeps the empty object: its fields are generated from
+	// the loading-annotated arms only
+	sharedType := "{}"
+	if !isLoadingState {
+		sharedChildren := []*collected.Selection{}
+		for _, child := range selection.Children {
+			if child.Kind == "inline_fragment" || child.Internal ||
+				(child.Kind == "field" && child.FieldName == "__typename") {
+				continue
 			}
-			explicitAbstractFields[name] = true
+			if child.Kind == "fragment" {
+				if definition, ok := collectedDocs.Selections[child.FieldName]; ok {
+					condition := definition.TypeCondition
+					if condition != "" && condition != selection.FieldType &&
+						!collectedDocs.PossibleTypes[condition][selection.FieldType] {
+						fragName := child.FieldName
+						if child.FragmentRef != nil {
+							fragName = *child.FragmentRef
+						}
+						for typeName := range concreteTypesSet {
+							if condition == typeName || collectedDocs.PossibleTypes[condition][typeName] {
+								namedFragmentsByType[typeName] = append(namedFragmentsByType[typeName], fragName)
+							}
+						}
+						continue
+					}
+				}
+			}
+			sharedChildren = append(sharedChildren, child)
+		}
+		if len(sharedChildren) > 0 {
+			if generated, err := generateSelectionType(ctx, sharedChildren, readonly, indentLevel, selection.FieldType, collectedDocs, unmasked); err == nil {
+				sharedType = generated
+			}
 		}
 	}
 
@@ -917,17 +946,12 @@ func generateInterfaceUnionTypeWithLoading(
 		}
 		fragmentChildren, optionalFields := expandMaskedSpreads(ctx, collectedDocs, allChildren, typeName)
 		for _, fragmentChild := range fragmentChildren {
-			// internal (pipeline-added) fields are hidden from the generated type
-			// unless they distribute an explicit abstract-level selection into the
-			// arm; $unmasked includes every server-visible field
+			// internal (pipeline-added) fields are hidden from the generated type,
+			// matching the top-level selection generator; $unmasked includes every
+			// server-visible field. explicit abstract-level selections surface in
+			// the shared object above, not the arms
 			if fragmentChild.Internal && !unmasked {
-				name := fragmentChild.FieldName
-				if fragmentChild.Alias != nil {
-					name = *fragmentChild.Alias
-				}
-				if !explicitAbstractFields[name] {
-					continue
-				}
+				continue
 			}
 			// Skip __typename fields from fragments - we'll add the discriminated version
 			if fragmentChild.Kind == "field" && fragmentChild.FieldName != "__typename" {
@@ -1099,10 +1123,10 @@ func generateInterfaceUnionTypeWithLoading(
 
 	// Create the union type
 	if isLoadingState {
-		unionType := fmt.Sprintf("({} & (%s))", strings.Join(unionParts, " | "))
+		unionType := fmt.Sprintf("(%s & (%s))", sharedType, strings.Join(unionParts, " | "))
 		return unionType
 	} else {
-		unionType := fmt.Sprintf("{} & (%s)", strings.Join(unionParts, " | "))
+		unionType := fmt.Sprintf("%s & (%s)", sharedType, strings.Join(unionParts, " | "))
 		return unionType
 	}
 }

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/documents_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/documents_test.go
@@ -1005,13 +1005,11 @@ func TestTypescriptGeneration(t *testing.T) {
 						export type UnionAbstractQuery$result = {
 							readonly entities: ({} & (({
 								readonly kitty: boolean;
-								readonly id: string;
 								readonly isAnimal: boolean;
 								readonly names: (string | null)[];
 								readonly __typename: "Cat";
 							}) | ({
 								readonly firstName: string;
-								readonly id: string;
 								readonly admin: boolean | null;
 								readonly age: number | null;
 								readonly __typename: "User";
@@ -1066,7 +1064,6 @@ func TestTypescriptGeneration(t *testing.T) {
 							readonly entities: ({} & (({
 								readonly isAnimal: boolean;
 								readonly kitty: boolean;
-								readonly id: string;
 								readonly __typename: "Cat";
 							}) | ({
 								readonly " $fragments"?: {};
@@ -1248,7 +1245,6 @@ func TestTypescriptGeneration(t *testing.T) {
 
 						export type NodeQuery$result = {
 							readonly node: {} & (({
-								readonly id: string;
 								readonly " $fragments": {
 									UserFrag: {};
 								};

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/documents_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/documents_test.go
@@ -747,16 +747,16 @@ func TestTypescriptGeneration(t *testing.T) {
 						};
 
 						export type ComplexQuery$result = {
-							readonly nodes: ({} & (({
+							readonly nodes: ({
+								readonly id: string;
+							} & (({
 								readonly kitty: boolean;
 								readonly names: (string | null)[];
-								readonly id: string;
 								readonly __typename: "Cat";
 							}) | ({
 								readonly firstName: string;
 								readonly admin: boolean | null;
 								readonly age: number | null;
-								readonly id: string;
 								readonly __typename: "User";
 							}) | ({
 								readonly " $fragments"?: {};
@@ -767,7 +767,9 @@ func TestTypescriptGeneration(t *testing.T) {
 						export type ComplexQuery$input = null | undefined;
 
 						export type ComplexQuery$unmasked = {
-							readonly nodes: ({} & (({
+							readonly nodes: ({
+								readonly id: string;
+							} & (({
 								readonly id: string;
 								readonly kitty: boolean;
 								readonly names: (string | null)[];
@@ -874,7 +876,9 @@ func TestTypescriptGeneration(t *testing.T) {
 						};
 
 						export type MixedQuery$result = {
-							readonly nodes: ({} & (({
+							readonly nodes: ({
+								readonly id: string;
+							} & (({
 								readonly id: string;
 								readonly kitty: boolean;
 								readonly __typename: "Cat";
@@ -891,7 +895,9 @@ func TestTypescriptGeneration(t *testing.T) {
 						export type MixedQuery$input = null | undefined;
 
 						export type MixedQuery$unmasked = {
-							readonly nodes: ({} & (({
+							readonly nodes: ({
+								readonly id: string;
+							} & (({
 								readonly id: string;
 								readonly kitty: boolean;
 								readonly __typename: "Cat";

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/masking_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/masking_test.go
@@ -247,6 +247,41 @@ func TestTypescriptFragmentMasking(t *testing.T) {
 				},
 			},
 			{
+				Name: "unconditional spread upgrades a conditional expansion",
+				Pass: true,
+				Input: []string{
+					`query MaskQuery($show: Boolean!) {
+						user(id: "1") {
+							id
+							...MaskUserInfo @mask_disable @include(if: $show)
+							...MaskOuter @mask_disable
+						}
+					}`,
+					`fragment MaskUserInfo on User {
+						nickname
+						age
+					}`,
+					`fragment MaskOuter on User {
+						...MaskUserInfo @mask_disable
+					}`,
+				},
+				Extra: map[string]any{
+					"MaskQuery": tests.Dedent(`
+						export type MaskQuery$result = {
+							readonly user: {
+								readonly id: string;
+								readonly nickname: string | null;
+								readonly age: number | null;
+								readonly " $fragments": {
+									MaskUserInfo: {};
+									MaskOuter: {};
+								};
+							};
+						};
+					`),
+				},
+			},
+			{
 				Name: "defaultFragmentMasking disable inlines without a directive",
 				Pass: true,
 				ProjectConfig: func(config *plugins.ProjectConfig) {

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/masking_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/masking_test.go
@@ -400,6 +400,45 @@ func TestTypescriptMaskDisableMerging(t *testing.T) {
 				},
 			},
 			{
+				Name: "diamond spreads emit a single fragment marker",
+				Pass: true,
+				Input: []string{
+					`fragment DiamondA on Item {
+						...DiamondB @mask_disable
+						...DiamondC @mask_disable
+						meta {
+							label
+						}
+					}`,
+					`fragment DiamondB on Item {
+						...DiamondC @mask_disable
+						id
+					}`,
+					`fragment DiamondC on Item {
+						details {
+							__typename
+						}
+					}`,
+				},
+				Extra: map[string]any{
+					"DiamondA": tests.Dedent(`
+						export type DiamondA$data = {
+							readonly details: {
+								readonly __typename: string;
+							} | null;
+							readonly id: string;
+							readonly meta: {
+								readonly label: string;
+							};
+							readonly " $fragments": {
+								DiamondB: {};
+								DiamondC: {};
+							};
+						};
+					`),
+				},
+			},
+			{
 				Name: "overlapping fields inside a union arm are merged",
 				Pass: true,
 				Input: []string{

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/masking_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/masking_test.go
@@ -476,7 +476,6 @@ func TestTypescriptMaskDisableMerging(t *testing.T) {
 										readonly label: string;
 										readonly color: string;
 									};
-									readonly id: string;
 									readonly __typename: "TextDetail";
 								}) | ({
 									readonly " $fragments"?: {};

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/masking_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/masking_test.go
@@ -286,6 +286,176 @@ func TestTypescriptFragmentMasking(t *testing.T) {
 	})
 }
 
+// when several unmasked fragments select the same field with different
+// sub-selections the generated type has to describe the union of every
+// occurrence's children, not just the first one (issue #1727)
+func TestTypescriptMaskDisableMerging(t *testing.T) {
+	tests.RunTable(t, tests.Table[config.PluginConfig, *plugin.HoudiniCore]{
+		Schema: `
+			type Query {
+				item: Item!
+			}
+
+			type Item {
+				id: ID!
+				meta: Meta!
+				details: Detail
+			}
+
+			type Meta {
+				label: String!
+				color: String!
+			}
+
+			union Detail = TextDetail | ImageDetail
+
+			type TextDetail {
+				id: ID!
+				text: String!
+				meta: Meta!
+			}
+
+			type ImageDetail {
+				id: ID!
+				url: String!
+			}
+		`,
+		VerifyTest: func(t *testing.T, plugin *plugin.HoudiniCore, test tests.Test[config.PluginConfig]) {
+			config, err := plugin.DB.ProjectConfig(context.Background())
+			require.NoError(t, err)
+
+			for docName, expected := range test.Extra {
+				typeDefs, err := afero.ReadFile(plugin.Fs, config.ArtifactTypePath(docName))
+				require.NoError(t, err)
+				require.Contains(t, string(typeDefs), expected)
+			}
+		},
+		Tests: []tests.Test[config.PluginConfig]{
+			{
+				Name: "overlapping object sub-selections are merged",
+				Pass: true,
+				Input: []string{
+					`query MergeQuery {
+						item {
+							...ItemLabel @mask_disable
+							...ItemColor @mask_disable
+						}
+					}`,
+					`fragment ItemLabel on Item {
+						meta {
+							label
+						}
+					}`,
+					`fragment ItemColor on Item {
+						meta {
+							color
+						}
+					}`,
+				},
+				Extra: map[string]any{
+					"MergeQuery": tests.Dedent(`
+						export type MergeQuery$result = {
+							readonly item: {
+								readonly meta: {
+									readonly label: string;
+									readonly color: string;
+								};
+								readonly " $fragments": {
+									ItemLabel: {};
+									ItemColor: {};
+								};
+							};
+						};
+					`),
+				},
+			},
+			{
+				Name: "a narrow union selection does not erase inline fragments",
+				Pass: true,
+				Input: []string{
+					`query MergeQuery {
+						item {
+							...DetailType @mask_disable
+							...DetailContent @mask_disable
+						}
+					}`,
+					`fragment DetailType on Item {
+						details {
+							__typename
+						}
+					}`,
+					`fragment DetailContent on Item {
+						details {
+							__typename
+							... on TextDetail {
+								text
+							}
+						}
+					}`,
+				},
+				Extra: map[string]any{
+					"MergeQuery": tests.Dedent(`
+						readonly text: string;
+					`),
+				},
+			},
+			{
+				Name: "overlapping fields inside a union arm are merged",
+				Pass: true,
+				Input: []string{
+					`query MergeQuery {
+						item {
+							...TextLabel @mask_disable
+							...TextColor @mask_disable
+						}
+					}`,
+					`fragment TextLabel on Item {
+						details {
+							... on TextDetail {
+								meta {
+									label
+								}
+							}
+						}
+					}`,
+					`fragment TextColor on Item {
+						details {
+							... on TextDetail {
+								meta {
+									color
+								}
+							}
+						}
+					}`,
+				},
+				Extra: map[string]any{
+					"MergeQuery": tests.Dedent(`
+						export type MergeQuery$result = {
+							readonly item: {
+								readonly details: {} & (({
+									readonly meta: {
+										readonly label: string;
+										readonly color: string;
+									};
+									readonly id: string;
+									readonly __typename: "TextDetail";
+								}) | ({
+									readonly " $fragments"?: {};
+									readonly __typename: "non-exhaustive; don't match this";
+								})) | null;
+								readonly " $fragments": {
+									TextLabel: {};
+									TextColor: {};
+								};
+							};
+						};
+					`),
+				},
+			},
+		},
+	})
+}
+
 // @includeListID stamps an opaque __id onto the list value so the client can
 // pass it back via @listID; the generated type must reflect that intersection
 func TestTypescriptIncludeListID(t *testing.T) {

--- a/packages/houdini-core/plugin/runtime/imperativeCache.go
+++ b/packages/houdini-core/plugin/runtime/imperativeCache.go
@@ -90,6 +90,23 @@ func generateCacheTypeDefContent(
 	}
 	content.WriteString(cacheTypeDef)
 
+	// register the project's scalar output types with the houdini runtime: the
+	// published CacheTypeDef interface can't declare `scalars` itself (an interface
+	// merge would have to redeclare the exact same type), so GraphQLValue picks the
+	// union up from this augmentation. without it, custom scalars mapped to types
+	// like URL or bigint fail the GraphQLObject constraint on every store
+	scalarUnion, err := generateScalarUnion(ctx, db)
+	if err != nil {
+		return "", err
+	}
+	content.WriteString(fmt.Sprintf(`
+declare module 'houdini/runtime' {
+	interface CacheTypeDef {
+		scalars: %s
+	}
+}
+`, scalarUnion))
+
 	return content.String(), nil
 }
 
@@ -102,6 +119,24 @@ func generateImports(
 
 	// Base import for Record type
 	imports.WriteString(`import type { Record } from "./public/record";` + "\n")
+
+	// custom scalars can map to types that live in a module (e.g. Temporal.Instant);
+	// the CacheTypeDef scalars member and the houdini/runtime augmentation both
+	// reference those types so their imports have to be part of the file
+	scalarImports := map[string]bool{}
+	for _, scalarCfg := range projectConfig.Scalars {
+		if scalarCfg.Module != "" {
+			scalarImports[typescript.ScalarImportStatement(scalarCfg)] = true
+		}
+	}
+	sortedScalarImports := make([]string, 0, len(scalarImports))
+	for stmt := range scalarImports {
+		sortedScalarImports = append(sortedScalarImports, stmt)
+	}
+	sort.Strings(sortedScalarImports)
+	for _, stmt := range sortedScalarImports {
+		imports.WriteString(stmt + ";\n")
+	}
 
 	// Collect all documents with their argument info in a single query
 	documentsWithArgs, err := getDocumentsWithArguments(ctx, db)
@@ -926,14 +961,18 @@ func generateScalarUnion(
 	// our goal here is to generate a typescript-safe union of the runtime values that could be seen in a selection (the default scalars + any custom config)
 	scalarValues := []string{"number", "boolean", "string"}
 
+	// sorted so the generated file is stable across runs
+	customTypes := []string{}
 	err := db.StepQuery(ctx, `
 		SELECT DISTINCT "type" from scalar_config
 	`, nil, func(stmt plugins.Row) {
-		scalarValues = append(scalarValues, stmt.GetText("type"))
+		customTypes = append(customTypes, stmt.GetText("type"))
 	})
 	if err != nil {
 		return "", err
 	}
+	sort.Strings(customTypes)
+	scalarValues = append(scalarValues, customTypes...)
 
 	return strings.Join(scalarValues, " | "), nil
 }

--- a/packages/houdini-core/plugin/runtime/imperativeCache.go
+++ b/packages/houdini-core/plugin/runtime/imperativeCache.go
@@ -163,12 +163,13 @@ func generateImports(
 		return sortedDocs[i].Name < sortedDocs[j].Name
 	})
 
-	// Generate imports for queries first
+	// Generate imports for queries first. The $artifact type keys the queries list
+	// so cache.read/write can match a document handle to its result/input types
 	for _, doc := range sortedDocs {
 		if doc.Kind == "query" {
 			imports.WriteString(fmt.Sprintf(
-				`import type { %s$result, %s$input } from "../artifacts/%s";`+"\n",
-				doc.Name, doc.Name, doc.Name,
+				`import type { %s$result, %s$input, %s$artifact } from "../artifacts/%s";`+"\n",
+				doc.Name, doc.Name, doc.Name, doc.Name,
 			))
 		}
 	}
@@ -196,7 +197,8 @@ func generateImports(
 		))
 	}
 
-	// Generate imports for fragments
+	// Generate imports for fragments. The $artifact type keys each type's fragments
+	// list so record.read/write can match a fragment handle to its data/input types
 	for _, doc := range sortedDocs {
 		if doc.Kind == "fragment" {
 			// Use pre-loaded argument info
@@ -207,8 +209,8 @@ func generateImports(
 				))
 			}
 			imports.WriteString(fmt.Sprintf(
-				`import type { %s$data } from "../artifacts/%s";`+"\n",
-				doc.Name, doc.Name,
+				`import type { %s$data, %s$artifact } from "../artifacts/%s";`+"\n",
+				doc.Name, doc.Name, doc.Name,
 			))
 		}
 	}
@@ -787,11 +789,18 @@ func getFragmentsByType(
 		fragmentName := stmt.ColumnText(1)
 		hasArgs := stmt.ColumnInt(2) == 1
 
+		// each tuple is keyed by the fragment's artifact type so read/write can
+		// match a fragment handle (anything carrying the artifact) to its types
 		var fragmentTuple string
 		if hasArgs {
-			fragmentTuple = fmt.Sprintf("[any, %s$data, %s$input]", fragmentName, fragmentName)
+			fragmentTuple = fmt.Sprintf(
+				"[%s$artifact, %s$data, %s$input]",
+				fragmentName,
+				fragmentName,
+				fragmentName,
+			)
 		} else {
-			fragmentTuple = fmt.Sprintf("[any, %s$data, never]", fragmentName)
+			fragmentTuple = fmt.Sprintf("[%s$artifact, %s$data, never]", fragmentName, fragmentName)
 		}
 
 		fragmentsByType[typeName] = append(fragmentsByType[typeName], fragmentTuple)
@@ -999,9 +1008,13 @@ func generateQueriesSection(
 	// Sort for consistent output
 	sort.Strings(queryNames)
 
-	// Generate tuples
+	// Generate tuples, each keyed by the query's artifact type so read/write can
+	// match a document handle (anything carrying the artifact) to its types
 	for _, name := range queryNames {
-		queryTuples = append(queryTuples, fmt.Sprintf("[any, %s$result, %s$input]", name, name))
+		queryTuples = append(
+			queryTuples,
+			fmt.Sprintf("[%s$artifact, %s$result, %s$input]", name, name, name),
+		)
 	}
 
 	if len(queryTuples) == 0 {

--- a/packages/houdini-core/plugin/runtime/imperativeCache_test.go
+++ b/packages/houdini-core/plugin/runtime/imperativeCache_test.go
@@ -149,14 +149,14 @@ func TestGenerateImperativeCacheTypeDefs(t *testing.T) {
 
 			expected := tests.Dedent(`
 				import type { Record } from "./public/record";
-				import type { TestQuery$result, TestQuery$input } from "../artifacts/TestQuery";
-				import type { TestQueryNoArgs$result, TestQueryNoArgs$input } from "../artifacts/TestQueryNoArgs";
+				import type { TestQuery$result, TestQuery$input, TestQuery$artifact } from "../artifacts/TestQuery";
+				import type { TestQueryNoArgs$result, TestQueryNoArgs$input, TestQueryNoArgs$artifact } from "../artifacts/TestQueryNoArgs";
 				import type { MyEnum$options } from "$houdini/graphql/enums";
 				import type { NestedUserFilter } from "$houdini/graphql/inputs";
 				import type { UserFilter } from "$houdini/graphql/inputs";
-				import type { UserInfo$data } from "../artifacts/UserInfo";
+				import type { UserInfo$data, UserInfo$artifact } from "../artifacts/UserInfo";
 				import type { UserInfoWithArguments$input } from "../artifacts/UserInfoWithArguments";
-				import type { UserInfoWithArguments$data } from "../artifacts/UserInfoWithArguments";
+				import type { UserInfoWithArguments$data, UserInfoWithArguments$artifact } from "../artifacts/UserInfoWithArguments";
 
 				export declare type CacheTypeDef = {
 						types: {
@@ -365,7 +365,7 @@ func TestGenerateImperativeCacheTypeDefs(t *testing.T) {
 										args: never;
 									};
 								};
-								fragments: [[any, UserInfo$data, never], [any, UserInfoWithArguments$data, UserInfoWithArguments$input]];
+								fragments: [[UserInfo$artifact, UserInfo$data, never], [UserInfoWithArguments$artifact, UserInfoWithArguments$data, UserInfoWithArguments$input]];
 							};
 						};
 						lists: {
@@ -386,7 +386,7 @@ func TestGenerateImperativeCacheTypeDefs(t *testing.T) {
 								filters: never;
 							};
 						};
-						queries: [[any, TestQuery$result, TestQuery$input], [any, TestQueryNoArgs$result, TestQueryNoArgs$input]];
+						queries: [[TestQuery$artifact, TestQuery$result, TestQuery$input], [TestQueryNoArgs$artifact, TestQueryNoArgs$result, TestQueryNoArgs$input]];
 						scalars: number | boolean | string;
 				};
 

--- a/packages/houdini-core/plugin/runtime/imperativeCache_test.go
+++ b/packages/houdini-core/plugin/runtime/imperativeCache_test.go
@@ -8,6 +8,7 @@ import (
 
 	"code.houdinigraphql.com/packages/houdini-core/config"
 	"code.houdinigraphql.com/packages/houdini-core/plugin"
+	"code.houdinigraphql.com/plugins"
 	"code.houdinigraphql.com/plugins/tests"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
@@ -388,6 +389,12 @@ func TestGenerateImperativeCacheTypeDefs(t *testing.T) {
 						queries: [[any, TestQuery$result, TestQuery$input], [any, TestQueryNoArgs$result, TestQueryNoArgs$input]];
 						scalars: number | boolean | string;
 				};
+
+				declare module 'houdini/runtime' {
+					interface CacheTypeDef {
+						scalars: number | boolean | string
+					}
+				}
 			`)
 
 			contents, err := afero.ReadFile(
@@ -396,6 +403,73 @@ func TestGenerateImperativeCacheTypeDefs(t *testing.T) {
 			)
 			require.NoError(t, err)
 			require.Equal(t, expected, strings.TrimSpace(string(contents)))
+		},
+	})
+}
+
+// custom scalar output types have to be registered with the houdini runtime
+// (via the CacheTypeDef augmentation) so values like URL or Temporal.Instant
+// satisfy the GraphQLObject constraint on every store (issue #1728)
+func TestGenerateImperativeCacheTypeDefsCustomScalars(t *testing.T) {
+	tests.RunTable(t, tests.Table[config.PluginConfig, *plugin.HoudiniCore]{
+		Schema: `
+			scalar URL
+			scalar Instant
+
+			type Query {
+				user: User
+			}
+
+			type User {
+				id: ID!
+				website: URL
+				createdAt: Instant
+			}
+		`,
+		VerifyTest: func(t *testing.T, plugin *plugin.HoudiniCore, test tests.Test[config.PluginConfig]) {
+			config, err := plugin.DB.ProjectConfig(context.Background())
+			require.NoError(t, err)
+
+			contents, err := afero.ReadFile(
+				plugin.Fs,
+				filepath.Join(config.ProjectRoot, config.RuntimeDir, "runtime", "generated.ts"),
+			)
+			require.NoError(t, err)
+
+			for _, expected := range test.Extra["contains"].([]string) {
+				require.Contains(t, string(contents), expected)
+			}
+		},
+		Tests: []tests.Test[config.PluginConfig]{
+			{
+				Name: "custom scalars are registered with the runtime",
+				Pass: true,
+				ProjectConfig: func(cfg *plugins.ProjectConfig) {
+					cfg.Scalars = map[string]plugins.ScalarConfig{
+						"URL": {
+							Type: "URL",
+						},
+						"Instant": {
+							Type:   "Temporal.Instant",
+							Module: "temporal-polyfill",
+						},
+					}
+				},
+				Input: []string{`query UserQuery { user { id website createdAt } }`},
+				Extra: map[string]any{
+					"contains": []string{
+						`import type { Temporal } from 'temporal-polyfill';`,
+						`scalars: number | boolean | string | Temporal.Instant | URL;`,
+						tests.Dedent(`
+							declare module 'houdini/runtime' {
+								interface CacheTypeDef {
+									scalars: number | boolean | string | Temporal.Instant | URL
+								}
+							}
+						`),
+					},
+				},
+			},
 		},
 	})
 }

--- a/packages/houdini-core/runtime/public/types.ts
+++ b/packages/houdini-core/runtime/public/types.ts
@@ -110,60 +110,58 @@ export type ListType<Def extends CacheTypeDef, Name extends ValidLists<Def>> = P
 // it very responsive.
 
 /**
- * Note on the `_Key extends _Target && _Target extends _Key` check:
- * Sometimes two queries might have a similar shape/inputs, e.g.:
- *
- * query Query1($userId: ID!) {    |    query Query2($userId: ID!) {
- *   user(id: $userId) {           |      user($id: $userId) {
- *     id                          |        id
- *     name                        |        name
- *   }                             |        birthDate
- * }                               |      }
- *                                 |    }
- *
- * To TypeScript, it would look like Query2's result would extend Query1's result.
- * But if Query2 was listed in front of Query1 in the queries array above, `_Key extends _Target` will evaluate to true,
- * causing it to return Query2's input/result types, while you were looking for Query1's input/result types.
- * The additional `_Target extends _Key` ensures that the two objects have exactly the same shape, at least prompting the
- * user for the correct fields.
+ * Each entry in the queries/fragments lists is keyed by the document's artifact type
+ * (`X$artifact`, the type of the generated artifact const). Every artifact carries
+ * unique literal values (name, hash) so the mutual-extends check below identifies
+ * exactly one document — even two documents with identical selections have distinct
+ * hashes. The target can be anything that exposes the artifact (a `graphql()` handle
+ * or a framework store), so matching goes through its `artifact` member.
  */
 
 export type FragmentVariables<_List, _Target> = _List extends [infer Head, ...infer Rest]
 	? Head extends [infer _Key, infer _Value, infer _Input]
-		? _Key extends _Target
-			? _Target extends _Key
-				? _Input
-				: FragmentValue<Rest, _Target>
-			: FragmentValue<Rest, _Target>
+		? _Target extends { artifact: infer _Artifact }
+			? _Artifact extends _Key
+				? _Key extends _Artifact
+					? _Input
+					: FragmentVariables<Rest, _Target>
+				: FragmentVariables<Rest, _Target>
+			: 'Encountered unknown fragment. Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
 		: 'Encountered unknown fragment. Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
 	: 'Encountered unknown fragment. Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
 
 export type FragmentValue<List, _Target> = List extends [infer Head, ...infer Rest]
 	? Head extends [infer _Key, infer _Value, infer _Input]
-		? _Key extends _Target
-			? _Target extends _Key
-				? _Value
+		? _Target extends { artifact: infer _Artifact }
+			? _Artifact extends _Key
+				? _Key extends _Artifact
+					? _Value
+					: FragmentValue<Rest, _Target>
 				: FragmentValue<Rest, _Target>
-			: FragmentValue<Rest, _Target>
+			: 'Encountered unknown fragment. Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
 		: 'Encountered unknown fragment. Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
 	: 'Encountered unknown fragment. Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
 
 export type QueryValue<List, _Target> = List extends [infer Head, ...infer Rest]
 	? Head extends [infer _Key, infer _Value, infer _Input]
-		? _Key extends _Target
-			? _Target extends _Key
-				? _Value
+		? _Target extends { artifact: infer _Artifact }
+			? _Artifact extends _Key
+				? _Key extends _Artifact
+					? _Value
+					: QueryValue<Rest, _Target>
 				: QueryValue<Rest, _Target>
-			: QueryValue<Rest, _Target>
+			: 'Encountered unknown query.Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
 		: 'Encountered unknown query.Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
 	: 'Encountered unknown query.Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
 
 export type QueryInput<List, _Target> = List extends [infer Head, ...infer Rest]
 	? Head extends [infer _Key, infer _Value, infer _Input]
-		? _Key extends _Target
-			? _Target extends _Key
-				? _Input
+		? _Target extends { artifact: infer _Artifact }
+			? _Artifact extends _Key
+				? _Key extends _Artifact
+					? _Input
+					: QueryInput<Rest, _Target>
 				: QueryInput<Rest, _Target>
-			: QueryInput<Rest, _Target>
+			: 'Encountered unknown query.Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
 		: 'Encountered unknown query.Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'
 	: 'Encountered unknown query.Please make sure your runtime is up to date (ie, `vite dev` or `vite build`).'

--- a/packages/houdini-core/runtime/public/types.ts
+++ b/packages/houdini-core/runtime/public/types.ts
@@ -28,8 +28,11 @@ export type CacheTypeDef = {
 	// entries in the tuple are graphql tag, query shape, query input
 	queries: [any, any, any][]
 
-	// a union of valid runtime types (default scalars | config types)
-	scalars: any
+	// a union of valid runtime types (default scalars | config types).
+	// optional so the placeholder generated.ts (which re-exports the published
+	// CacheTypeDef, whose scalars only exist via augmentation) satisfies the
+	// constraint before codegen overwrites it
+	scalars?: any
 }
 
 export type ValidTypes<Def extends CacheTypeDef> = keyof Def['types']

--- a/packages/houdini-svelte/plugin/generate/stores.go
+++ b/packages/houdini-svelte/plugin/generate/stores.go
@@ -212,8 +212,10 @@ func generateQueryStore(
 		return "", err
 	}
 
+	// typeof artifact narrows the store's artifact member to this document's
+	// artifact type so cache.read/write can match the store to its result/input
 	classDeclaration := fmt.Sprintf(
-		"export class %s extends %s<%s$result, %s$input>",
+		"export class %s extends %s<%s$result, %s$input, typeof artifact>",
 		storeName,
 		storeImport.Name,
 		name,
@@ -383,7 +385,7 @@ import type { %s, %s$data, %s$input } from '$houdini/artifacts/%s.js'%s
 
 export type { %s }
 
-export class %s extends %s<%s$data, { %s: any }, %s$input> {
+export class %s extends %s<%s$data, { %s: any }, %s$input, typeof artifact> {
     constructor() {
         super({
             artifact,

--- a/packages/houdini-svelte/plugin/generate/stores_test.go
+++ b/packages/houdini-svelte/plugin/generate/stores_test.go
@@ -195,7 +195,7 @@ export * from './client'
 
 						export type { TestFragment }
 
-						export class TestFragmentStore extends FragmentStore<TestFragment$data, { TestFragment: any }, TestFragment$input> {
+						export class TestFragmentStore extends FragmentStore<TestFragment$data, { TestFragment: any }, TestFragment$input, typeof artifact> {
 						    constructor() {
 						        super({
 						            artifact,
@@ -222,7 +222,7 @@ export * from './client'
 
 						export type { RefetchableUser }
 
-						export class RefetchableUserStore extends FragmentStoreRefetchable<RefetchableUser$data, { RefetchableUser: any }, RefetchableUser$input> {
+						export class RefetchableUserStore extends FragmentStoreRefetchable<RefetchableUser$data, { RefetchableUser: any }, RefetchableUser$input, typeof artifact> {
 						    constructor() {
 						        super({
 						            artifact,
@@ -249,7 +249,7 @@ export * from './client'
 						import artifact from '$houdini/artifacts/TestQuery.js'
 						import type { TestQuery$result, TestQuery$input } from '$houdini/artifacts/TestQuery.js'
 
-						export class TestQueryStore extends QueryStore<TestQuery$result, TestQuery$input> {
+						export class TestQueryStore extends QueryStore<TestQuery$result, TestQuery$input, typeof artifact> {
 						    constructor() {
 						        super({
 						            artifact,
@@ -280,7 +280,7 @@ export * from './client'
 						import artifact from '$houdini/artifacts/TestQuery.js'
 						import type { TestQuery$result, TestQuery$input } from '$houdini/artifacts/TestQuery.js'
 
-						export class TestQueryStore extends QueryStore<TestQuery$result, TestQuery$input> {
+						export class TestQueryStore extends QueryStore<TestQuery$result, TestQuery$input, typeof artifact> {
 						    constructor() {
 						        super({
 						            artifact,
@@ -311,7 +311,7 @@ export * from './client'
 						import artifact from '$houdini/artifacts/TestQuery.js'
 						import type { TestQuery$result, TestQuery$input } from '$houdini/artifacts/TestQuery.js'
 
-						export class TestQueryStore extends QueryStore<TestQuery$result, TestQuery$input> {
+						export class TestQueryStore extends QueryStore<TestQuery$result, TestQuery$input, typeof artifact> {
 						    constructor() {
 						        super({
 						            artifact,
@@ -342,7 +342,7 @@ export * from './client'
 						import artifact from '$houdini/artifacts/TestQuery.js'
 						import type { TestQuery$result, TestQuery$input } from '$houdini/artifacts/TestQuery.js'
 
-						export class TestQueryStore extends QueryStore<TestQuery$result, TestQuery$input> {
+						export class TestQueryStore extends QueryStore<TestQuery$result, TestQuery$input, typeof artifact> {
 						    constructor() {
 						        super({
 						            artifact,
@@ -381,7 +381,7 @@ export * from './client'
 							import artifact from '$houdini/artifacts/TestQuery.js'
 							import type { TestQuery$result, TestQuery$input } from '$houdini/artifacts/TestQuery.js'
 
-							export class TestQueryStore extends QueryStoreCursor<TestQuery$result, TestQuery$input> {
+							export class TestQueryStore extends QueryStoreCursor<TestQuery$result, TestQuery$input, typeof artifact> {
 							    constructor() {
 							        super({
 							            artifact,
@@ -420,7 +420,7 @@ export * from './client'
 							import artifact from '$houdini/artifacts/TestQuery.js'
 							import type { TestQuery$result, TestQuery$input } from '$houdini/artifacts/TestQuery.js'
 
-							export class TestQueryStore extends QueryStoreCursor<TestQuery$result, TestQuery$input> {
+							export class TestQueryStore extends QueryStoreCursor<TestQuery$result, TestQuery$input, typeof artifact> {
 							    constructor() {
 							        super({
 							            artifact,
@@ -455,7 +455,7 @@ export * from './client'
 							import artifact from '$houdini/artifacts/TestQuery.js'
 							import type { TestQuery$result, TestQuery$input } from '$houdini/artifacts/TestQuery.js'
 
-							export class TestQueryStore extends QueryStoreOffset<TestQuery$result, TestQuery$input> {
+							export class TestQueryStore extends QueryStoreOffset<TestQuery$result, TestQuery$input, typeof artifact> {
 							    constructor() {
 							        super({
 							            artifact,
@@ -487,7 +487,7 @@ export * from './client'
 
 							export type { TestFragment }
 
-							export class TestFragmentStore extends FragmentStore<TestFragment$data, { TestFragment: any }, TestFragment$input> {
+							export class TestFragmentStore extends FragmentStore<TestFragment$data, { TestFragment: any }, TestFragment$input, typeof artifact> {
 							    constructor() {
 							        super({
 							            artifact,
@@ -521,7 +521,7 @@ export * from './client'
 
 						export type { TestFragment }
 
-						export class TestFragmentStore extends FragmentStoreCursor<TestFragment$data, { TestFragment: any }, TestFragment$input> {
+						export class TestFragmentStore extends FragmentStoreCursor<TestFragment$data, { TestFragment: any }, TestFragment$input, typeof artifact> {
 						    constructor() {
 						        super({
 						            artifact,
@@ -559,7 +559,7 @@ export * from './client'
 
 						export type { TestFragment }
 
-						export class TestFragmentStore extends FragmentStoreCursor<TestFragment$data, { TestFragment: any }, TestFragment$input> {
+						export class TestFragmentStore extends FragmentStoreCursor<TestFragment$data, { TestFragment: any }, TestFragment$input, typeof artifact> {
 						    constructor() {
 						        super({
 						            artifact,
@@ -594,7 +594,7 @@ export * from './client'
 
 						export type { TestFragment }
 
-						export class TestFragmentStore extends FragmentStoreOffset<TestFragment$data, { TestFragment: any }, TestFragment$input> {
+						export class TestFragmentStore extends FragmentStoreOffset<TestFragment$data, { TestFragment: any }, TestFragment$input, typeof artifact> {
 						    constructor() {
 						        super({
 						            artifact,

--- a/packages/houdini-svelte/runtime/stores/fragment.ts
+++ b/packages/houdini-svelte/runtime/stores/fragment.ts
@@ -21,14 +21,17 @@ export class FragmentStore<
 	_Data extends GraphQLObject,
 	_ReferenceType extends {},
 	_Input extends GraphQLVariables = GraphQLVariables,
+	// generated stores narrow this to their document's artifact type so a store
+	// can be matched back to its data/input types (e.g. by record.read/write)
+	_Artifact extends FragmentArtifact = FragmentArtifact,
 > {
-	artifact: FragmentArtifact
+	artifact: _Artifact
 	name: string
 	kind = CompiledFragmentKind
 
 	protected context: HoudiniFetchContext | null = null
 
-	constructor({ artifact, storeName }: { artifact: FragmentArtifact; storeName: string }) {
+	constructor({ artifact, storeName }: { artifact: _Artifact; storeName: string }) {
 		this.artifact = artifact
 		this.name = storeName
 	}

--- a/packages/houdini-svelte/runtime/stores/pagination/fragment.ts
+++ b/packages/houdini-svelte/runtime/stores/pagination/fragment.ts
@@ -26,16 +26,19 @@ import type { OffsetFragmentStoreInstance } from '../../types.js'
 import { FragmentStore } from '../fragment.js'
 import type { StoreConfig } from '../query.js'
 
-type FragmentStoreConfig<_Data extends GraphQLObject, _Input> = StoreConfig<
-	_Data,
+type FragmentStoreConfig<
+	_Data extends GraphQLObject,
 	_Input,
-	FragmentArtifact
-> & { paginationArtifact: QueryArtifact }
+	_Artifact extends FragmentArtifact = FragmentArtifact,
+> = StoreConfig<_Data, _Input, _Artifact> & { paginationArtifact: QueryArtifact }
 
 export class BasePaginatedFragmentStore<
 	_Data extends GraphQLObject,
 	_ReferenceType extends {},
 	_Input,
+	// generated stores narrow this to their document's artifact type so a store
+	// can be matched back to its data/input types (e.g. by record.read/write)
+	_Artifact extends FragmentArtifact = FragmentArtifact,
 > {
 	// all paginated stores need to have a flag to distinguish from other fragment stores
 	paginated = true
@@ -43,9 +46,9 @@ export class BasePaginatedFragmentStore<
 	protected paginationArtifact: QueryArtifact
 	name: string
 	kind = CompiledFragmentKind
-	artifact: FragmentArtifact
+	artifact: _Artifact
 
-	constructor(config: FragmentStoreConfig<_Data, _Input>) {
+	constructor(config: FragmentStoreConfig<_Data, _Input, _Artifact>) {
 		this.paginationArtifact = config.paginationArtifact
 		this.name = config.storeName
 		this.artifact = config.artifact
@@ -93,7 +96,8 @@ export class FragmentStoreCursor<
 	_Data extends GraphQLObject,
 	_ReferenceType extends {},
 	_Input extends GraphQLVariables,
-> extends BasePaginatedFragmentStore<_Data, _ReferenceType, _Input> {
+	_Artifact extends FragmentArtifact = FragmentArtifact,
+> extends BasePaginatedFragmentStore<_Data, _ReferenceType, _Input, _Artifact> {
 	// we want to add the cursor-based fetch to the return value of get
 	get(initialValue: _Data | { [fragmentKey]: _ReferenceType } | null) {
 		const base = new FragmentStore<_Data, {}, _Input>({
@@ -286,7 +290,8 @@ export class FragmentStoreOffset<
 	_Data extends GraphQLObject,
 	_ReferenceType extends {},
 	_Input extends GraphQLVariables,
-> extends BasePaginatedFragmentStore<_Data, _ReferenceType, _Input> {
+	_Artifact extends FragmentArtifact = FragmentArtifact,
+> extends BasePaginatedFragmentStore<_Data, _ReferenceType, _Input, _Artifact> {
 	get(initialValue: _Data | null): OffsetFragmentStoreInstance<_Data, _Input> {
 		const base = new FragmentStore<_Data, {}, _Input>({
 			artifact: this.artifact,

--- a/packages/houdini-svelte/runtime/stores/pagination/query.ts
+++ b/packages/houdini-svelte/runtime/stores/pagination/query.ts
@@ -2,6 +2,7 @@ import { extractPageInfo } from 'houdini/runtime'
 import { cursorHandlers, offsetHandlers } from 'houdini/runtime'
 import type {
 	GraphQLObject,
+	QueryArtifact,
 	QueryResult,
 	CursorHandlers,
 	OffsetHandlers,
@@ -30,7 +31,8 @@ export type CursorStoreResult<
 export class QueryStoreCursor<
 	_Data extends GraphQLObject,
 	_Input extends GraphQLVariables | null | undefined,
-> extends QueryStore<_Data, _Input> {
+	_Artifact extends QueryArtifact = QueryArtifact,
+> extends QueryStore<_Data, _Input, _Artifact> {
 	// all paginated stores need to have a flag to distinguish from other query stores
 	paginated = true
 
@@ -130,7 +132,8 @@ export class QueryStoreCursor<
 export class QueryStoreOffset<
 	_Data extends GraphQLObject,
 	_Input extends GraphQLVariables | null | undefined,
-> extends QueryStore<_Data, _Input> {
+	_Artifact extends QueryArtifact = QueryArtifact,
+> extends QueryStore<_Data, _Input, _Artifact> {
 	// all paginated stores need to have a flag to distinguish from other query stores
 	paginated = true
 

--- a/packages/houdini-svelte/runtime/stores/query.ts
+++ b/packages/houdini-svelte/runtime/stores/query.ts
@@ -29,7 +29,10 @@ import { BaseStore } from './base.js'
 export class QueryStore<
 	_Data extends GraphQLObject,
 	_Input extends GraphQLVariables | null | undefined,
-> extends BaseStore<_Data, _Input, QueryArtifact> {
+	// generated stores narrow this to their document's artifact type so a store
+	// can be matched back to its result/input types (e.g. by cache.read/write)
+	_Artifact extends QueryArtifact = QueryArtifact,
+> extends BaseStore<_Data, _Input, _Artifact> {
 	// whether the store requires variables for input
 	variables: boolean
 
@@ -42,7 +45,7 @@ export class QueryStore<
 	// the string identifying the store
 	protected storeName: string
 
-	constructor({ artifact, storeName, variables }: StoreConfig<_Data, _Input, QueryArtifact>) {
+	constructor({ artifact, storeName, variables }: StoreConfig<_Data, _Input, _Artifact>) {
 		super({
 			artifact,
 		})

--- a/packages/houdini-svelte/runtime/stores/refetchable.ts
+++ b/packages/houdini-svelte/runtime/stores/refetchable.ts
@@ -16,11 +16,11 @@ import { getSession } from '../session.js'
 import { FragmentStore } from './fragment.js'
 import type { StoreConfig } from './query.js'
 
-type RefetchableFragmentStoreConfig<_Data extends GraphQLObject, _Input> = StoreConfig<
-	_Data,
+type RefetchableFragmentStoreConfig<
+	_Data extends GraphQLObject,
 	_Input,
-	FragmentArtifact
-> & { refetchArtifact: QueryArtifact }
+	_Artifact extends FragmentArtifact = FragmentArtifact,
+> = StoreConfig<_Data, _Input, _Artifact> & { refetchArtifact: QueryArtifact }
 
 // the value handed back to components subscribing to a refetchable fragment store
 export type RefetchableFragmentResult<_Data extends GraphQLObject, _Input> = {
@@ -42,15 +42,18 @@ export class FragmentStoreRefetchable<
 	_Data extends GraphQLObject,
 	_ReferenceType extends {},
 	_Input extends GraphQLVariables,
+	// generated stores narrow this to their document's artifact type so a store
+	// can be matched back to its data/input types (e.g. by record.read/write)
+	_Artifact extends FragmentArtifact = FragmentArtifact,
 > {
 	kind = CompiledFragmentKind
-	artifact: FragmentArtifact
+	artifact: _Artifact
 	name: string
 	// a flag the refetchableFragment() helper looks for to validate the store
 	refetchable = true
 	protected refetchArtifact: QueryArtifact
 
-	constructor(config: RefetchableFragmentStoreConfig<_Data, _Input>) {
+	constructor(config: RefetchableFragmentStoreConfig<_Data, _Input, _Artifact>) {
 		this.artifact = config.artifact
 		this.name = config.storeName
 		this.refetchArtifact = config.refetchArtifact

--- a/packages/houdini/src/runtime/types.ts
+++ b/packages/houdini/src/runtime/types.ts
@@ -235,11 +235,15 @@ export type GraphQLDefaultScalar = string | number | boolean
 // Extracts CacheTypeDef['componentFields'] when declared by an augmentation, otherwise never.
 type CacheComponentFields = CacheTypeDef extends { componentFields: infer CF } ? CF : never
 
+// Extracts CacheTypeDef['scalars'] when declared by an augmentation (the generated runtime
+// registers the project's scalar output types), otherwise a permissive default.
+type CacheScalars = CacheTypeDef extends { scalars: infer S } ? S : GraphQLDefaultScalar | Date
+
 // GraphQLValue covers raw wire types, project scalar outputs (CacheTypeDef['scalars']),
 // and any injected framework value such as component fields (registered via CacheTypeDef augmentation).
 export type GraphQLValue =
 	| GraphQLDefaultScalar
-	| CacheTypeDef['scalars']
+	| CacheScalars
 	| CacheComponentFields
 	| symbol
 	| null
@@ -570,12 +574,12 @@ export const CachePolicy = {
 
 export type CachePolicies = ValuesOf<typeof CachePolicy>
 
-// CacheTypeDef is an interface so frameworks can augment it.
-// - scalars: custom scalar output types for this project
+// CacheTypeDef is an interface so the generated runtime and frameworks can augment it.
+// - scalars: declared by the generated runtime with the project's scalar output types
+//   (it can't be declared here — a merged redeclaration would have to match exactly)
 // - componentFields: optional; frameworks augment this to register injectable component types
 export interface CacheTypeDef {
 	types: {}
 	lists: {}
 	queries: []
-	scalars: boolean | number | string | Date
 }


### PR DESCRIPTION
This PR fixes the recent set of issues reported by @GodTamIt - thanks for reporting them!

-When multiple `@mask_disable` fragments select the same field with different sub-selections, the generated type kept only the first occurrence (a `details { __typename }` spread could collapse a whole union to `{ __typename: string }`). Sub-selections are now merged, matching what the artifact pipeline already does.
- Markers are now deduped, and a field that the pipeline auto-added internally becomes visible when a fragment selects it explicitly.
- The published runtime hardcoded the scalar union to `boolean | number | string | Date`. The generated runtime now registers the project's actual scalar union via `declare module 'houdini/runtime'` (same mechanism as `componentFields`). Note: a project that doesn't map any scalar to `Date` will now correctly reject `Date` values that were previously accepted by accident.
-  Tuples are now keyed by each document's `$artifact` type and matched through the handle's `artifact` member, which works for both React handles and Svelte stores (store classes gained a defaulted `_Artifact` generic, so hand-written usage is source-compatible)

Closes #1727, closes #1726, closes #1728, closes #1725