### PR TITLE
Only send x-houdini-request on same-origin requests (#1738)

### DIFF
--- a/.changeset/same-origin-csrf-header.md
+++ b/.changeset/same-origin-csrf-header.md
@@ -1,0 +1,6 @@
+---
+'houdini-core': patch
+'houdini': patch
+---
+
+Only send the `x-houdini-request` header on same-origin requests, so client-side requests to a remote API no longer fail CORS preflight.

--- a/packages/houdini-core/runtime/plugins/fetch.test.ts
+++ b/packages/houdini-core/runtime/plugins/fetch.test.ts
@@ -52,6 +52,47 @@ test('sends a spec-compliant GraphQL-over-HTTP request', async () => {
 	})
 })
 
+test('sends the x-houdini-request CSRF marker on same-origin requests', async () => {
+	// the marker gates CORS-simple bodies (uploads) on the router's own endpoint
+	vi.stubGlobal('location', {
+		href: 'http://localhost:5173/',
+		origin: 'http://localhost:5173',
+	})
+	try {
+		for (const target of ['/_api', 'http://localhost:5173/_api']) {
+			const fetchMock = fakeResponse({ body: { data: { viewer: null } } })
+			const store = createStore({ pipeline: [fetchPlugin(target)] })
+			await store.send({ fetch: fetchMock })
+
+			const [, args] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+			expect(args.headers).toMatchObject({ 'x-houdini-request': 'true' })
+		}
+	} finally {
+		vi.unstubAllGlobals()
+	}
+})
+
+test('does not send the x-houdini-request marker to a cross-origin api', async () => {
+	// a custom header turns an otherwise-simple request into a preflighted one the
+	// remote api's CORS config has no reason to allow (#1738)
+	vi.stubGlobal('location', {
+		href: 'http://localhost:5173/',
+		origin: 'http://localhost:5173',
+	})
+	try {
+		const fetchMock = fakeResponse({ body: { data: { viewer: null } } })
+		const store = createStore({
+			pipeline: [fetchPlugin('https://api.example.com/graphql')],
+		})
+		await store.send({ fetch: fetchMock })
+
+		const [, args] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+		expect(args.headers).not.toHaveProperty('x-houdini-request')
+	} finally {
+		vi.unstubAllGlobals()
+	}
+})
+
 test('surfaces request errors sent as 4xx with the graphql-response media type', async () => {
 	// a spec-compliant server responds to a validation failure with a 422 and the
 	// details in the errors list

--- a/packages/houdini-core/runtime/plugins/fetch.ts
+++ b/packages/houdini-core/runtime/plugins/fetch.ts
@@ -123,9 +123,12 @@ const defaultFetch = (
 				'Content-Type': 'application/json',
 				// a header a cross-origin <form>/simple request cannot set. The server
 				// requires it for CORS-simple POSTs to the graphql endpoint (uploads use
-				// multipart, which bypasses preflight) so it can't be a CSRF channel. Must
-				// stay in sync with HOUDINI_REQUEST_HEADER in router/server.ts.
-				'x-houdini-request': 'true',
+				// multipart, which bypasses preflight) so it can't be a CSRF channel. Only
+				// sent same-origin: a remote api never reads it, and a custom header turns an
+				// otherwise-simple request into a preflighted one the api's CORS config has
+				// no reason to allow (#1738). Must stay in sync with HOUDINI_REQUEST_HEADER
+				// in router/server.ts.
+				...(isSameOrigin(url) ? { 'x-houdini-request': 'true' } : {}),
 				...params?.headers,
 			},
 		})
@@ -175,6 +178,18 @@ const defaultFetch = (
 
 		return payload
 	}
+}
+
+// the CSRF marker only matters on requests that reach Houdini's own server. A relative url
+// always targets it; an absolute one counts only in the browser when the origin matches.
+// Server-side there is no CORS and the endpoint never gates JSON bodies, so absolute urls
+// skip the header there.
+function isSameOrigin(url: string): boolean {
+	const location = globalThis.location
+	if (!location) {
+		return !/^https?:\/\//.test(url)
+	}
+	return new URL(url, location.href).origin === location.origin
 }
 
 /**

--- a/packages/houdini/src/router/server.ts
+++ b/packages/houdini/src/router/server.ts
@@ -555,6 +555,7 @@ export function _serverHandler<ComponentType = unknown>({
 		forwardHeaders.delete('host')
 		forwardHeaders.delete('content-length') // refers to the original stream; fetch recomputes it
 		forwardHeaders.delete(HOUDINI_OPERATION_HEADER) // our internal routing hint, not for the api
+		forwardHeaders.delete(HOUDINI_REQUEST_HEADER) // our internal CSRF marker, not for the api
 		let upstreamResponse: Response
 		try {
 			upstreamResponse = await fetch(resolveApiEndpoint(config_file), {


### PR DESCRIPTION
Fixes #1738 

This PR fixes an issue with the CORS guard by only including the header on requests sent to houdini's internal API

### To help everyone out, please make sure your PR does the following:

- [x] Update the first line to point to the ticket that this PR fixes
- [x] Add a message that clearly describes the fix
- [x] If applicable, add a test that would fail without this fix
- [x] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [x]  Includes a changeset if your fix affects the user with `pnpm changeset`

