### PR TITLE
Multiple fixes from Discord

### DIFF
--- a/.changeset/deterministic-flatten-order.md
+++ b/.changeset/deterministic-flatten-order.md
@@ -1,0 +1,6 @@
+---
+'houdini': patch
+'houdini-core': patch
+---
+
+Make generated artifact field order deterministic so incremental rebuilds no longer rewrite (and hot-reload) artifacts whose content didn't actually change.

--- a/.changeset/fix-generated-types.md
+++ b/.changeset/fix-generated-types.md
@@ -1,0 +1,6 @@
+---
+"houdini": patch
+"houdini-core": patch
+---
+
+Fix three issues in generated TypeScript types: loading states now use field aliases instead of schema names, runtime scalar variables are optional in the input type since their values are resolved automatically, and `$optimistic` types wrap list fields in arrays.

--- a/.changeset/fix-hmr-fragment-drop.md
+++ b/.changeset/fix-hmr-fragment-drop.md
@@ -1,0 +1,6 @@
+---
+'houdini': patch
+'houdini-core': patch
+---
+
+Fix dev-server rebuilds dropping fragments from generated documents: saving a file that defines a fragment no longer strips nested fragment definitions and their fields from queries that reference them.

--- a/.changeset/fix-null-literals.md
+++ b/.changeset/fix-null-literals.md
@@ -1,0 +1,6 @@
+---
+"houdini": patch
+"houdini-core": patch
+---
+
+Fix null literals in documents being serialized as the string "null" in generated artifacts (argument values, list filters, and variable defaults).

--- a/.changeset/fix-persisted-queries-output.md
+++ b/.changeset/fix-persisted-queries-output.md
@@ -1,0 +1,6 @@
+---
+'houdini': patch
+'houdini-core': patch
+---
+
+Fix the persisted queries file never being written: setting `persistedQueriesPath` in `houdini.config.js` or passing `-o`/`--output` to `houdini generate` now produces the hash-to-query map file as documented.

--- a/.changeset/generated-runtime-ts-nocheck.md
+++ b/.changeset/generated-runtime-ts-nocheck.md
@@ -1,0 +1,8 @@
+---
+"houdini": patch
+"houdini-core": patch
+"houdini-svelte": patch
+"houdini-react": patch
+---
+
+Generated runtime files now start with `// @ts-nocheck` so strict app-level tsconfig options like `noUncheckedIndexedAccess` no longer fail the build on code you don't own.

--- a/.changeset/svelte-session-layout-warning.md
+++ b/.changeset/svelte-session-layout-warning.md
@@ -1,0 +1,5 @@
+---
+'houdini-svelte': patch
+---
+
+Warn at build time when your hooks file calls `setSession` but the root layout files (`src/routes/+layout.server.js` or `src/routes/+layout.svelte`) are missing, since the session is silently dropped without them.

--- a/docs/shared/01-core/01-config.mdx
+++ b/docs/shared/01-core/01-config.mdx
@@ -34,7 +34,7 @@ By default, your config file can contain the following values:
 - `schemaPath` (optional, default: `"./schema.graphql"`): the path to the static representation of your schema, can be a glob pointing to multiple files
 - `url` (optional): the URL of the GraphQL API. It's public (it ships in the client bundle), so switch it per environment with a `VITE_`-prefixed variable, e.g. `import.meta.env.VITE_API_URL ?? 'http://localhost:4000/graphql'`. `watchSchema.url` defaults to this when omitted.
 - `watchSchema` (optional, an object): configure the development server to poll a remote url for changes in the schema. When a change is detected, the dev server will automatically regenerate your runtime. When its `url` is omitted, the top-level `url` is used. For more information see [Schema Polling](#schema-polling).
-- `persistedQueriesPath` (optional, default: `<rootDir>/persisted_queries.json`): Configure the path of the persisted queries file.
+- `persistedQueriesPath` (optional, default: `<runtimeDir>/queries.json`): Configure the path of the generated persisted queries file (a JSON map of hash to query text), resolved relative to the project root. See [persisted queries](~/guides/trusted-documents).
 - `module` (optional, default: `"esm"`): One of `"esm"` or `"commonjs"`. Used to tell the artifact generator what kind of modules to create.
 - `definitionsPath` (optional, default: `"<rootDir>/graphql"`): a path that the generator will use to write `schema.graphql` and `documents.gql` files containing all of the internal fragment and directive definitions used in the project.
 - `scalars` (optional): An object describing custom scalars for your project (see below).

--- a/docs/svelte/02-setup/01-project-setup.mdx
+++ b/docs/svelte/02-setup/01-project-setup.mdx
@@ -152,6 +152,24 @@ export default defineConfig({
   ```
 </Notice>
 
+#### Server Hooks
+
+SvelteKit only lets a `load` function read the headers of a `fetch` response if they are listed in the `filterSerializedResponseHeaders` option of your `handle` hook; reading any other header throws an error during server-side rendering. When a query fails, Houdini reads the `content-type` header to tell a GraphQL error response apart from a transport failure, so add the option to your `src/hooks.server.js` (creating the file if you don't have one):
+
+```javascript title="src/hooks.server.js"
+export const handle = async ({ event, resolve }) => {
+	return await resolve(event, {
+		filterSerializedResponseHeaders: (name) => name === 'content-type'
+	})
+}
+```
+
+Without this, a query that fails during server-side rendering surfaces SvelteKit's `Failed to get response header "content-type"` error instead of the actual problem.
+
+#### Session Support
+
+If you plan to use [sessions](~/guides/authentication), your project also needs a root `src/routes/+layout.server.js` and `src/routes/+layout.svelte`. Houdini injects the code that passes your session from the server to the client into these files, so the session is silently dropped if they don't exist. See [the authentication guide](~/guides/authentication#the-session-flows-through-your-root-layout) for the full explanation.
+
 ### Svelte
 
 First, we need to add the dedicated houdini package for svelte:

--- a/docs/svelte/05-guides/01-authentication.mdx
+++ b/docs/svelte/05-guides/01-authentication.mdx
@@ -18,9 +18,15 @@ export const handle: Handle = async ({ event, resolve }) => {
     setSession(event, { user })
 
     // pass the event onto the default handle
-    return await resolve(event)
+    return await resolve(event, {
+        // make sure Houdini can read the content-type header of responses
+        // fetched during a load (see the Server Hooks section of the setup guide)
+        filterSerializedResponseHeaders: (name) => name === 'content-type'
+    })
 }
 ```
+
+The `filterSerializedResponseHeaders` option isn't specific to authentication; every SvelteKit project needs it so Houdini can inspect failed responses. See [Server Hooks](~/setup/project-setup#server-hooks) for the details.
 
 Then, you can use the `session` parameter passed to your client's network function to access the information:
 
@@ -39,3 +45,28 @@ export default new HoudiniClient({
 ```
 
 Tip: If your API uses HTTP-Only cookies, don't forget to add `credentials: "include"` to `fetchParams`' return value
+
+## The Session Flows Through Your Root Layout
+
+`setSession` only stores the session on `event.locals`; on its own that value never leaves the server. To get it the rest of the way, Houdini injects a small amount of code into two files at build time:
+
+- `src/routes/+layout.server.js` (or `.ts`): Houdini wraps this file's `load` function (defining one if the file doesn't) so the session is copied from `event.locals` into the root layout's data. Every route inherits that data, which is how the generated loads read the session when they run on the server.
+- `src/routes/+layout.svelte`: Houdini adds code that reads the session out of the page data and stores it for client-side use, which is how queries, mutations, and subscriptions that run in the browser (client-side navigation, cache refreshes, and so on) send the current session.
+
+Houdini only transforms files that already exist in your project; it never creates them. If either file is missing, there is nothing for SvelteKit to run and the session is silently dropped: without `+layout.server.js` the session never reaches your loads, and without `+layout.svelte` requests made in the browser are sent without it.
+
+If your project doesn't have them, create both files. They don't need any content of their own:
+
+```javascript title="src/routes/+layout.server.js"
+// this file only needs to exist, Houdini adds the session logic at build time
+```
+
+```svelte title="src/routes/+layout.svelte"
+<script>
+	let { children } = $props()
+</script>
+
+{@render children()}
+```
+
+To help catch this, `houdini generate` prints a warning when your hooks file calls `setSession` but one of these files is missing.

--- a/docs/svelte/05-guides/02-error-handling.mdx
+++ b/docs/svelte/05-guides/02-error-handling.mdx
@@ -24,3 +24,5 @@ export default new HoudiniClient({
     }
 })
 ```
+
+If a failing query during server-side rendering surfaces SvelteKit's `Failed to get response header "content-type"` error instead of the real response details, add the `filterSerializedResponseHeaders` option to your `handle` hook; see [Server Hooks](~/setup/project-setup#server-hooks).

--- a/packages/houdini-core/plugin/documents/artifacts/merge.go
+++ b/packages/houdini-core/plugin/documents/artifacts/merge.go
@@ -2,7 +2,6 @@ package artifacts
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 
@@ -34,7 +33,9 @@ func FlattenSelection(
 	)
 	for _, orig := range doc.Selections {
 		clone := orig.Clone(true)
-		fields.Add(clone, false, doc.Selections)
+		if err := fields.Add(clone, false, doc.Selections); err != nil {
+			return nil, fmt.Errorf("flattening %s: %w", name, err)
+		}
 	}
 	return fields.ToSelectionSet(), nil
 }
@@ -197,13 +198,15 @@ func (c *fieldCollection) Add(
 
 			err := c.Fields[*selection.Alias].Selection.Add(subSel, hidden, mask)
 			if err != nil {
-				return nil
+				return err
 			}
 		}
 
 		// we also want to make sure that the field is present in any inline fragments we've seen
 		for _, frag := range c.InlineFragments {
-			frag.Selection.Add(c.Fields[*selection.Alias].Field, hidden, visibilityMask)
+			if err := frag.Selection.Add(c.Fields[*selection.Alias].Field, hidden, visibilityMask); err != nil {
+				return err
+			}
 		}
 
 		// we're done
@@ -213,7 +216,9 @@ func (c *fieldCollection) Add(
 		// if the inline fragment doesn't have a type condition then just add every field
 		if selection.FieldName == "" || selection.FieldName == c.ParentType {
 			for _, sel := range selection.Children {
-				c.Add(sel, hidden, visibilityMask)
+				if err := c.Add(sel, hidden, visibilityMask); err != nil {
+					return err
+				}
 			}
 			return nil
 		}
@@ -231,7 +236,9 @@ func (c *fieldCollection) Add(
 		// and most include the fragment's sub selection
 		definition, ok := c.CollectedDocuments.Selections[selection.FieldName]
 		if !ok {
-			return plugins.WrapError(errors.New("fragment not found"))
+			return plugins.WrapError(
+				fmt.Errorf("fragment not found in collected documents: %s", selection.FieldName),
+			)
 		}
 
 		// figure out if the fragment's fields are masked in this document. explicit
@@ -332,7 +339,9 @@ func (c *fieldCollection) WalkInlineFragment(
 					}
 				}
 			}
-			c.InlineFragments[selection.FieldName].Selection.Add(child, hidden, mask)
+			if err := c.InlineFragments[selection.FieldName].Selection.Add(child, hidden, mask); err != nil {
+				return err
+			}
 		case "fragment":
 			err := c.InlineFragments[selection.FieldName].Selection.Add(child, true, visibilityMask)
 			if err != nil {
@@ -344,7 +353,9 @@ func (c *fieldCollection) WalkInlineFragment(
 			}
 
 		case "inline_fragment":
-			c.WalkInlineFragment(child, hidden, visibilityMask)
+			if err := c.WalkInlineFragment(child, hidden, visibilityMask); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -367,11 +378,13 @@ func (c *fieldCollection) WalkInlineFragment(
 					}
 					switch child.Kind {
 					case "field":
-						c.InlineFragments[selection.FieldName].Selection.Add(
+						if err := c.InlineFragments[selection.FieldName].Selection.Add(
 							child,
 							hidden,
 							mask,
-						)
+						); err != nil {
+							return err
+						}
 					}
 				}
 			}
@@ -415,11 +428,13 @@ func (c *fieldCollection) WalkInlineFragment(
 							}
 
 							// just add one field, we'll do the rest when we copy over the abstract selection into the concrete one
-							c.InlineFragments[concreteType].Selection.Add(
+							if err := c.InlineFragments[concreteType].Selection.Add(
 								frag.Field.Children[0],
 								!frag.Field.Children[0].Visible,
 								visibilityMask,
-							)
+							); err != nil {
+								return err
+							}
 						}
 					}
 				}
@@ -438,11 +453,13 @@ func (c *fieldCollection) WalkInlineFragment(
 					}
 					switch child.Kind {
 					case "field":
-						c.InlineFragments[concreteType].Selection.Add(
+						if err := c.InlineFragments[concreteType].Selection.Add(
 							child,
 							hidden,
 							mask,
-						)
+						); err != nil {
+							return err
+						}
 					}
 				}
 			}
@@ -459,11 +476,13 @@ func (c *fieldCollection) WalkInlineFragment(
 				}
 			}
 		}
-		c.InlineFragments[selection.FieldName].Selection.Add(
+		if err := c.InlineFragments[selection.FieldName].Selection.Add(
 			field.Field,
 			hidden,
 			mask,
-		)
+		); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/packages/houdini-core/plugin/documents/artifacts/merge.go
+++ b/packages/houdini-core/plugin/documents/artifacts/merge.go
@@ -40,6 +40,17 @@ func FlattenSelection(
 	return fields.ToSelectionSet(), nil
 }
 
+// sortedKeys returns the keys of a set in a stable (alphabetical) order so walking
+// them produces the same result on every run
+func sortedKeys(set map[string]bool) []string {
+	keys := make([]string, 0, len(set))
+	for key := range set {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 func newFieldCollection(
 	name string,
 	docs *collected.Documents,
@@ -79,6 +90,13 @@ type fieldCollection struct {
 	Fields          map[string]*fieldCollectionField
 	InlineFragments map[string]*fieldCollectionField
 	FragmentSpreads map[string]*fieldCollectionField
+
+	// insertion order for each map above. map iteration order is randomized in Go, so
+	// without these the flattened output (and therefore the written artifact) would
+	// change from run to run even when nothing in the document did
+	fieldOrder          []string
+	inlineFragmentOrder []string
+	fragmentSpreadOrder []string
 }
 
 func (c *fieldCollection) Size() int {
@@ -183,6 +201,7 @@ func (c *fieldCollection) Add(
 				Visible:       !hidden,
 				Unconditional: unconditional,
 			}
+			c.fieldOrder = append(c.fieldOrder, *selection.Alias)
 		}
 
 		for _, subSel := range selection.Children {
@@ -203,8 +222,8 @@ func (c *fieldCollection) Add(
 		}
 
 		// we also want to make sure that the field is present in any inline fragments we've seen
-		for _, frag := range c.InlineFragments {
-			if err := frag.Selection.Add(c.Fields[*selection.Alias].Field, hidden, visibilityMask); err != nil {
+		for _, name := range c.inlineFragmentOrder {
+			if err := c.InlineFragments[name].Selection.Add(c.Fields[*selection.Alias].Field, hidden, visibilityMask); err != nil {
 				return err
 			}
 		}
@@ -228,6 +247,9 @@ func (c *fieldCollection) Add(
 
 	case "fragment":
 		// add the fragment spread
+		if _, seen := c.FragmentSpreads[selection.FieldName]; !seen {
+			c.fragmentSpreadOrder = append(c.fragmentSpreadOrder, selection.FieldName)
+		}
 		c.FragmentSpreads[selection.FieldName] = &fieldCollectionField{
 			Field:   selection,
 			Visible: !hidden,
@@ -325,6 +347,7 @@ func (c *fieldCollection) WalkInlineFragment(
 				c.SortKeys,
 			),
 		}
+		c.inlineFragmentOrder = append(c.inlineFragmentOrder, selection.FieldName)
 	}
 
 	// add every child to the inline fragment
@@ -348,6 +371,9 @@ func (c *fieldCollection) WalkInlineFragment(
 				return err
 			}
 
+			if _, seen := c.FragmentSpreads[selection.FieldName]; !seen {
+				c.fragmentSpreadOrder = append(c.fragmentSpreadOrder, selection.FieldName)
+			}
 			c.FragmentSpreads[selection.FieldName] = &fieldCollectionField{
 				Field: child,
 			}
@@ -366,7 +392,7 @@ func (c *fieldCollection) WalkInlineFragment(
 	if abstractTypes, ok := c.CollectedDocuments.Implementations[selection.FieldName]; ok {
 		// if we've seen the abstract type already then we need to add each of the abstract types
 		// selectiosn to the inline fragment for the concrete type
-		for abstractType := range abstractTypes {
+		for _, abstractType := range sortedKeys(abstractTypes) {
 			if frag, ok := c.InlineFragments[abstractType]; ok {
 				// add every child field to the concrete inline fragment
 				for _, child := range frag.Field.Children {
@@ -397,14 +423,14 @@ func (c *fieldCollection) WalkInlineFragment(
 
 	// or the field type could itself be an abstract type with concrete types we've already seen
 	if concreteTypes, ok := c.CollectedDocuments.PossibleTypes[selection.FieldName]; ok {
-		for concreteType := range concreteTypes {
+		for _, concreteType := range sortedKeys(concreteTypes) {
 			// we need to look for any inline fragments that have already been applied that point to abstract selections
 			// that the concrete type implements and if we find anything the we need to add a concrete selection even if
 			// one is not already present
 			if abstractTypes, ok := c.CollectedDocuments.Implementations[concreteType]; ok {
 				// if we have an inline fragment for the abstract type implemented by the concrete type we need to merge
 				// them into one
-				for abstractType := range abstractTypes {
+				for _, abstractType := range sortedKeys(abstractTypes) {
 					if abstractType == selection.FieldName {
 						continue
 					}
@@ -426,6 +452,7 @@ func (c *fieldCollection) WalkInlineFragment(
 									c.SortKeys,
 								),
 							}
+							c.inlineFragmentOrder = append(c.inlineFragmentOrder, concreteType)
 
 							// just add one field, we'll do the rest when we copy over the abstract selection into the concrete one
 							if err := c.InlineFragments[concreteType].Selection.Add(
@@ -467,7 +494,8 @@ func (c *fieldCollection) WalkInlineFragment(
 	}
 
 	// also if there is a concrete selection already present we want to include that in the inline framgment
-	for _, field := range c.Fields {
+	for _, name := range c.fieldOrder {
+		field := c.Fields[name]
 		var mask []*collected.Selection
 		if visibilityMask != nil {
 			for _, field := range visibilityMask {
@@ -491,9 +519,11 @@ func (c *fieldCollection) WalkInlineFragment(
 func (c *fieldCollection) ToSelectionSet() []*collected.Selection {
 	result := []*collected.Selection{}
 
-	// if we aren't supposed to sort the keys just add everything
+	// if we aren't supposed to sort the keys, emit everything in insertion order so
+	// the flattened output is stable across runs
 	if !c.SortKeys {
-		for _, f := range c.Fields {
+		for _, name := range c.fieldOrder {
+			f := c.Fields[name]
 			local := *f.Field.Clone(false)
 			field := &local
 			field.Directives = f.Directives
@@ -506,13 +536,15 @@ func (c *fieldCollection) ToSelectionSet() []*collected.Selection {
 			result = append(result, field)
 		}
 
-		for _, f := range c.InlineFragments {
+		for _, name := range c.inlineFragmentOrder {
+			f := c.InlineFragments[name]
 			field := f.Field.Clone(false)
 			field.Children = f.Selection.ToSelectionSet()
 			result = append(result, field)
 		}
 
-		for _, f := range c.FragmentSpreads {
+		for _, name := range c.fragmentSpreadOrder {
+			f := c.FragmentSpreads[name]
 			field := f.Field.Clone(false)
 			if f.Visible {
 				field.Visible = true

--- a/packages/houdini-core/plugin/documents/artifacts/print.go
+++ b/packages/houdini-core/plugin/documents/artifacts/print.go
@@ -355,6 +355,8 @@ func printValue(value *collected.ArgumentValue, usedVariables map[string]bool) s
 	switch value.Kind {
 	case "Enum":
 		return value.Raw
+	case "Null":
+		return "null"
 	case "Object":
 		var resultBuilder strings.Builder
 		resultBuilder.WriteRune('{')
@@ -399,6 +401,8 @@ func stringifyValue(value *collected.ArgumentValue, usedVariables map[string]boo
 		return "$" + value.Raw
 	case "Int", "Float", "Boolean":
 		return value.Raw
+	case "Null":
+		return "null"
 	case "Object":
 		var resultBuilder strings.Builder
 		resultBuilder.WriteRune('{')

--- a/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_operations_test.go
@@ -3369,9 +3369,9 @@ export type RefetchFriends$input = null | undefined;
 
 export type RefetchFriends$optimistic = {
 	readonly addFriend?: {
-		readonly friends?: {
+		readonly friends?: ({
 			readonly firstName?: string;
-		};
+		})[];
 	};
 };
 

--- a/packages/houdini-core/plugin/documents/artifacts/selection_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/selection_test.go
@@ -2975,7 +2975,7 @@ export type AnimalsOverview$result = {
 };
 
 export type AnimalsOverview$input = {
-	id: string;
+	id?: string;
 };
 
 export type AnimalsOverview$unmasked = {
@@ -5113,6 +5113,20 @@ export type LoginForm$unmasked = {
 export type LoginForm$artifact = typeof artifact
 
 "HoudiniHash=7781e7aef13f15dc275ab44769bc456f5af795fc04864518008fbbb1e05fe4e7"`),
+				},
+			},
+			{
+				Name: "null literals in arguments and variable defaults",
+				Pass: true,
+				Input: []string{
+					`query NullLiteralQuery($name: String = null) {
+            users(stringValue: $name, intValue: null, filter: { name: null }) @list(name: "Null_Users") {
+              firstName
+            }
+          }`,
+				},
+				Extra: map[string]any{
+					"NullLiteralQuery": "const artifact = {\n    \"name\": \"NullLiteralQuery\",\n    \"kind\": \"HoudiniQuery\",\n    \"hash\": \"b168d64e381365250361866d0735e605dd687b515c90b497da2f60b02129fbe5\",\n\n    \"refetch\": {\n        \"path\": [\"users\"],\n        \"method\": \"offset\",\n        \"pageSize\": 0,\n        \"embedded\": false,\n        \"targetType\": \"Query\",\n        \"paginated\": false,\n        \"direction\": \"forward\",\n        \"mode\": \"Infinite\"\n    },\n\n    \"raw\": `query NullLiteralQuery($name: String = null) {\n    users(filter: {name: null}, intValue: null, stringValue: $name) {\n        firstName\n        __typename\n        id\n    }\n}\n`,\n\n    \"rootType\": \"Query\",\n    \"stripVariables\": [] as Array<string>,\n\n    \"selection\": {\n        \"fields\": {\n            \"users\": {\n                \"type\": \"User\",\n                \"keyRaw\": \"users(filter: {name: null}, intValue: null, stringValue: $name)\",\n\n                \"directives\": [{\n                    \"name\": \"list\",\n                    \"arguments\": {\n                        \"name\": {\n                            \"kind\": \"StringValue\",\n                            \"value\": \"Null_Users\"\n                        }\n                    }\n                }],\n\n                \"list\": {\n                    \"name\": \"Null_Users\",\n                    \"connection\": false,\n                    \"type\": \"User\"\n                },\n\n                \"selection\": {\n                    \"fields\": {\n                        \"__typename\": {\n                            \"type\": \"String\",\n                            \"keyRaw\": \"__typename\",\n                        },\n\n                        \"firstName\": {\n                            \"type\": \"String\",\n                            \"keyRaw\": \"firstName\",\n                            \"visible\": true,\n                        },\n\n                        \"id\": {\n                            \"type\": \"ID\",\n                            \"keyRaw\": \"id\",\n                        },\n                    },\n                },\n\n                \"filters\": {\n                    \"filter\": {\n                        \"kind\": \"Object\",\n                        \"value\": {\n                            \"name\": {\n                                \"kind\": \"Null\",\n                                \"value\": null\n                            }\n                        }\n                    },\n                    \"intValue\": {\n                        \"kind\": \"Null\",\n                        \"value\": null\n                    },\n                    \"stringValue\": {\n                        \"kind\": \"Variable\",\n                        \"value\": \"name\"\n                    },\n                },\n                \"visible\": true,\n            },\n        },\n    },\n\n    \"pluginData\": {},\n\n    \"input\": {\n        \"fields\": {\n            \"name\": \"String\",\n        },\n\n        \"types\": {},\n\n        \"defaults\": {\n            \"name\": null,\n        },\n\n        \"runtimeScalars\": {},\n    },\n\n    \"policy\": \"CacheOrNetwork\",\n    \"partial\": false\n} as const\n\nexport default artifact\n\nexport type NullLiteralQuery = {\n\treadonly \"input\": NullLiteralQuery$input;\n\treadonly \"result\": NullLiteralQuery$result | undefined;\n};\n\nexport type NullLiteralQuery$result = {\n\treadonly users: ({\n\t\treadonly firstName: string;\n\t})[];\n};\n\nexport type NullLiteralQuery$input = {\n\tname?: string | null;\n};\n\nexport type NullLiteralQuery$unmasked = {\n\treadonly users: ({\n\t\treadonly __typename: \"User\";\n\t\treadonly firstName: string;\n\t\treadonly id: string;\n\t})[];\n};\n\nexport type NullLiteralQuery$artifact = typeof artifact\n\n\"HoudiniHash=b168d64e381365250361866d0735e605dd687b515c90b497da2f60b02129fbe5\"",
 				},
 			},
 		},

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/documents.go
@@ -24,6 +24,21 @@ type DocumentContext struct {
 	ScalarImports map[string]bool // full import statement → true
 }
 
+// isRuntimeScalarVariable returns true when the variable was declared with a
+// runtime scalar type. the runtimeScalars transform rewrites the variable's type
+// to its static equivalent and tags it with the runtime scalar directive, so the
+// directive is the only remaining marker by the time types are generated. the
+// value is resolved on the server (e.g. from the session), so the user never
+// provides it and the input field has to be optional
+func isRuntimeScalarVariable(variable *collected.OperationVariable) bool {
+	for _, directive := range variable.Directives {
+		if directive.Name == graphql.RuntimeScalarDirective {
+			return true
+		}
+	}
+	return false
+}
+
 // spreadDisablesMasking returns true when a fragment spread's fields should be
 // inlined into the surrounding type. @mask_disable and @mask_enable on the spread
 // take priority, otherwise we fall back to the project's defaultFragmentMasking
@@ -348,7 +363,8 @@ func generateFragmentTypes(
 				collectedDocs,
 			)
 			optional := ""
-			if !strings.HasSuffix(variable.TypeModifiers, "!") {
+			if !strings.HasSuffix(variable.TypeModifiers, "!") ||
+				isRuntimeScalarVariable(variable) {
 				optional = "?"
 			}
 			inputFields = append(
@@ -513,7 +529,8 @@ func generateOperationTypes(
 				collectedDocs,
 			)
 			optional := ""
-			if !strings.HasSuffix(variable.TypeModifiers, "!") {
+			if !strings.HasSuffix(variable.TypeModifiers, "!") ||
+				isRuntimeScalarVariable(variable) {
 				optional = "?"
 			}
 			inputFields = append(
@@ -1030,13 +1047,19 @@ func generateInterfaceUnionTypeWithLoading(
 					optional = "?"
 				}
 
+				// the response is keyed by the alias when one is present
+				childFieldName := fragmentChild.FieldName
+				if fragmentChild.Alias != nil {
+					childFieldName = *fragmentChild.Alias
+				}
+
 				fields = append(
 					fields,
 					fmt.Sprintf(
 						"%s%s%s%s: %s;",
 						fieldIndent,
 						readonlyPrefix,
-						fragmentChild.FieldName,
+						childFieldName,
 						optional,
 						fieldType,
 					),
@@ -1251,7 +1274,12 @@ func generateOptimisticType(
 			continue
 		}
 
+		// optimistic responses are keyed the same way as the server payload, so an
+		// aliased field uses its alias
 		fieldName := selection.FieldName
+		if selection.Alias != nil {
+			fieldName = *selection.Alias
+		}
 		readonlyPrefix := ""
 		if readonly {
 			readonlyPrefix = "readonly "
@@ -1268,9 +1296,16 @@ func generateOptimisticType(
 			}
 		}
 
+		// modifiers encode list wrapping and nullability (inner→outer) and apply to
+		// both nested objects and leaves
+		modifiers := ""
+		if selection.TypeModifiers != nil {
+			modifiers = *selection.TypeModifiers
+		}
+
 		if hasInlineFragments {
 			// Generate union type for interface/union fields
-			fieldType = generateInterfaceUnionType(
+			unionType := generateInterfaceUnionType(
 				ctx,
 				selection,
 				readonly,
@@ -1278,13 +1313,15 @@ func generateOptimisticType(
 				false,
 				indentLevel+1,
 			)
+			fieldType = ApplyTypeModifiers(unionType, modifiers, false)
 		} else if len(selection.Children) > 0 {
-			// Regular nested object type
+			// Regular nested object type. Apply the type modifiers so list-typed
+			// fields are arrays of the object shape, not a bare object.
 			childType, childErr := generateOptimisticType(ctx, selection.Children, readonly, indentLevel+1, selection.FieldType, collectedDocs)
 			if childErr != nil {
 				return "", childErr
 			}
-			fieldType = childType
+			fieldType = ApplyTypeModifiers(childType, modifiers, false)
 		} else {
 			// Leaf field - convert the GraphQL type to TypeScript.
 			// Special-case __typename on a concrete parent type: we know the exact string literal.
@@ -1301,19 +1338,14 @@ func generateOptimisticType(
 			fields = append(fields, comment)
 		}
 
-		// For optimistic types, all fields are optional
-		// If the field is nullable in the schema, preserve that nullability
-		if selection.TypeModifiers != nil && !strings.Contains(*selection.TypeModifiers, "!") {
-			// Field is nullable - add | null to the optimistic type
-			if len(selection.Children) > 0 {
-				// For object types, add | null after the object type
+		// For optimistic types, all fields are optional. Nullability (and list
+		// wrapping) is already handled by ApplyTypeModifiers above for object and
+		// union fields and by convertLeafType for leaves, but keep a safety net for
+		// nullable leaves whose conversion didn't include it.
+		if selection.TypeModifiers != nil && !strings.Contains(*selection.TypeModifiers, "!") &&
+			len(selection.Children) == 0 {
+			if !strings.Contains(fieldType, "| null") && !strings.Contains(fieldType, "| undefined") {
 				fieldType = fmt.Sprintf("%s | null", fieldType)
-			} else {
-				// For scalar types, nullability should already be included by convertToTypeScriptTypeSimple
-				// but ensure it's there for optimistic types
-				if !strings.Contains(fieldType, "| null") && !strings.Contains(fieldType, "| undefined") {
-					fieldType = fmt.Sprintf("%s | null", fieldType)
-				}
 			}
 		}
 		fields = append(
@@ -1406,7 +1438,12 @@ func generateLoadingStateType(
 			continue
 		}
 
+		// the response (and the loading placeholder) is keyed by the alias when one
+		// is present, matching the non-loading branch
 		fieldName := selection.FieldName
+		if selection.Alias != nil {
+			fieldName = *selection.Alias
+		}
 		readonlyPrefix := "readonly "
 
 		var fieldType string

--- a/packages/houdini-core/plugin/documents/artifacts/typescript/documents_test.go
+++ b/packages/houdini-core/plugin/documents/artifacts/typescript/documents_test.go
@@ -1171,6 +1171,85 @@ func TestTypescriptGeneration(t *testing.T) {
 				},
 			},
 			{
+				Name: "loading state uses field alias",
+				Input: []string{
+					`query LoadingAliasQuery { user(id: "1") @loading { id name: firstName @loading } }`,
+				},
+				Pass: true,
+				Extra: map[string]any{
+					"LoadingAliasQuery": tests.Dedent(`
+						export type LoadingAliasQuery$result = {
+							/**
+							 * Get a user.
+							 */
+							readonly user: {
+								readonly id: string;
+								/**
+								 * The user's first name
+								 */
+								readonly name: string;
+							} | null;
+						} | {
+							/**
+							 * Get a user.
+							 */
+							readonly user: {
+								/**
+								 * The user's first name
+								 */
+								readonly name: LoadingType;
+							};
+						};
+					`),
+				},
+			},
+			{
+				Name: "runtime scalar variables are optional in the input type",
+				ProjectConfig: func(cfg *plugins.ProjectConfig) {
+					cfg.RuntimeScalars = map[string]string{
+						"UserFromSession": "ID",
+					}
+				},
+				Input: []string{
+					`query SessionQuery($id: UserFromSession!) { user(id: $id) { firstName } }`,
+				},
+				Pass: true,
+				Extra: map[string]any{
+					"SessionQuery": tests.Dedent(`
+						export type SessionQuery$input = {
+							id?: string;
+						};
+					`),
+				},
+			},
+			{
+				Name: "optimistic type wraps list fields in arrays",
+				Input: []string{
+					`mutation ListMutation {
+						doThing(id: "1", firstName: "test", list: []) {
+							friends {
+								firstName
+							}
+						}
+					}`,
+				},
+				Pass: true,
+				Extra: map[string]any{
+					"ListMutation": tests.Dedent(`
+						export type ListMutation$optimistic = {
+							readonly doThing?: {
+								readonly friends?: ({
+									/**
+									 * The user's first name
+									 */
+									readonly firstName?: string;
+								} | null)[] | null;
+							} | null;
+						};
+					`),
+				},
+			},
+			{
 				Name: "fragment spreads",
 				Input: []string{
 					`fragment Foo on User { firstName }`,

--- a/packages/houdini-core/plugin/documents/collected/collect.go
+++ b/packages/houdini-core/plugin/documents/collected/collect.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"sync"
 
-	
-
 	"code.houdinigraphql.com/packages/houdini-core/config"
 	"code.houdinigraphql.com/plugins"
 )
@@ -68,39 +66,43 @@ func CollectDocuments(
 	docIDs := []int64{}
 
 	// the documents we care about are those that fall in the current task as well as
-	// any fragments that are referenced in a document that is in the current task
+	// every fragment that is referenced (transitively) by a document we've already decided
+	// to collect. the recursion matters: flattening a task document needs the definition of
+	// every fragment in its spread chain, not just the ones it references directly
 	documentSearch, err := conn.Prepare(`
-    SELECT documents.id,
-           documents.name,
-					 documents.internal,
-					 documents.visible,
-           true  AS current
-    FROM documents
-    JOIN raw_documents
-      ON documents.raw_document = raw_documents.id
-    WHERE (raw_documents.current_task = $task_id OR $task_id IS NULL)
+    WITH RECURSIVE collected_docs AS (
+      SELECT documents.id,
+             documents.name,
+             documents.internal,
+             documents.visible,
+             true AS current
+      FROM documents
+      JOIN raw_documents
+        ON documents.raw_document = raw_documents.id
+      WHERE (raw_documents.current_task = $task_id OR $task_id IS NULL)
 
-    UNION ALL
+      UNION
 
-    SELECT DISTINCT documents.id,
-           documents.name,
-           false AS current,
-					 documents.internal,
-					 documents.visible
-    FROM documents AS current_task_docs
-      JOIN raw_documents AS current_task_raw
-        ON current_task_docs.raw_document = current_task_raw.id
-      JOIN selection_refs
-        ON selection_refs.document = current_task_docs.id
-      JOIN selections
-        ON selection_refs.child_id = selections.id
-        AND selections.kind = 'fragment'
-      JOIN documents
-        ON selections.field_name = documents.name
-      JOIN raw_documents AS doc_raw
-        ON documents.raw_document = doc_raw.id
-    WHERE (current_task_raw.current_task = $task_id OR $task_id IS NULL)
-      AND NOT (doc_raw.current_task = $task_id OR $task_id IS NULL)
+      SELECT referenced.id,
+             referenced.name,
+             referenced.internal,
+             referenced.visible,
+             false AS current
+      FROM collected_docs
+        JOIN selection_refs
+          ON selection_refs.document = collected_docs.id
+        JOIN selections
+          ON selection_refs.child_id = selections.id
+        LEFT JOIN component_fields
+          ON selections.type = component_fields.type_field
+        JOIN documents AS referenced
+          ON referenced.name = COALESCE(component_fields.fragment, selections.field_name)
+      WHERE selections.kind = 'fragment'
+         OR (selections.kind = 'field' AND component_fields.id IS NOT NULL)
+    )
+    SELECT id, name, internal, visible, MAX(current) AS current
+    FROM collected_docs
+    GROUP BY id, name, internal, visible
   `)
 	if err != nil {
 		return nil, err
@@ -933,7 +935,7 @@ func collectDoc(
 				errs.Append(plugins.WrapError(err))
 			}
 
-				// send the result over the channel
+			// send the result over the channel
 			resultCh <- collectResult{
 				Documents:     docs,
 				PossibleTypes: possibleTypes,
@@ -1410,7 +1412,6 @@ func prepareCollectStatements(conn plugins.Conn, count int) (*CollectStatements,
 	}, nil
 }
 
-
 func (s *CollectStatements) Finalize() {
 	s.Search.Finalize()
 	s.DocumentVariables.Finalize()
@@ -1620,8 +1621,6 @@ func prepareArgumentValuesSearch(conn plugins.Conn, valueIDs []int64) (plugins.S
 	// we're done
 	return stmt, nil
 }
-
-
 
 type collectResult struct {
 	Documents     []*Document

--- a/packages/houdini-core/plugin/documents/generate.go
+++ b/packages/houdini-core/plugin/documents/generate.go
@@ -67,6 +67,18 @@ func Generate(
 		return nil
 	})
 
+	// generate the persisted queries file. this has to happen here (not in GenerateRuntime)
+	// because it reads documents.printed/hash which EnsureDocumentsPrinted populated above,
+	// and GenerateRuntime runs in parallel with GenerateDocuments
+	group.Go(func() error {
+		files, err := GeneratePersistentQueries(ctx, db, fs)
+		if err != nil {
+			return err
+		}
+		fps.Append(files...)
+		return nil
+	})
+
 	err = group.Wait()
 	if err != nil {
 		return nil, err

--- a/packages/houdini-core/plugin/documents/persistentQueries.go
+++ b/packages/houdini-core/plugin/documents/persistentQueries.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 
 	"github.com/spf13/afero"
-	
-	
 
 	"code.houdinigraphql.com/plugins"
 )
@@ -31,8 +29,11 @@ func GeneratePersistentQueries(
 		return nil, err
 	}
 
-	persistedQueriesPath := projectConfig.PersistedQueriesPath
-	outputPath := filepath.Join(projectConfig.ProjectRoot, persistedQueriesPath)
+	// resolve the configured path relative to the project root (absolute paths are used as-is)
+	outputPath := projectConfig.PersistedQueriesPath
+	if !filepath.IsAbs(outputPath) {
+		outputPath = filepath.Join(projectConfig.ProjectRoot, outputPath)
+	}
 
 	if !strings.HasSuffix(outputPath, ".json") {
 		return nil, &plugins.Error{
@@ -143,6 +144,12 @@ func GeneratePersistentQueries(
 	}
 
 	jsonData, err := json.MarshalIndent(queryMap, "", "    ")
+	if err != nil {
+		return nil, plugins.WrapError(err)
+	}
+
+	// make sure the target directory exists before writing
+	err = fs.MkdirAll(filepath.Dir(outputPath), 0755)
 	if err != nil {
 		return nil, plugins.WrapError(err)
 	}

--- a/packages/houdini-core/plugin/documents/persistentQueries_test.go
+++ b/packages/houdini-core/plugin/documents/persistentQueries_test.go
@@ -254,23 +254,23 @@ func runFullGeneration(
 	projectConfig.PersistedQueriesPath = testPersistentQueriesPath
 	p.DB.SetProjectConfig(projectConfig)
 
-	// Use the REAL generation function instead of manual steps
-	// First generate documents/artifacts to ensure hashing is done
+	// Use the REAL generation function instead of manual steps.
+	// GenerateDocuments is responsible for writing the persisted queries file: it's the
+	// step that populates documents.printed/hash, and in the real pipeline GenerateRuntime
+	// runs concurrently with it (so persisted queries can't be generated there).
 	_, err = p.GenerateDocuments(context.Background())
 	if err != nil {
 		require.False(t, test.Pass, err.Error())
 		return nil, err
 	}
 
-	// Then generate runtime which includes persistent queries
-	_, err = p.GenerateRuntime(context.Background())
-	if err != nil {
-		require.False(t, test.Pass, err.Error())
-		return nil, err
-	}
-
-	// Read the REAL persistent queries that got generated
+	// The persisted queries file must exist after GenerateDocuments alone, without
+	// running GenerateRuntime
 	fullPath := filepath.Join(projectConfig.ProjectRoot, testPersistentQueriesPath)
+	exists, err := afero.Exists(p.Fs, fullPath)
+	require.NoError(t, err)
+	require.True(t, exists, "persisted queries file should be written by GenerateDocuments")
+
 	content, err := afero.ReadFile(p.Fs, fullPath)
 	require.NoError(t, err)
 

--- a/packages/houdini-core/plugin/documents/taskCollection_test.go
+++ b/packages/houdini-core/plugin/documents/taskCollection_test.go
@@ -44,6 +44,7 @@ func TestTaskScopedCollectionIncludesOutOfTaskFragments(t *testing.T) {
 			require.NoError(t, p.AfterValidate(ctx))
 			_, err := p.GenerateDocuments(ctx)
 			require.NoError(t, err)
+			fullRunArtifact := readArtifact(t, p.Fs, "NestedQuery")
 
 			// simulate the HMR task: the sibling fragment's file was saved and the
 			// dependency walk pulled in the query's file. the parent/nested files stay out.
@@ -78,6 +79,9 @@ func TestTaskScopedCollectionIncludesOutOfTaskFragments(t *testing.T) {
 			require.NoError(t, err)
 
 			artifact := readArtifact(t, p.Fs, "NestedQuery")
+			// nothing about the query changed, so the incremental run must reproduce the
+			// full run's artifact byte for byte (flatten order is deterministic)
+			require.Equal(t, fullRunArtifact, artifact)
 			for _, expected := range []string{
 				// fields contributed by the out-of-task fragments
 				`"keyRaw": "name"`,

--- a/packages/houdini-core/plugin/documents/taskCollection_test.go
+++ b/packages/houdini-core/plugin/documents/taskCollection_test.go
@@ -1,0 +1,134 @@
+package documents_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+
+	"code.houdinigraphql.com/packages/houdini-core/config"
+	"code.houdinigraphql.com/packages/houdini-core/plugin"
+	"code.houdinigraphql.com/packages/houdini-core/plugin/documents/collected"
+	"code.houdinigraphql.com/plugins"
+	"code.houdinigraphql.com/plugins/tests"
+)
+
+// Regression test for incremental (HMR) rebuilds dropping fragments that live in files
+// outside the current task. The scenario mirrors a dev-server save: the file defining
+// SiblingFragment changes, the task expands to the query that depends on it, but the
+// files defining ParentFragment and NestedFragment are untouched. Collection must still
+// pull in the whole spread chain (transitively) so the regenerated query artifact keeps
+// every fragment's fields and raw definitions.
+func TestTaskScopedCollectionIncludesOutOfTaskFragments(t *testing.T) {
+	tests.RunTable(t, tests.Table[config.PluginConfig, *plugin.HoudiniCore]{
+		Schema: `
+			type Query {
+				user: User!
+			}
+
+			type User {
+				id: ID!
+				name: String!
+				email: String!
+			}
+		`,
+		PerformTest: func(t *testing.T, p *plugin.HoudiniCore, test tests.Test[config.PluginConfig]) {
+			ctx := context.Background()
+
+			// run the full pipeline once, like the dev server does on boot
+			require.NoError(t, p.AfterExtract(ctx))
+			require.NoError(t, p.Validate(ctx))
+			require.NoError(t, p.AfterValidate(ctx))
+			_, err := p.GenerateDocuments(ctx)
+			require.NoError(t, err)
+
+			// simulate the HMR task: the sibling fragment's file was saved and the
+			// dependency walk pulled in the query's file. the parent/nested files stay out.
+			conn, err := p.DB.Take(ctx)
+			require.NoError(t, err)
+			markTask, err := conn.Prepare(
+				`UPDATE raw_documents SET current_task = 'hmr-task' WHERE filepath IN ('query.graphql', 'sibling.graphql')`,
+			)
+			require.NoError(t, err)
+			err = p.DB.ExecStatement(markTask, nil)
+			markTask.Finalize()
+			p.DB.Put(conn)
+			require.NoError(t, err)
+
+			taskCtx := plugins.ContextWithTaskID(ctx, "hmr-task")
+
+			// collection must contain the full spread chain, not just the task documents
+			conn, err = p.DB.Take(taskCtx)
+			require.NoError(t, err)
+			docs, err := collected.CollectDocuments(taskCtx, p.DB, conn, false)
+			p.DB.Put(conn)
+			require.NoError(t, err)
+
+			for _, name := range []string{"NestedQuery", "SiblingFragment", "ParentFragment", "NestedFragment"} {
+				require.Contains(t, docs.Selections, name)
+			}
+			// but only the task's own documents get regenerated
+			require.ElementsMatch(t, []string{"NestedQuery", "SiblingFragment"}, docs.TaskDocuments)
+
+			// and the regenerated artifact keeps the out-of-task fragments' contribution
+			_, err = p.GenerateDocuments(taskCtx)
+			require.NoError(t, err)
+
+			artifact := readArtifact(t, p.Fs, "NestedQuery")
+			for _, expected := range []string{
+				// fields contributed by the out-of-task fragments
+				`"keyRaw": "name"`,
+				`"keyRaw": "id"`,
+				// the raw document needs every transitive fragment definition
+				"fragment ParentFragment",
+				"fragment NestedFragment",
+				"fragment SiblingFragment",
+				"...NestedFragment",
+			} {
+				require.Contains(t, artifact, expected)
+			}
+		},
+		Tests: []tests.Test[config.PluginConfig]{
+			{
+				Name: "out-of-task fragments survive incremental regeneration",
+				Pass: true,
+				Input: []string{
+					`query NestedQuery { user { ...SiblingFragment ...ParentFragment } }`,
+					`fragment SiblingFragment on User { email }`,
+					`fragment ParentFragment on User { name ...NestedFragment }`,
+					`fragment NestedFragment on User { id }`,
+				},
+				Filepaths: []string{
+					"query.graphql",
+					"sibling.graphql",
+					"parent.graphql",
+					"nested.graphql",
+				},
+			},
+		},
+	})
+}
+
+// readArtifact finds the generated artifact file for the named document in the test
+// filesystem and returns its content
+func readArtifact(t *testing.T, fs afero.Fs, name string) string {
+	t.Helper()
+	var match string
+	err := afero.Walk(fs, "/project", func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		if strings.Contains(path, "artifacts") && strings.HasPrefix(info.Name(), name+".") {
+			match = path
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, match, "artifact for %s not found", name)
+	raw, err := afero.ReadFile(fs, match)
+	require.NoError(t, err)
+	return string(raw)
+}

--- a/packages/houdini-core/plugin/generateRuntime.go
+++ b/packages/houdini-core/plugin/generateRuntime.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"path/filepath"
 
-	"code.houdinigraphql.com/packages/houdini-core/plugin/documents"
 	"code.houdinigraphql.com/packages/houdini-core/plugin/runtime"
 	"code.houdinigraphql.com/packages/houdini-core/plugin/schema"
 	"code.houdinigraphql.com/plugins"
@@ -40,15 +39,8 @@ func (p *HoudiniCore) GenerateRuntime(ctx context.Context) ([]string, error) {
 
 	generated := plugins.ThreadSafeSlice[string]{}
 
-	// generate the documents file
-	g.Go(func() error {
-		documentFiles, err := documents.GeneratePersistentQueries(ctx, p.DB, p.Fs)
-		if err != nil {
-			return err
-		}
-		generated.Append(documentFiles...)
-		return nil
-	})
+	// note: persisted queries are generated as part of GenerateDocuments (they depend on
+	// documents.printed/hash which are only populated there, and the two hooks run in parallel)
 
 	// generate definitions files (schema.graphql, documents.gql, enums)
 	g.Go(func() error {

--- a/packages/houdini-core/plugin/runtime/imperativeCache.go
+++ b/packages/houdini-core/plugin/runtime/imperativeCache.go
@@ -54,6 +54,7 @@ func GenerateImperativeCacheTypeDefs(
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate cache type definitions: %w", err)
 	}
+	content = EnsureTSNoCheck(targetPath, content)
 
 	// Write the file
 	err = afero.WriteFile(fs, targetPath, []byte(content), 0644)

--- a/packages/houdini-core/plugin/runtime/imperativeCache_test.go
+++ b/packages/houdini-core/plugin/runtime/imperativeCache_test.go
@@ -148,6 +148,7 @@ func TestGenerateImperativeCacheTypeDefs(t *testing.T) {
 			require.NoError(t, err)
 
 			expected := tests.Dedent(`
+				// @ts-nocheck
 				import type { Record } from "./public/record";
 				import type { TestQuery$result, TestQuery$input, TestQuery$artifact } from "../artifacts/TestQuery";
 				import type { TestQueryNoArgs$result, TestQueryNoArgs$input, TestQueryNoArgs$artifact } from "../artifacts/TestQueryNoArgs";

--- a/packages/houdini-core/plugin/runtime/pluginIndex.go
+++ b/packages/houdini-core/plugin/runtime/pluginIndex.go
@@ -23,7 +23,7 @@ func GeneratePluginIndex(
 
 	indexPath := filepath.Join(config.ProjectRoot, config.RuntimeDir, "plugins", "index.ts")
 
-	content := `export * from "../runtime/plugins/index.js"`
+	content := TSNoCheckHeader + `export * from "../runtime/plugins/index.js"`
 
 	// make sure the direcotry exists
 	err = fs.MkdirAll(filepath.Dir(indexPath), 0o755)

--- a/packages/houdini-core/plugin/runtime/pluginIndex_test.go
+++ b/packages/houdini-core/plugin/runtime/pluginIndex_test.go
@@ -39,7 +39,7 @@ func TestPluginIndexGeneration(t *testing.T) {
 
 			require.Equal(
 				t,
-				`export * from "../runtime/plugins/index.js"`,
+				"// @ts-nocheck\n"+`export * from "../runtime/plugins/index.js"`,
 				string(indexContent),
 			)
 		},

--- a/packages/houdini-core/plugin/runtime/runtimeIndex.go
+++ b/packages/houdini-core/plugin/runtime/runtimeIndex.go
@@ -98,7 +98,7 @@ func GenerateRuntimeIndexFile(
 	}
 
 	// build up the indexContent of the file
-	indexContent := fmt.Sprintf(`export * from './runtime/client'
+	indexContent := TSNoCheckHeader + fmt.Sprintf(`export * from './runtime/client'
 export * from './runtime'
 export * from './%s'
 %s

--- a/packages/houdini-core/plugin/runtime/runtimeIndex_test.go
+++ b/packages/houdini-core/plugin/runtime/runtimeIndex_test.go
@@ -36,7 +36,8 @@ func TestRuntimeIndexGeneration(t *testing.T) {
 			)
 			require.Nil(t, err)
 
-			require.Equal(t, `export * from './runtime/client'
+			require.Equal(t, `// @ts-nocheck
+export * from './runtime/client'
 export * from './runtime'
 export * from './graphql'
 

--- a/packages/houdini-core/plugin/runtime/transformRuntime.go
+++ b/packages/houdini-core/plugin/runtime/transformRuntime.go
@@ -12,7 +12,61 @@ import (
 	"code.houdinigraphql.com/plugins"
 )
 
+// TSNoCheckHeader is prepended to every runtime source file that houdini writes into the
+// project. The runtime is copied in as .ts source (in houdini 1 it shipped pre-built as
+// .js + .d.ts), so it inherits the user's tsconfig; the pragma keeps stricter app-level
+// options (noUncheckedIndexedAccess, etc.) from failing the build on generated code.
+const TSNoCheckHeader = "// @ts-nocheck\n"
+
+// EnsureTSNoCheck returns content with a // @ts-nocheck pragma as its very first line.
+// It only applies to typescript/javascript source files (.ts, .tsx, .js, .jsx, .mjs,
+// .cjs); declaration files (.d.ts) and non-source assets are returned untouched. If the
+// pragma already appears in the file (a patch step prepended imports above it, for
+// example) it is hoisted back to the top, since typescript only honors it before the
+// first statement.
+func EnsureTSNoCheck(path string, content string) string {
+	if strings.HasSuffix(path, ".d.ts") {
+		return content
+	}
+	switch fp.Ext(path) {
+	case ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs":
+	default:
+		return content
+	}
+
+	// drop any existing pragma lines so the one we add is always the first line
+	for strings.HasPrefix(content, TSNoCheckHeader) {
+		content = strings.TrimPrefix(content, TSNoCheckHeader)
+	}
+	for {
+		index := strings.Index(content, "\n"+TSNoCheckHeader)
+		if index == -1 {
+			break
+		}
+		content = content[:index+1] + content[index+1+len(TSNoCheckHeader):]
+	}
+
+	return TSNoCheckHeader + content
+}
+
 func TransformRuntime(
+	ctx context.Context,
+	db plugins.DatabasePool[config.PluginConfig],
+	config plugins.ProjectConfig,
+	filepath string,
+	content string,
+) (string, error) {
+	result, err := transformRuntimeContent(ctx, db, config, filepath, content)
+	if err != nil {
+		return "", err
+	}
+
+	// every runtime source file gets the ts-nocheck pragma so the user's tsconfig
+	// strictness doesn't apply to generated code
+	return EnsureTSNoCheck(filepath, result), nil
+}
+
+func transformRuntimeContent(
 	ctx context.Context,
 	db plugins.DatabasePool[config.PluginConfig],
 	config plugins.ProjectConfig,

--- a/packages/houdini-core/plugin/runtime/transformRuntime_test.go
+++ b/packages/houdini-core/plugin/runtime/transformRuntime_test.go
@@ -3,6 +3,7 @@ package runtime_test
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"code.houdinigraphql.com/packages/houdini-core/config"
@@ -49,8 +50,60 @@ func TestRuntimeTransform_configEndpoint(t *testing.T) {
 			require.Nil(t, err)
 			require.Contains(t, result, `apiURL: "/graphql"`)
 			require.Contains(t, result, "...projectConfig")
+			// every runtime source file carries the ts-nocheck pragma as its first line
+			require.True(t, strings.HasPrefix(result, "// @ts-nocheck\n"))
 		},
 	})
+}
+
+// generated runtime files land in the user's project as .ts source, so they get a
+// // @ts-nocheck first line to opt out of the app's tsconfig strictness. Only
+// executable ts/js sources get it — declarations and assets stay untouched.
+func TestEnsureTSNoCheck(t *testing.T) {
+	// plain source files get the pragma prepended
+	require.Equal(
+		t,
+		"// @ts-nocheck\nexport const foo = 1\n",
+		runtime.EnsureTSNoCheck("lib/constants.ts", "export const foo = 1\n"),
+	)
+	require.Equal(
+		t,
+		"// @ts-nocheck\nexport default () => null\n",
+		runtime.EnsureTSNoCheck("index.tsx", "export default () => null\n"),
+	)
+	require.Equal(
+		t,
+		"// @ts-nocheck\nmodule.exports = {}\n",
+		runtime.EnsureTSNoCheck("lib/config.js", "module.exports = {}\n"),
+	)
+
+	// declaration files and non-source assets are untouched
+	require.Equal(
+		t,
+		"export declare const foo: number\n",
+		runtime.EnsureTSNoCheck("types.d.ts", "export declare const foo: number\n"),
+	)
+	require.Equal(t, `{"foo": 1}`, runtime.EnsureTSNoCheck("package.json", `{"foo": 1}`))
+	require.Equal(
+		t,
+		"query Foo { id }",
+		runtime.EnsureTSNoCheck("documents.graphql", "query Foo { id }"),
+	)
+
+	// already-present pragmas are hoisted back to the top, not duplicated
+	require.Equal(
+		t,
+		"// @ts-nocheck\nimport foo from 'bar'\nexport const baz = 1\n",
+		runtime.EnsureTSNoCheck(
+			"index.ts",
+			"import foo from 'bar'\n// @ts-nocheck\nexport const baz = 1\n",
+		),
+	)
+	require.Equal(
+		t,
+		"// @ts-nocheck\nexport const foo = 1\n",
+		runtime.EnsureTSNoCheck("index.ts", "// @ts-nocheck\nexport const foo = 1\n"),
+	)
 }
 
 func TestRuntimeTransform_extraConfig(t *testing.T) {

--- a/packages/houdini-react/plugin/runtime.go
+++ b/packages/houdini-react/plugin/runtime.go
@@ -10,12 +10,24 @@ import (
 
 	"github.com/spf13/afero"
 
+	coreruntime "code.houdinigraphql.com/packages/houdini-core/plugin/runtime"
 	plugins "code.houdinigraphql.com/plugins"
 	"code.houdinigraphql.com/plugins/graphql"
 )
 
 // TransformRuntime patches static runtime files as they are copied into the plugin directory.
 func (p *HoudiniReact) TransformRuntime(ctx context.Context, fp string, content string) (string, error) {
+	result, err := p.transformRuntimeContent(ctx, fp, content)
+	if err != nil {
+		return "", err
+	}
+
+	// every runtime source file gets the ts-nocheck pragma so the user's tsconfig
+	// strictness doesn't apply to generated code
+	return coreruntime.EnsureTSNoCheck(fp, result), nil
+}
+
+func (p *HoudiniReact) transformRuntimeContent(ctx context.Context, fp string, content string) (string, error) {
 	// Inject `// @refresh reset` into every JSX/TSX runtime file. These are
 	// framework internals the user never edits directly, so they should opt
 	// out of react-refresh's preamble injection (which causes "can't detect
@@ -190,7 +202,9 @@ func (p *HoudiniReact) UpdateIndexFiles(ctx context.Context) ([]string, error) {
 	newContent.WriteString(overloads.String())
 	newContent.WriteString(existingStr[insertPos:])
 
-	result := newContent.String()
+	// the imports were prepended above the copied file's // @ts-nocheck pragma,
+	// so hoist it back to the very top where typescript honors it
+	result := coreruntime.EnsureTSNoCheck(targetPath, newContent.String())
 	if result == existingStr {
 		return []string{}, nil
 	}
@@ -294,6 +308,7 @@ func (p *HoudiniReact) GenerateRuntime(ctx context.Context) ([]string, error) {
 	}
 
 	manifestPath := filepath.Join(runtimeDir, "manifest.ts")
+	content = coreruntime.EnsureTSNoCheck(manifestPath, content)
 
 	existing, _ := afero.ReadFile(p.Filesystem(), manifestPath)
 	if string(existing) != content {
@@ -312,6 +327,7 @@ func (p *HoudiniReact) GenerateRuntime(ctx context.Context) ([]string, error) {
 	}
 
 	mockPath := filepath.Join(runtimeDir, "mock.ts")
+	mockContent = coreruntime.EnsureTSNoCheck(mockPath, mockContent)
 	existingMock, _ := afero.ReadFile(p.Filesystem(), mockPath)
 	if string(existingMock) != mockContent {
 		if err := plugins.WriteFile(p.Filesystem(), mockPath, []byte(mockContent), 0644); err != nil {
@@ -642,10 +658,12 @@ func (p *HoudiniReact) AddGraphQLType(ctx context.Context) ([]string, error) {
 	}
 
 	// Legacy structure: preamble (fragment imports) first, then existing content, then type.
-	appended := preamble.String() +
-		existingStr +
-		"\nexport type GraphQL<_Document extends string> = " +
-		typeChain.String() + "never\n"
+	// The preamble lands above the copied file's // @ts-nocheck pragma, so hoist it back
+	// to the very top where typescript honors it.
+	appended := coreruntime.EnsureTSNoCheck(targetPath, preamble.String()+
+		existingStr+
+		"\nexport type GraphQL<_Document extends string> = "+
+		typeChain.String()+"never\n")
 
 	if err := plugins.WriteFile(p.Filesystem(), targetPath, []byte(appended), 0644); err != nil {
 		return nil, err
@@ -763,7 +781,11 @@ func (p *HoudiniReact) UpdateHookFiles(ctx context.Context) ([]string, error) {
 			before.WriteString(spec.passthrough + "\n")
 		}
 
-		result := top.String() + existingStr[:insertPos] + before.String() + existingStr[insertPos:]
+		// hoist the copied file's // @ts-nocheck pragma back above the injected imports
+		result := coreruntime.EnsureTSNoCheck(
+			fp,
+			top.String()+existingStr[:insertPos]+before.String()+existingStr[insertPos:],
+		)
 
 		if err := plugins.WriteFile(p.Filesystem(), fp, []byte(result), 0644); err != nil {
 			return nil, err
@@ -1205,6 +1227,12 @@ func (p *HoudiniReact) InjectComponentFieldArtifactTypes(ctx context.Context) ([
 			modified = reactImport + modified
 		}
 
+		// if the artifact carried a // @ts-nocheck pragma, the injected imports just
+		// pushed it below the top of the file — hoist it back so it stays effective
+		if strings.Contains(str, coreruntime.TSNoCheckHeader) {
+			modified = coreruntime.EnsureTSNoCheck(artPath, modified)
+		}
+
 		if err := plugins.WriteFile(p.Filesystem(), artPath, []byte(modified), 0644); err != nil {
 			return nil, err
 		}
@@ -1239,7 +1267,7 @@ func (p *HoudiniReact) GenerateComponentFieldTypes(ctx context.Context) ([]strin
 
 	// Write the augmentation file.
 	augPath := filepath.Join(runtimeDir, "componentFieldTypes.ts")
-	augContent := `import type * as React from 'react'
+	augContent := coreruntime.TSNoCheckHeader + `import type * as React from 'react'
 
 declare module 'houdini/runtime' {
 	interface CacheTypeDef {
@@ -1269,7 +1297,8 @@ declare module 'houdini/runtime' {
 	indexStr := string(indexBytes)
 	sideEffect := `import './componentFieldTypes'`
 	if !strings.Contains(indexStr, sideEffect) {
-		patched := sideEffect + "\n" + indexStr
+		// hoist the copied file's // @ts-nocheck pragma back above the injected import
+		patched := coreruntime.EnsureTSNoCheck(indexPath, sideEffect+"\n"+indexStr)
 		if err := plugins.WriteFile(p.Filesystem(), indexPath, []byte(patched), 0644); err != nil {
 			return nil, err
 		}

--- a/packages/houdini-react/plugin/runtime_test.go
+++ b/packages/houdini-react/plugin/runtime_test.go
@@ -36,7 +36,8 @@ func TestTransformRuntime(t *testing.T) {
 					// runtimeDir  = /project/.houdini/plugins/houdini-react/runtime
 					// clientPath  = /project/src/+client
 					// relPath     = ../../../../src/+client
-					"expected": "import client from '../../../../src/+client'\nexport default () => client\n",
+					// every runtime source file carries the // @ts-nocheck pragma
+					"expected": "// @ts-nocheck\nimport client from '../../../../src/+client'\nexport default () => client\n",
 				},
 			},
 			{
@@ -44,7 +45,7 @@ func TestTransformRuntime(t *testing.T) {
 				Pass: true,
 				Extra: map[string]any{
 					"input":    "export * from './hooks'\n",
-					"expected": "export * from './hooks'\n",
+					"expected": "// @ts-nocheck\nexport * from './hooks'\n",
 				},
 			},
 		},
@@ -94,7 +95,7 @@ func TestTransformRuntimeLoginURL(t *testing.T) {
 					"redirect": "https://worker.example/login",
 					"input":    "export * from './hooks'\n",
 					// .tsx files also receive the @refresh reset preamble
-					"expected": "// @refresh reset\nexport * from './hooks'\n\nexport { loginURL } from './login.js'\n",
+					"expected": "// @ts-nocheck\n// @refresh reset\nexport * from './hooks'\n\nexport { loginURL } from './login.js'\n",
 				},
 			},
 			{
@@ -103,7 +104,7 @@ func TestTransformRuntimeLoginURL(t *testing.T) {
 				Extra: map[string]any{
 					"providers": "github,google",
 					"input":     "export * from './hooks'\n",
-					"expected": "// @refresh reset\nexport * from './hooks'\n" +
+					"expected": "// @ts-nocheck\n// @refresh reset\nexport * from './hooks'\n" +
 						"\nimport { loginURL as _loginURL } from './login.js'\n" +
 						"export function loginURL(opts: { provider: 'github' | 'google'; redirectTo?: string }): string {\n" +
 						"\treturn _loginURL({ redirectTo: opts.redirectTo, params: { provider: opts.provider } })\n" +
@@ -115,7 +116,7 @@ func TestTransformRuntimeLoginURL(t *testing.T) {
 				Pass: true,
 				Extra: map[string]any{
 					"input":    "export * from './hooks'\n",
-					"expected": "// @refresh reset\nexport * from './hooks'\n",
+					"expected": "// @ts-nocheck\n// @refresh reset\nexport * from './hooks'\n",
 				},
 			},
 		},
@@ -164,7 +165,7 @@ func TestTransformRuntimeDevtools(t *testing.T) {
 				Name: "defaults to the dev guard when no plugin config exists",
 				Pass: true,
 				Extra: map[string]any{
-					"expected": devtoolsIndexStub,
+					"expected": "// @ts-nocheck\n" + devtoolsIndexStub,
 				},
 			},
 			{
@@ -172,7 +173,7 @@ func TestTransformRuntimeDevtools(t *testing.T) {
 				Pass: true,
 				Extra: map[string]any{
 					"config":   `{"devtools":"dev"}`,
-					"expected": devtoolsIndexStub,
+					"expected": "// @ts-nocheck\n" + devtoolsIndexStub,
 				},
 			},
 			{
@@ -180,7 +181,7 @@ func TestTransformRuntimeDevtools(t *testing.T) {
 				Pass: true,
 				Extra: map[string]any{
 					"config":   `{"devtools":"always"}`,
-					"expected": "import plugin from './plugin.js'\n\nexport default plugin\n",
+					"expected": "// @ts-nocheck\nimport plugin from './plugin.js'\n\nexport default plugin\n",
 				},
 			},
 			{
@@ -188,7 +189,7 @@ func TestTransformRuntimeDevtools(t *testing.T) {
 				Pass: true,
 				Extra: map[string]any{
 					"config":   `{"devtools":"never"}`,
-					"expected": "export default null\n",
+					"expected": "// @ts-nocheck\nexport default null\n",
 				},
 			},
 		},
@@ -253,7 +254,8 @@ func TestUpdateIndexFiles(t *testing.T) {
 				Extra: map[string]any{
 					// Overloads must land immediately before the generic function —
 					// the leading imports/exports in the stub must remain in place.
-					"expected": "\n" +
+					// The ts-nocheck pragma is hoisted above the injected imports.
+					"expected": "// @ts-nocheck\n\n" +
 						"import type { MyQuery$artifact } from '../artifacts/MyQuery'\n" +
 						"import type { YourQuery$artifact } from '../artifacts/YourQuery'\n" +
 						"\n" +
@@ -287,7 +289,7 @@ func TestUpdateIndexFiles(t *testing.T) {
 				Input: []string{`query MyQuery { id }`},
 				Extra: map[string]any{
 					"call_twice": true,
-					"expected": "\n" +
+					"expected": "// @ts-nocheck\n\n" +
 						"import type { MyQuery$artifact } from '../artifacts/MyQuery'\n" +
 						"\n" +
 						"import type { Cache } from 'houdini/runtime/cache'\n\n" +
@@ -384,7 +386,7 @@ func TestUpdateHookFiles(t *testing.T) {
 						"useQuery.ts": "import type { QueryArtifact } from 'houdini/runtime'\n\nexport function useQuery<_A>(doc: any): any {}\n",
 					},
 					"expected": map[string]string{
-						"useQuery.ts": "import type { MyQuery$result, MyQuery$artifact, MyQuery$input } from '$houdini/artifacts/MyQuery'\n" +
+						"useQuery.ts": "// @ts-nocheck\nimport type { MyQuery$result, MyQuery$artifact, MyQuery$input } from '$houdini/artifacts/MyQuery'\n" +
 							"\n" +
 							"import type { QueryArtifact } from 'houdini/runtime'\n\n" +
 							"export function useQuery(document: { artifact: MyQuery$artifact }, variables?: MyQuery$input, config?: UseQueryConfig): MyQuery$result\n" +
@@ -404,7 +406,7 @@ func TestUpdateHookFiles(t *testing.T) {
 						"useMutation.ts": "import type { MutationArtifact } from 'houdini/runtime'\n\nexport function useMutation<_A>(doc: any): any {}\n",
 					},
 					"expected": map[string]string{
-						"useMutation.ts": "import type { MyMutation$result, MyMutation$artifact, MyMutation$input, MyMutation$optimistic } from '$houdini/artifacts/MyMutation'\n" +
+						"useMutation.ts": "// @ts-nocheck\nimport type { MyMutation$result, MyMutation$artifact, MyMutation$input, MyMutation$optimistic } from '$houdini/artifacts/MyMutation'\n" +
 							"\n" +
 							"import type { MutationArtifact } from 'houdini/runtime'\n\n" +
 							"export function useMutation(document: { artifact: MyMutation$artifact }): [MutationHandler<MyMutation$result, MyMutation$input, MyMutation$optimistic>, boolean]\n" +
@@ -424,7 +426,7 @@ func TestUpdateHookFiles(t *testing.T) {
 						"useFragment.ts": "import { fragmentKey } from 'houdini/runtime'\nimport type { FragmentArtifact } from 'houdini/runtime'\n\nexport function useFragment<_A>(ref: any, doc: any): any {}\n",
 					},
 					"expected": map[string]string{
-						"useFragment.ts": "import type { MyFragment$data, MyFragment$artifact } from '$houdini/artifacts/MyFragment'\n" +
+						"useFragment.ts": "// @ts-nocheck\nimport type { MyFragment$data, MyFragment$artifact } from '$houdini/artifacts/MyFragment'\n" +
 							"\n" +
 							"import { fragmentKey } from 'houdini/runtime'\nimport type { FragmentArtifact } from 'houdini/runtime'\n\n" +
 							"export function useFragment(reference: { readonly \" $fragments\": { MyFragment: any } }, document: { artifact: MyFragment$artifact }): MyFragment$data\n" +
@@ -445,7 +447,7 @@ func TestUpdateHookFiles(t *testing.T) {
 						"useFragment.ts": "import { fragmentKey } from 'houdini/runtime'\nimport type { FragmentArtifact } from 'houdini/runtime'\n\nexport function useFragment<_A>(ref: any, doc: any): any {}\n",
 					},
 					"expected": map[string]string{
-						"useFragment.ts": "import type { MyPluralFragment$data, MyPluralFragment$artifact } from '$houdini/artifacts/MyPluralFragment'\n" +
+						"useFragment.ts": "// @ts-nocheck\nimport type { MyPluralFragment$data, MyPluralFragment$artifact } from '$houdini/artifacts/MyPluralFragment'\n" +
 							"\n" +
 							"import { fragmentKey } from 'houdini/runtime'\nimport type { FragmentArtifact } from 'houdini/runtime'\n\n" +
 							"export function useFragment(reference: ReadonlyArray<{ readonly \" $fragments\": { MyPluralFragment: any } }>, document: { artifact: MyPluralFragment$artifact }): MyPluralFragment$data[]\n" +
@@ -466,7 +468,7 @@ func TestUpdateHookFiles(t *testing.T) {
 						"useFragmentHandle.ts": "import type { QueryArtifact } from 'houdini/runtime'\n\nexport function useFragmentHandle<_A>(ref: any, doc: any): any {}\n",
 					},
 					"expected": map[string]string{
-						"useFragmentHandle.ts": "import type { MyFragment$data, MyFragment$artifact, MyFragment$input } from '$houdini/artifacts/MyFragment'\n" +
+						"useFragmentHandle.ts": "// @ts-nocheck\nimport type { MyFragment$data, MyFragment$artifact, MyFragment$input } from '$houdini/artifacts/MyFragment'\n" +
 							"\n" +
 							"import type { QueryArtifact } from 'houdini/runtime'\n\n" +
 							"export function useFragmentHandle(reference: { readonly \" $fragments\": { MyFragment: any } }, document: { artifact: MyFragment$artifact }): DocumentHandle<QueryArtifact, MyFragment$data, GraphQLVariables>\n" +
@@ -487,7 +489,7 @@ func TestUpdateHookFiles(t *testing.T) {
 						"useFragmentHandle.ts": "import type { QueryArtifact } from 'houdini/runtime'\n\nexport function useFragmentHandle<_A>(ref: any, doc: any): any {}\n",
 					},
 					"expected": map[string]string{
-						"useFragmentHandle.ts": "import type { MyPaginatedFragment$data, MyPaginatedFragment$artifact, MyPaginatedFragment$input } from '$houdini/artifacts/MyPaginatedFragment'\n" +
+						"useFragmentHandle.ts": "// @ts-nocheck\nimport type { MyPaginatedFragment$data, MyPaginatedFragment$artifact, MyPaginatedFragment$input } from '$houdini/artifacts/MyPaginatedFragment'\n" +
 							"import type { MyPaginatedFragment_Pagination_Query$artifact } from '$houdini/artifacts/MyPaginatedFragment_Pagination_Query'\n" +
 							"\n" +
 							"import type { QueryArtifact } from 'houdini/runtime'\n\n" +
@@ -518,7 +520,7 @@ func TestUpdateHookFiles(t *testing.T) {
 						"useQuery.ts": "import type { QueryArtifact } from 'houdini/runtime'\n\nexport function useQuery<_A>(doc: any): any {}\n",
 					},
 					"expected": map[string]string{
-						"useQuery.ts": "import type { MyQuery$result, MyQuery$artifact, MyQuery$input } from '$houdini/artifacts/MyQuery'\n" +
+						"useQuery.ts": "// @ts-nocheck\nimport type { MyQuery$result, MyQuery$artifact, MyQuery$input } from '$houdini/artifacts/MyQuery'\n" +
 							"\n" +
 							"import type { QueryArtifact } from 'houdini/runtime'\n\n" +
 							"export function useQuery(document: { artifact: MyQuery$artifact }, variables?: MyQuery$input, config?: UseQueryConfig): MyQuery$result\n" +
@@ -586,7 +588,7 @@ func TestAddGraphQLType(t *testing.T) {
 						},
 					},
 					// preamble (fragment imports) go BEFORE existing content, type appended at end
-					"expected": "import type { UserAvatar } from '../artifacts/UserAvatar'\n" +
+					"expected": "// @ts-nocheck\nimport type { UserAvatar } from '../artifacts/UserAvatar'\n" +
 						indexStub +
 						"\nexport type GraphQL<_Document extends string> = " +
 						"_Document extends `fragment UserAvatar on User { avatar }` ? Required<UserAvatar>['shape'] : " +
@@ -608,7 +610,7 @@ func TestAddGraphQLType(t *testing.T) {
 						{"filepath": "src/components/Avatar.tsx", "type": "User", "field": "Avatar", "prop": "user", "fragment": "UserAvatar", "content": "fragment UserAvatar on User { avatar }"},
 					},
 					"call_twice": true,
-					"expected": "import type { UserAvatar } from '../artifacts/UserAvatar'\n" +
+					"expected": "// @ts-nocheck\nimport type { UserAvatar } from '../artifacts/UserAvatar'\n" +
 						indexStub +
 						"\nexport type GraphQL<_Document extends string> = " +
 						"_Document extends `fragment UserAvatar on User { avatar }` ? Required<UserAvatar>['shape'] : " +
@@ -868,6 +870,7 @@ func TestGenerateRuntime(t *testing.T) {
 				Pass: true,
 				Extra: map[string]any{
 					"expected": tests.Dedent(`
+						// @ts-nocheck
 						import type { RouterManifest } from 'houdini/runtime'
 
 						export default {
@@ -880,7 +883,7 @@ func TestGenerateRuntime(t *testing.T) {
 						export type RouteScalars = {
 						}
 					`) + "\n" + tsTypeManifest,
-					"expectedMock": "import React from 'react'\n" +
+					"expectedMock": "// @ts-nocheck\nimport React from 'react'\n" +
 						"import { _createMock, buildMockPath } from './testing'\n" +
 						"\ntype _MockValue<R, V> = R | ((vars: V) => R)\n\n" +
 						"export function createMock({ url, params = {}, search, data }: { url: string; params?: Record<string, string>; search?: Record<string, unknown>; data: Record<string, any> }): React.ComponentType<{}> {\n" +
@@ -909,7 +912,7 @@ func TestGenerateRuntime(t *testing.T) {
 					// runtimeDir  = /project/.houdini/plugins/houdini-react/runtime
 					// artifacts   = ../../../artifacts/<Name>
 					// component   = ../units/entries/<id>  (entry file, not source)
-					"expectedMock": "import React from 'react'\n" +
+					"expectedMock": "// @ts-nocheck\nimport React from 'react'\n" +
 						"import { _createMock, buildMockPath } from './testing'\n" +
 						"import type { RouteHrefs, ParamsForRoute, SearchForRoute } from './routes'\n" +
 						"\nimport type { FinalQuery$unmasked, FinalQuery$input } from '$houdini/artifacts/FinalQuery'\n" +
@@ -927,6 +930,7 @@ func TestGenerateRuntime(t *testing.T) {
 						"\treturn _createMock({ path: buildMockPath(args.url as string, (args as any).params ?? {}, (args as any).search), data: args.data as Record<string, any> })\n" +
 						"}\n",
 					"expected": tests.Dedent(`
+						// @ts-nocheck
 						import type { RouterManifest } from 'houdini/runtime'
 
 						export default {
@@ -975,7 +979,7 @@ func TestGenerateRuntime(t *testing.T) {
 					"views": map[string]string{
 						"src/routes/[id]/+page.tsx": mockView([]string{"MyQuery"}),
 					},
-					"expectedMock": "import React from 'react'\n" +
+					"expectedMock": "// @ts-nocheck\nimport React from 'react'\n" +
 						"import { _createMock, buildMockPath } from './testing'\n" +
 						"import type { RouteHrefs, ParamsForRoute, SearchForRoute } from './routes'\n" +
 						"\nimport type { MyQuery$unmasked, MyQuery$input } from '$houdini/artifacts/MyQuery'\n" +
@@ -991,6 +995,7 @@ func TestGenerateRuntime(t *testing.T) {
 						"\treturn _createMock({ path: buildMockPath(args.url as string, (args as any).params ?? {}, (args as any).search), data: args.data as Record<string, any> })\n" +
 						"}\n",
 					"expected": tests.Dedent(`
+						// @ts-nocheck
 						import type { RouterManifest } from 'houdini/runtime'
 
 						export default {
@@ -1039,7 +1044,7 @@ func TestGenerateRuntime(t *testing.T) {
 					// $q and $tags are nullable, so they surface as search params (the list
 					// keeps its wrapper chain). $first is required, so it is omitted — a
 					// missing search param can never make the query fail.
-					"expectedMock": "import React from 'react'\n" +
+					"expectedMock": "// @ts-nocheck\nimport React from 'react'\n" +
 						"import { _createMock, buildMockPath } from './testing'\n" +
 						"import type { RouteHrefs, ParamsForRoute, SearchForRoute } from './routes'\n" +
 						"\nimport type { SearchQuery$unmasked, SearchQuery$input } from '$houdini/artifacts/SearchQuery'\n" +
@@ -1055,6 +1060,7 @@ func TestGenerateRuntime(t *testing.T) {
 						"\treturn _createMock({ path: buildMockPath(args.url as string, (args as any).params ?? {}, (args as any).search), data: args.data as Record<string, any> })\n" +
 						"}\n",
 					"expected": tests.Dedent(`
+						// @ts-nocheck
 						import type { RouterManifest } from 'houdini/runtime'
 
 						export default {
@@ -1103,6 +1109,7 @@ func TestGenerateRuntime(t *testing.T) {
 						"src/routes/+error.tsx": "export default ({ errors }) => <div>{errors[0].message}</div>",
 					},
 					"expected": tests.Dedent(`
+						// @ts-nocheck
 						import type { RouterManifest } from 'houdini/runtime'
 
 						export default {
@@ -1142,6 +1149,7 @@ func TestGenerateRuntime(t *testing.T) {
 						"src/routes/+page.tsx":   "export const headers = () => ({ 'X-From': 'page' })\nexport default () => <div>hello</div>",
 					},
 					"expected": tests.Dedent(`
+						// @ts-nocheck
 						import type { RouterManifest } from 'houdini/runtime'
 
 						export default {
@@ -1188,7 +1196,7 @@ func TestGenerateRuntime(t *testing.T) {
 					"views": map[string]string{
 						"src/routes/+page.tsx": mockView([]string{"PageQuery"}),
 					},
-					"expectedMock": "import React from 'react'\n" +
+					"expectedMock": "// @ts-nocheck\nimport React from 'react'\n" +
 						"import { _createMock, buildMockPath } from './testing'\n" +
 						"import type { RouteHrefs, ParamsForRoute, SearchForRoute } from './routes'\n" +
 						"\nimport type { PageQuery$unmasked, PageQuery$input } from '$houdini/artifacts/PageQuery'\n" +
@@ -1218,6 +1226,7 @@ func TestGenerateRuntime(t *testing.T) {
 				},
 				Extra: map[string]any{
 					"expected": tests.Dedent(`
+						// @ts-nocheck
 						import type { RouterManifest } from 'houdini/runtime'
 
 						export default {

--- a/packages/houdini-svelte/plugin/config/config.go
+++ b/packages/houdini-svelte/plugin/config/config.go
@@ -26,6 +26,8 @@ type PluginConfig struct {
 	Framework    PluginFramework        `json:"framework"`
 	ClientPath   string                 `json:"client"`
 	CustomStores PluginConfigStorePaths `json:"customStores"`
+	// Static removes the session infrastructure from the application
+	Static bool `json:"static"`
 }
 
 type PluginConfigStorePaths struct {

--- a/packages/houdini-svelte/plugin/runtime.go
+++ b/packages/houdini-svelte/plugin/runtime.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	coreruntime "code.houdinigraphql.com/packages/houdini-core/plugin/runtime"
 	"code.houdinigraphql.com/packages/houdini-svelte/plugin/config"
 	"code.houdinigraphql.com/packages/houdini-svelte/plugin/generate"
 	"github.com/spf13/afero"
@@ -16,6 +17,21 @@ func (p *HoudiniSvelte) IncludeRuntime(ctx context.Context) (string, error) {
 }
 
 func (p *HoudiniSvelte) TransformRuntime(
+	ctx context.Context,
+	fp string,
+	content string,
+) (string, error) {
+	result, err := p.transformRuntimeContent(ctx, fp, content)
+	if err != nil {
+		return "", err
+	}
+
+	// every runtime source file gets the ts-nocheck pragma so the user's tsconfig
+	// strictness doesn't apply to generated code
+	return coreruntime.EnsureTSNoCheck(fp, result), nil
+}
+
+func (p *HoudiniSvelte) transformRuntimeContent(
 	ctx context.Context,
 	fp string,
 	content string,
@@ -202,7 +218,9 @@ func (p *HoudiniSvelte) UpdateIndexFiles(ctx context.Context) ([]string, error) 
 	// Add the original generic function
 	newContent.WriteString(existingStr[insertPos:])
 
-	newString := newContent.String()
+	// the imports were prepended above the copied file's // @ts-nocheck pragma,
+	// so hoist it back to the very top where typescript honors it
+	newString := coreruntime.EnsureTSNoCheck(targetPath, newContent.String())
 	if newString == existingStr {
 		// no changes
 		return []string{}, nil
@@ -212,7 +230,7 @@ func (p *HoudiniSvelte) UpdateIndexFiles(ctx context.Context) ([]string, error) 
 	err = afero.WriteFile(
 		p.Fs,
 		targetPath,
-		[]byte(newContent.String()),
+		[]byte(newString),
 		0644,
 	)
 	if err != nil {

--- a/packages/houdini-svelte/plugin/runtime_test.go
+++ b/packages/houdini-svelte/plugin/runtime_test.go
@@ -54,7 +54,10 @@ func TestRuntime_graphqlTag(t *testing.T) {
 			found, err := afero.ReadFile(plugin.Fs, targetPath)
 			require.NoError(t, err)
 
-			expected := `
+			// the injected imports land above the copied file's // @ts-nocheck pragma,
+			// so UpdateIndexFiles hoists it back to the very top
+			expected := `// @ts-nocheck
+
 import type { MyQueryStore } from '$houdini/plugins/houdini-svelte/stores/MyQuery'
 import type { YourQueryStore } from '$houdini/plugins/houdini-svelte/stores/YourQuery'
 

--- a/packages/houdini-svelte/plugin/session.go
+++ b/packages/houdini-svelte/plugin/session.go
@@ -1,0 +1,125 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/afero"
+
+	"code.houdinigraphql.com/packages/houdini-svelte/plugin/config"
+)
+
+// the session set in hooks.server.{js,ts} only reaches the application through code
+// that houdini injects into the project's root layout files: +layout.server.{js,ts}
+// moves the session from event.locals into the layout data (so every load can read it)
+// and +layout.svelte keeps the client-side session in sync (so client-side fetches and
+// mutations include it). Houdini transforms those files when they exist but never
+// creates them, so a project that calls setSession without them silently drops the
+// session. SessionLayoutWarnings returns a warning message for each missing file.
+func SessionLayoutWarnings(
+	fs afero.Fs,
+	projectRoot string,
+	pluginConfig config.PluginConfig,
+) []string {
+	// the session infrastructure only exists in kit projects that haven't opted out
+	if pluginConfig.Framework == config.PluginFrameworkSvelte || pluginConfig.Static {
+		return nil
+	}
+
+	// find the project's server hooks file (if there isn't one, the session is never set)
+	hooksPath := ""
+	for _, candidate := range []string{"hooks.server.ts", "hooks.server.js"} {
+		fp := filepath.Join(projectRoot, "src", candidate)
+		if exists, _ := afero.Exists(fs, fp); exists {
+			hooksPath = fp
+			break
+		}
+	}
+	if hooksPath == "" {
+		return nil
+	}
+
+	// the session is only in use if the hooks file calls setSession
+	content, err := afero.ReadFile(fs, hooksPath)
+	if err != nil || !strings.Contains(string(content), "setSession") {
+		return nil
+	}
+
+	// reference the hooks file the way the user knows it (relative to the project root)
+	relHooks := hooksPath
+	if rel, err := filepath.Rel(projectRoot, hooksPath); err == nil {
+		relHooks = filepath.ToSlash(rel)
+	}
+
+	warnings := []string{}
+
+	// +layout.server.{js,ts} carries the session from event.locals into the layout data
+	layoutServerExists := false
+	for _, candidate := range []string{"+layout.server.js", "+layout.server.ts"} {
+		fp := filepath.Join(projectRoot, "src", "routes", candidate)
+		if exists, _ := afero.Exists(fs, fp); exists {
+			layoutServerExists = true
+			break
+		}
+	}
+	if !layoutServerExists {
+		warnings = append(warnings, fmt.Sprintf(
+			"%s calls setSession but src/routes/+layout.server.js (or .ts) does not exist: Houdini passes the session to your routes through this file's load function, so without it the session is silently dropped. Create the file (it can be empty) to fix this. For more information: https://houdinigraphql.com/svelte/guides/authentication",
+			relHooks,
+		))
+	}
+
+	// +layout.svelte keeps the client-side session up to date
+	layoutSveltePath := filepath.Join(projectRoot, "src", "routes", "+layout.svelte")
+	if exists, _ := afero.Exists(fs, layoutSveltePath); !exists {
+		warnings = append(warnings, fmt.Sprintf(
+			"%s calls setSession but src/routes/+layout.svelte does not exist: Houdini keeps the client-side session up to date through this component, so client-side fetches and mutations will not include your session. Create the file to fix this. For more information: https://houdinigraphql.com/svelte/guides/authentication",
+			relHooks,
+		))
+	}
+
+	return warnings
+}
+
+// sessionLayoutWarnings resolves the plugin's config and filesystem and delegates to
+// SessionLayoutWarnings
+func (p *HoudiniSvelte) sessionLayoutWarnings(ctx context.Context) ([]string, error) {
+	// load the plugin config straight from the database: DB.PluginConfig panics when
+	// the plugin row is missing (which happens in test harnesses), so read the row
+	// ourselves and skip the check when there isn't one
+	conn, err := p.DB.Take(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer p.DB.Put(conn)
+
+	stmt, err := conn.Prepare(`SELECT config FROM plugins WHERE name = ?1`)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Finalize()
+	stmt.BindText(1, p.Name())
+
+	hasRow, err := stmt.Step()
+	if err != nil {
+		return nil, err
+	}
+	if !hasRow {
+		return nil, nil
+	}
+
+	pluginConfig := config.PluginConfig{}
+	if err := json.Unmarshal([]byte(stmt.GetText("config")), &pluginConfig); err != nil {
+		return nil, err
+	}
+
+	projectConfig, err := p.DB.ProjectConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return SessionLayoutWarnings(p.Fs, projectConfig.ProjectRoot, pluginConfig), nil
+}

--- a/packages/houdini-svelte/plugin/session_test.go
+++ b/packages/houdini-svelte/plugin/session_test.go
@@ -1,0 +1,170 @@
+package plugin_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+
+	"code.houdinigraphql.com/packages/houdini-svelte/plugin"
+	"code.houdinigraphql.com/packages/houdini-svelte/plugin/config"
+	"code.houdinigraphql.com/plugins/tests"
+)
+
+const hooksWithSession = `
+import { setSession } from '$houdini'
+
+export const handle = async ({ event, resolve }) => {
+	setSession(event, { user: { token: 'value' } })
+	return await resolve(event)
+}
+`
+
+const hooksWithoutSession = `
+export const handle = async ({ event, resolve }) => {
+	return await resolve(event)
+}
+`
+
+func TestSessionLayoutWarnings(t *testing.T) {
+	projectRoot := "/project"
+
+	table := []struct {
+		name   string
+		files  map[string]string
+		config config.PluginConfig
+		// substrings that must each appear in exactly one warning, in order
+		expected []string
+	}{
+		{
+			name:     "no hooks file",
+			files:    map[string]string{},
+			expected: []string{},
+		},
+		{
+			name: "hooks file without setSession",
+			files: map[string]string{
+				"src/hooks.server.ts": hooksWithoutSession,
+			},
+			expected: []string{},
+		},
+		{
+			name: "setSession with both layout files",
+			files: map[string]string{
+				"src/hooks.server.ts":          hooksWithSession,
+				"src/routes/+layout.server.ts": "",
+				"src/routes/+layout.svelte":    "",
+			},
+			expected: []string{},
+		},
+		{
+			name: "setSession with no layout files",
+			files: map[string]string{
+				"src/hooks.server.ts": hooksWithSession,
+			},
+			expected: []string{
+				"src/routes/+layout.server.js (or .ts) does not exist",
+				"src/routes/+layout.svelte does not exist",
+			},
+		},
+		{
+			name: "setSession missing only the server layout",
+			files: map[string]string{
+				"src/hooks.server.ts":       hooksWithSession,
+				"src/routes/+layout.svelte": "",
+			},
+			expected: []string{
+				"src/routes/+layout.server.js (or .ts) does not exist",
+			},
+		},
+		{
+			name: "setSession missing only the layout component",
+			files: map[string]string{
+				"src/hooks.server.ts":          hooksWithSession,
+				"src/routes/+layout.server.js": "",
+			},
+			expected: []string{
+				"src/routes/+layout.svelte does not exist",
+			},
+		},
+		{
+			name: "javascript hooks file is detected",
+			files: map[string]string{
+				"src/hooks.server.js": hooksWithSession,
+			},
+			expected: []string{
+				"src/hooks.server.js calls setSession but src/routes/+layout.server.js",
+				"src/hooks.server.js calls setSession but src/routes/+layout.svelte",
+			},
+		},
+		{
+			name: "static projects are skipped",
+			files: map[string]string{
+				"src/hooks.server.ts": hooksWithSession,
+			},
+			config:   config.PluginConfig{Static: true},
+			expected: []string{},
+		},
+		{
+			name: "non-kit projects are skipped",
+			files: map[string]string{
+				"src/hooks.server.ts": hooksWithSession,
+			},
+			config:   config.PluginConfig{Framework: config.PluginFrameworkSvelte},
+			expected: []string{},
+		},
+	}
+
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			for path, content := range test.files {
+				fp := filepath.Join(projectRoot, filepath.FromSlash(path))
+				require.NoError(t, fs.MkdirAll(filepath.Dir(fp), 0755))
+				require.NoError(t, afero.WriteFile(fs, fp, []byte(content), 0644))
+			}
+
+			warnings := plugin.SessionLayoutWarnings(fs, projectRoot, test.config)
+
+			require.Len(t, warnings, len(test.expected))
+			for i, want := range test.expected {
+				require.Contains(t, warnings[i], want)
+			}
+		})
+	}
+}
+
+// the session check runs as part of Validate against the registered plugin config.
+// warnings are printed, never returned, so a project with missing layout files still
+// builds
+func TestValidate_sessionWarningsDoNotFailTheBuild(t *testing.T) {
+	tests.RunTable(t, tests.Table[config.PluginConfig, *plugin.HoudiniSvelte]{
+		Schema: `type Query { hello: String }`,
+		Plugin: tests.Plugin[config.PluginConfig]{
+			Name: "houdini-svelte",
+		},
+		SetupTest: func(t *testing.T, p *plugin.HoudiniSvelte, test tests.Test[config.PluginConfig]) {
+			// a hooks file that uses the session without any root layout files
+			require.NoError(t, afero.WriteFile(
+				p.Filesystem(),
+				filepath.Join("/project", "src", "hooks.server.ts"),
+				[]byte(hooksWithSession),
+				0644,
+			))
+		},
+		PerformTest: func(t *testing.T, p *plugin.HoudiniSvelte, test tests.Test[config.PluginConfig]) {
+			require.NoError(t, p.Validate(context.Background()))
+		},
+		Tests: []tests.Test[config.PluginConfig]{
+			{
+				Name: "missing layout files warn but do not error",
+				Pass: true,
+				Input: []string{
+					`query GetUser { hello }`,
+				},
+			},
+		},
+	})
+}

--- a/packages/houdini-svelte/plugin/validate.go
+++ b/packages/houdini-svelte/plugin/validate.go
@@ -9,6 +9,17 @@ import (
 )
 
 func (p *HoudiniSvelte) Validate(ctx context.Context) error {
+	// check the project structure for files the session relies on. these are
+	// warnings only: the session is silently dropped without them but the build
+	// is still valid
+	if warnings, err := p.sessionLayoutWarnings(ctx); err == nil && len(warnings) > 0 {
+		if logger, err := p.DB.Logger(ctx); err == nil {
+			for _, warning := range warnings {
+				logger.Warn("[houdini-svelte] warning: %s", warning)
+			}
+		}
+	}
+
 	forbiddenNames := []string{
 		"Query",
 		"Mutation",

--- a/packages/houdini/src/cmd/generate.ts
+++ b/packages/houdini/src/cmd/generate.ts
@@ -8,13 +8,13 @@ import {
 	PIPELINE_HOOKS,
 	type PipelineHook,
 } from '../lib/index.js'
+import * as path from '../lib/path.js'
 import { get_config } from '../lib/project.js'
 import pull_schema from './pullSchema.js'
 
 export async function generate(
 	args: {
 		pullSchema: boolean
-		persistOutput?: string
 		output?: string
 		headers: string[]
 		log?: string
@@ -38,12 +38,17 @@ export async function generate(
 
 	// make sure we pull the schema if we specify
 	if (args.pullSchema) {
-		await pull_schema({ headers: args.headers, output: args.output })
+		await pull_schema({ headers: args.headers })
 	}
 
 	try {
 		// grab the config file
 		const config: Config | null = await get_config()
+
+		// -o/--output overrides the persisted queries path from the config file
+		if (args.output && config) {
+			config.config_file.persistedQueriesPath = path.resolve(args.output)
+		}
 
 		const [db, dbFilepath] = await init_db(config, args.preserveDatabase)
 

--- a/packages/houdini/src/lib/config.ts
+++ b/packages/houdini/src/lib/config.ts
@@ -143,7 +143,8 @@ export type ConfigFile = {
 	watchSchema?: WatchSchemaConfig | false | null
 
 	/**
-	 * Specifies the the persisted queries path and file. (default: `<rootDir>/persisted_queries.json`)
+	 * Specifies the path of the generated persisted queries file, resolved relative to the
+	 * project root. (default: `<runtimeDir>/queries.json`)
 	 */
 	persistedQueriesPath?: string
 


### PR DESCRIPTION
This PR fixes a large set of issues that were reported on discord:
- loading states now use field aliases instead of schema names
- runtime scalar variables are optional in the input type since their values are resolved automatically
- `$optimistic` types wrap list fields in arrays.
- an HMR instability