### PR TITLE
fix: Windows plugin process spawn

### DIFF
--- a/.changeset/windows-plugin-spawn.md
+++ b/.changeset/windows-plugin-spawn.md
@@ -1,0 +1,8 @@
+---
+'houdini': patch
+'houdini-core': patch
+'houdini-react': patch
+'houdini-svelte': patch
+---
+
+Fix codegen failing on Windows with `spawn ... ENOENT` when starting plugin binaries.

--- a/docs/shared/02-extending-houdini/02-codegen-plugins-golang.mdx
+++ b/docs/shared/02-extending-houdini/02-codegen-plugins-golang.mdx
@@ -122,6 +122,8 @@ Each binary goes into its own package (`my-plugin-darwin-arm64`, `my-plugin-linu
 
 The root package's `bin` field points to a small Node.js shim rather than a binary directly. The shim's job is to find the right binary for the current platform and hand off execution to it via `execFileSync`. As a post-install optimization, the shim replaces itself with a hard link to the actual binary so subsequent invocations skip Node entirely.
 
+That optimization is skipped on Windows (the binary has to keep its `.exe` suffix), under Yarn, and whenever install scripts are disabled, so the shim can still be in place when codegen runs. Windows can't execute a script directly, so codegen checks whether a plugin's `bin` is a Node script and, if it is, runs it through Node.
+
 The shim also supports a `HOUDINI_PLATFORM` environment variable, which lets callers force a specific platform. This is useful in CI environments where the host architecture doesn't match the target.
 
 ## Static Runtimes

--- a/packages/_scripts/templates/shim.cjs
+++ b/packages/_scripts/templates/shim.cjs
@@ -175,7 +175,8 @@ function getBinaryPath() {
 	if (fs.existsSync(buildSiblingPath)) return buildSiblingPath;
 	attempted.push(buildSiblingPath);
 
-	const pnpmMatch = __dirname.match(/(.+\/node_modules\/)\.pnpm\/[^/]+\/node_modules\//);
+	// match both path separators: __dirname uses backslashes on Windows
+	const pnpmMatch = __dirname.match(/(.+[\\/]node_modules[\\/])\.pnpm[\\/][^\\/]+[\\/]node_modules[\\/]/);
 	if (pnpmMatch) {
 		const pnpmDir = path.join(pnpmMatch[1], '.pnpm');
 		try {

--- a/packages/houdini/src/lib/codegen.ts
+++ b/packages/houdini/src/lib/codegen.ts
@@ -67,6 +67,7 @@ import type { HookError } from './error.js'
 import { PluginHookError, format_hook_error } from './error.js'
 import * as fs from './fs.js'
 import { Logger } from './logger.js'
+import { is_node_script } from './plugins.js'
 import type { ProjectManifest } from './types.js'
 import { LogLevel } from './types.js'
 
@@ -478,7 +479,8 @@ export async function codegen_setup(
 			if (child.pid === undefined || child.exitCode !== null) continue
 			try {
 				if (process.platform === 'win32') {
-					child.kill()
+					// the plugin may be a grandchild of a node shim, so kill the whole tree
+					spawn('taskkill', ['/pid', child.pid.toString(), '/f', '/t'])
 				} else {
 					// websocket plugins own their process group, stdio plugins don't —
 					// same signaling as close() below
@@ -504,9 +506,7 @@ export async function codegen_setup(
 				let executable = plugin.executable
 				const args = ['--database', db_file]
 
-				// Run the plugin through a node shim if it's a javascript plugin
-				const jsExtensions = ['.js', '.mjs', '.cjs']
-				if (jsExtensions.includes(path.extname(plugin.executable))) {
+				if (is_node_script(plugin.executable)) {
 					executable = 'node'
 					args.unshift(plugin.executable)
 				} else if (path.extname(plugin.executable) === '.wasm') {

--- a/packages/houdini/src/lib/plugins.test.ts
+++ b/packages/houdini/src/lib/plugins.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, test, vi, beforeEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest'
 
-import { plugin_path } from './plugins.js'
+import { posixify, resolve } from './path.js'
+import { is_node_script, plugin_path } from './plugins.js'
 
 // plugin_path's local-path branch never touches the filesystem, but the module
 // imports fs.ts which depends on glob — mock it to keep the test lightweight.
@@ -30,22 +33,28 @@ vi.mock('node:module', () => ({
 }))
 
 describe('plugin_path local resolution', () => {
+	// absolute paths pick up a drive letter on windows, so build the expectations the same way
+	const abs = (p: string) => resolve(p)
+
 	test('resolves ./ path relative to config file', async () => {
 		const result = await plugin_path('./plugins/my-plugin.js', '/project/houdini.config.js')
-		expect(result.executable).toBe('/project/plugins/my-plugin.js')
-		expect(result.directory).toBe('/project/plugins')
+		expect(result.executable).toBe(abs('/project/plugins/my-plugin.js'))
+		expect(result.directory).toBe(abs('/project/plugins'))
 	})
 
 	test('resolves ../ path relative to config file', async () => {
 		const result = await plugin_path('../shared/plugin.js', '/project/app/houdini.config.js')
-		expect(result.executable).toBe('/project/shared/plugin.js')
-		expect(result.directory).toBe('/project/shared')
+		expect(result.executable).toBe(abs('/project/shared/plugin.js'))
+		expect(result.directory).toBe(abs('/project/shared'))
 	})
 
 	test('resolves absolute path as-is', async () => {
-		const result = await plugin_path('/absolute/path/plugin.js', '/project/houdini.config.js')
-		expect(result.executable).toBe('/absolute/path/plugin.js')
-		expect(result.directory).toBe('/absolute/path')
+		const result = await plugin_path(
+			abs('/absolute/path/plugin.js'),
+			'/project/houdini.config.js'
+		)
+		expect(result.executable).toBe(abs('/absolute/path/plugin.js'))
+		expect(result.directory).toBe(abs('/absolute/path'))
 	})
 
 	test('throws for unknown npm package', async () => {
@@ -82,5 +91,37 @@ describe('plugin_path npm package resolution', () => {
 		await expect(plugin_path('my-plugin', '/project/houdini.config.js')).rejects.toThrow(
 			"Found package 'my-plugin' but it has no bin field"
 		)
+	})
+})
+
+describe('is_node_script', () => {
+	const root = posixify(mkdtempSync(`${tmpdir()}/houdini-script-`))
+	afterAll(() => rmSync(root, { recursive: true, force: true }))
+
+	const write = (name: string, content: string | Buffer) => {
+		const file = `${root}/${name}`
+		writeFileSync(file, content)
+		return file
+	}
+
+	test.each(['.js', '.mjs', '.cjs'])('%s files run through node', (ext) => {
+		expect(is_node_script(`/missing/plugin${ext}`)).toBe(true)
+	})
+
+	test('scripts with a node shebang run through node', () => {
+		expect(is_node_script(write('shim', '#!/usr/bin/env node\nconsole.log(1)\n'))).toBe(true)
+		expect(is_node_script(write('plugin.v2', '#!/usr/bin/node\n'))).toBe(true)
+	})
+
+	test('other interpreters are spawned directly', () => {
+		expect(is_node_script(write('wrapper', '#!/bin/sh\nexec go run . "$@"\n'))).toBe(false)
+		expect(is_node_script(write('script', '#!/usr/bin/env python3\n'))).toBe(false)
+	})
+
+	test('native binaries are spawned directly', () => {
+		expect(is_node_script(write('binary', Buffer.from([0x7f, 0x45, 0x4c, 0x46])))).toBe(false)
+		expect(is_node_script(write('binary.exe', '#!/usr/bin/env node\n'))).toBe(false)
+		expect(is_node_script(`${root}/plugin.wasm`)).toBe(false)
+		expect(is_node_script(`${root}/missing`)).toBe(false)
 	})
 })

--- a/packages/houdini/src/lib/plugins.ts
+++ b/packages/houdini/src/lib/plugins.ts
@@ -1,3 +1,4 @@
+import { closeSync, openSync, readSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { pathToFileURL } from 'node:url'
 
@@ -87,6 +88,32 @@ export async function plugin_path(
 	return {
 		executable: native_bin,
 		directory: plugin_dir,
+	}
+}
+
+// Go plugins publish their `bin` as a small node script that locates and execs the real binary.
+// On unix the postinstall usually swaps that script for the binary itself, but on windows it
+// stays a script, and windows can't spawn a script directly (ENOENT). Codegen uses this to
+// know when an executable (a javascript plugin, or that script) has to be run through node.
+export function is_node_script(executable: string): boolean {
+	const ext = path.extname(executable)
+	if (['.js', '.mjs', '.cjs'].includes(ext)) {
+		return true
+	}
+	if (['.wasm', '.exe'].includes(ext)) {
+		return false
+	}
+	try {
+		const fd = openSync(executable, 'r')
+		try {
+			const header = Buffer.alloc(128)
+			const read = readSync(fd, header, 0, header.length, 0)
+			return /^#![^\n]*\bnode\b/.test(header.toString('utf8', 0, read))
+		} finally {
+			closeSync(fd)
+		}
+	} catch {
+		return false
 	}
 }
 


### PR DESCRIPTION
Fixes ["Windows launcher issue"](https://discord.com/channels/1024421016405016718/1528401921193541692) thread on discord

The houdini compiler would crash on Windows when it attempted to load plugins.

### To help everyone out, please make sure your PR does the following:

- [X] Update the first line to point to the ticket that this PR fixes
- [X] Add a message that clearly describes the fix
- [X] If applicable, add a test that would fail without this fix
- [X] Make sure the unit and integration tests pass locally with `pnpm run tests` and `cd integration && pnpm run tests`
- [X] Includes a changeset if your fix affects the user with `pnpm changeset`

